### PR TITLE
fix: resolve CI failures after router merge

### DIFF
--- a/app/router/cmd/router/main.go
+++ b/app/router/cmd/router/main.go
@@ -31,15 +31,28 @@ func main() {
 	// Apply testnet URLs if enabled
 	cfg.GetBinanceTestnetURLs()
 
-	// Create Binance clients
-	spotClient, err := binance.NewTestnetSpotClient(&cfg.Binance, logger.With().Str("client", "spot").Logger())
-	if err != nil {
-		logger.Fatal().Err(err).Msg("Failed to create spot client")
+	// Create Binance clients based on enabled trading modes
+	var spotClient *binance.Client
+	var futuresClient *binance.Client
+
+	if cfg.Binance.IsSpotEnabled() {
+		spotClient, err = binance.NewTestnetSpotClient(&cfg.Binance, logger.With().Str("client", "spot").Logger())
+		if err != nil {
+			logger.Fatal().Err(err).Msg("Failed to create spot client")
+		}
+		logger.Info().Msg("Spot trading enabled")
+	} else {
+		logger.Info().Msg("Spot trading disabled")
 	}
 
-	futuresClient, err := binance.NewTestnetFuturesClient(&cfg.Binance, logger.With().Str("client", "futures").Logger())
-	if err != nil {
-		logger.Fatal().Err(err).Msg("Failed to create futures client")
+	if cfg.Binance.IsFuturesEnabled() {
+		futuresClient, err = binance.NewTestnetFuturesClient(&cfg.Binance, logger.With().Str("client", "futures").Logger())
+		if err != nil {
+			logger.Fatal().Err(err).Msg("Failed to create futures client")
+		}
+		logger.Info().Msg("Futures trading enabled")
+	} else {
+		logger.Info().Msg("Futures trading disabled")
 	}
 
 	// Create event emitter

--- a/app/router/internal/config/config_test.go
+++ b/app/router/internal/config/config_test.go
@@ -1,0 +1,115 @@
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_ValidateOptionalKeys(t *testing.T) {
+	t.Run("validates spot-only configuration", func(t *testing.T) {
+		// Set up spot-only environment
+		os.Setenv("BINANCE_SPOT_API_KEY", "test-spot-key")
+		os.Setenv("BINANCE_SPOT_SECRET_KEY", "test-spot-secret")
+		os.Setenv("TRADING_MODE", "spot")
+		defer func() {
+			os.Unsetenv("BINANCE_SPOT_API_KEY")
+			os.Unsetenv("BINANCE_SPOT_SECRET_KEY")
+			os.Unsetenv("TRADING_MODE")
+		}()
+
+		config, err := Load()
+		require.NoError(t, err)
+		assert.NotNil(t, config)
+		assert.Equal(t, "test-spot-key", config.Binance.SpotAPIKey)
+		assert.Equal(t, "test-spot-secret", config.Binance.SpotSecretKey)
+	})
+
+	t.Run("validates futures-only configuration", func(t *testing.T) {
+		// Set up futures-only environment
+		os.Setenv("BINANCE_FUTURES_API_KEY", "test-futures-key")
+		os.Setenv("BINANCE_FUTURES_SECRET_KEY", "test-futures-secret")
+		os.Setenv("TRADING_MODE", "futures")
+		defer func() {
+			os.Unsetenv("BINANCE_FUTURES_API_KEY")
+			os.Unsetenv("BINANCE_FUTURES_SECRET_KEY")
+			os.Unsetenv("TRADING_MODE")
+		}()
+
+		config, err := Load()
+		require.NoError(t, err)
+		assert.NotNil(t, config)
+		assert.Equal(t, "test-futures-key", config.Binance.FuturesAPIKey)
+		assert.Equal(t, "test-futures-secret", config.Binance.FuturesSecretKey)
+	})
+
+	t.Run("validates both required when both trading modes enabled", func(t *testing.T) {
+		// Set up both trading modes
+		os.Setenv("BINANCE_SPOT_API_KEY", "test-spot-key")
+		os.Setenv("BINANCE_SPOT_SECRET_KEY", "test-spot-secret")
+		os.Setenv("BINANCE_FUTURES_API_KEY", "test-futures-key")
+		os.Setenv("BINANCE_FUTURES_SECRET_KEY", "test-futures-secret")
+		os.Setenv("TRADING_MODE", "spot,futures")
+		defer func() {
+			os.Unsetenv("BINANCE_SPOT_API_KEY")
+			os.Unsetenv("BINANCE_SPOT_SECRET_KEY")
+			os.Unsetenv("BINANCE_FUTURES_API_KEY")
+			os.Unsetenv("BINANCE_FUTURES_SECRET_KEY")
+			os.Unsetenv("TRADING_MODE")
+		}()
+
+		config, err := Load()
+		require.NoError(t, err)
+		assert.NotNil(t, config)
+		assert.Equal(t, "test-spot-key", config.Binance.SpotAPIKey)
+		assert.Equal(t, "test-futures-key", config.Binance.FuturesAPIKey)
+	})
+
+	t.Run("validates error when spot keys missing for spot mode", func(t *testing.T) {
+		// Set up spot mode without keys
+		os.Setenv("TRADING_MODE", "spot")
+		defer os.Unsetenv("TRADING_MODE")
+
+		_, err := Load()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "BINANCE_SPOT_API_KEY is required for spot trading")
+	})
+
+	t.Run("validates error when futures keys missing for futures mode", func(t *testing.T) {
+		// Set up futures mode without keys
+		os.Setenv("TRADING_MODE", "futures")
+		defer os.Unsetenv("TRADING_MODE")
+
+		_, err := Load()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "BINANCE_FUTURES_API_KEY is required for futures trading")
+	})
+}
+
+func TestBinanceConfig_TradingModes(t *testing.T) {
+	t.Run("IsSpotEnabled returns true when spot mode is set", func(t *testing.T) {
+		config := &BinanceConfig{TradingMode: "spot"}
+		assert.True(t, config.IsSpotEnabled())
+		assert.False(t, config.IsFuturesEnabled())
+	})
+
+	t.Run("IsFuturesEnabled returns true when futures mode is set", func(t *testing.T) {
+		config := &BinanceConfig{TradingMode: "futures"}
+		assert.False(t, config.IsSpotEnabled())
+		assert.True(t, config.IsFuturesEnabled())
+	})
+
+	t.Run("both modes enabled when comma-separated", func(t *testing.T) {
+		config := &BinanceConfig{TradingMode: "spot,futures"}
+		assert.True(t, config.IsSpotEnabled())
+		assert.True(t, config.IsFuturesEnabled())
+	})
+
+	t.Run("defaults to both modes when empty", func(t *testing.T) {
+		config := &BinanceConfig{TradingMode: ""}
+		assert.True(t, config.IsSpotEnabled())
+		assert.True(t, config.IsFuturesEnabled())
+	})
+}

--- a/app/router/internal/websocket/streams_test.go
+++ b/app/router/internal/websocket/streams_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -352,11 +353,11 @@ func TestStreamManager_MessageHandling(t *testing.T) {
 		})
 		defer server.Close()
 
-		receivedCount := 0
+		var receivedCount atomic.Int32
 		sm := NewStreamManager(getWebSocketURL(server.URL))
 		sm.SetDepthHandler(&mockStreamDepthHandler{
 			onDepthUpdate: func(event *DepthUpdateEvent) error {
-				receivedCount++
+				receivedCount.Add(1)
 				return nil
 			},
 		})
@@ -370,7 +371,7 @@ func TestStreamManager_MessageHandling(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 
 		// Should still receive the valid message despite malformed one
-		assert.Equal(t, 1, receivedCount)
+		assert.Equal(t, int32(1), receivedCount.Load())
 	})
 }
 

--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -12,6 +12,7 @@
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "typecheck": "tsc --noEmit",
+    "type-check": "tsc --noEmit",
     "format": "prettier --write \"src/**/*.{js,ts,jsx,tsx,json,css,md}\"",
     "format:check": "prettier --check \"src/**/*.{js,ts,jsx,tsx,json,css,md}\""
   },


### PR DESCRIPTION
## Summary
This PR fixes three CI failures that occurred after merging the router implementation:

1. **Race condition in WebSocket test** - Fixed by using atomic operations
2. **Missing type-check script** - Added script alias to UI package.json
3. **Router requires all API keys** - Made API keys optional based on trading mode

## Changes
- 🔧 Fixed race condition in  by using  instead of plain 
- 📦 Added  script to UI package.json (aliases existing  command)
- 🔑 Made router API keys optional based on  environment variable
- ✅ Added comprehensive tests for optional API key configuration

## Testing
- ✅ WebSocket race test passes with  flag
- ✅ undefined
 ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "type-check" not found

Did you mean "pnpm typecheck"? works in UI directory
- ✅ Router starts with only spot keys when 
- ✅ Router starts with only futures keys when 
- ✅ All new config tests pass

## Configuration
New environment variable:
-  - Set to , , or  (default: both enabled)

## Impact
- CI builds will pass again
- Developers can run the router with only the keys they need
- Better developer experience for testing specific trading modes

Fixes #16