### PR TITLE
fix: resolve remaining Go Router linting issues

### DIFF
--- a/app/router/internal/binance/exchange_info.go
+++ b/app/router/internal/binance/exchange_info.go
@@ -230,44 +230,47 @@ func (e *ExchangeInfoCache) refreshCache(ctx context.Context) error {
 	return nil
 }
 
+// Commented out unused functions to satisfy linter
+// TODO: Remove if not needed or implement usage
+
 // parseFilters extracts relevant filter values
-func (e *ExchangeInfoCache) parseFilters(info *SymbolInfo, filters []interface{}) {
-	for _, filterRaw := range filters {
-		filterMap, ok := filterRaw.(map[string]interface{})
-		if !ok {
-			continue
-		}
-
-		filterType, _ := filterMap["filterType"].(string)
-
-		switch filterType {
-		case "PRICE_FILTER":
-			info.MinPrice = parseDecimalField(filterMap, "minPrice")
-			info.MaxPrice = parseDecimalField(filterMap, "maxPrice")
-			info.TickSize = parseDecimalField(filterMap, "tickSize")
-			info.PricePrecision = calculatePrecision(info.TickSize)
-
-		case "LOT_SIZE":
-			info.MinQuantity = parseDecimalField(filterMap, "minQty")
-			info.MaxQuantity = parseDecimalField(filterMap, "maxQty")
-			info.StepSize = parseDecimalField(filterMap, "stepSize")
-			info.QuantityPrecision = calculatePrecision(info.StepSize)
-
-		case "MIN_NOTIONAL", "NOTIONAL":
-			info.MinNotional = parseDecimalField(filterMap, "minNotional")
-		}
-	}
-}
+// func (e *ExchangeInfoCache) parseFilters(info *SymbolInfo, filters []interface{}) {
+// 	for _, filterRaw := range filters {
+// 		filterMap, ok := filterRaw.(map[string]interface{})
+// 		if !ok {
+// 			continue
+// 		}
+//
+// 		filterType, _ := filterMap["filterType"].(string)
+//
+// 		switch filterType {
+// 		case "PRICE_FILTER":
+// 			info.MinPrice = parseDecimalField(filterMap, "minPrice")
+// 			info.MaxPrice = parseDecimalField(filterMap, "maxPrice")
+// 			info.TickSize = parseDecimalField(filterMap, "tickSize")
+// 			info.PricePrecision = calculatePrecision(info.TickSize)
+//
+// 		case "LOT_SIZE":
+// 			info.MinQuantity = parseDecimalField(filterMap, "minQty")
+// 			info.MaxQuantity = parseDecimalField(filterMap, "maxQty")
+// 			info.StepSize = parseDecimalField(filterMap, "stepSize")
+// 			info.QuantityPrecision = calculatePrecision(info.StepSize)
+//
+// 		case "MIN_NOTIONAL", "NOTIONAL":
+// 			info.MinNotional = parseDecimalField(filterMap, "minNotional")
+// 		}
+// 	}
+// }
 
 // parseDecimalField safely parses a decimal field from a map
-func parseDecimalField(m map[string]interface{}, field string) decimal.Decimal {
-	if val, ok := m[field].(string); ok {
-		if d, err := decimal.NewFromString(val); err == nil {
-			return d
-		}
-	}
-	return decimal.Zero
-}
+// func parseDecimalField(m map[string]interface{}, field string) decimal.Decimal {
+// 	if val, ok := m[field].(string); ok {
+// 		if d, err := decimal.NewFromString(val); err == nil {
+// 			return d
+// 		}
+// 	}
+// 	return decimal.Zero
+// }
 
 // calculatePrecision calculates decimal precision from step size
 func calculatePrecision(stepSize decimal.Decimal) int {

--- a/app/router/internal/binance/testnet_test.go
+++ b/app/router/internal/binance/testnet_test.go
@@ -59,11 +59,14 @@ func createTestnetClient(t *testing.T) *Client {
 	return client
 }
 
+// Commented out unused function to satisfy linter
+// TODO: Implement when futures testnet is ready
+
 // createTestnetFuturesClient creates a real futures testnet client
-func createTestnetFuturesClient(t *testing.T) *Client {
-	t.Skip("Futures testnet not implemented yet")
-	return nil
-}
+// func createTestnetFuturesClient(t *testing.T) *Client {
+// 	t.Skip("Futures testnet not implemented yet")
+// 	return nil
+// }
 
 // TestTestnetConnection verifies we can connect to testnet
 func TestTestnetConnection(t *testing.T) {

--- a/app/router/internal/health/health_test.go
+++ b/app/router/internal/health/health_test.go
@@ -14,6 +14,14 @@ import (
 	"router/internal/health"
 )
 
+// contextKey is a custom type for context keys to avoid collisions
+type contextKey string
+
+const (
+	binanceClientKey contextKey = "binanceClient"
+	redisClientKey   contextKey = "redisClient"
+)
+
 // Mock Binance client for testing
 type mockBinanceClient struct {
 	mock.Mock
@@ -231,8 +239,8 @@ func TestHealthEndpointHandler(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	// Set dependencies in context
-	ctx := context.WithValue(req.Context(), "binanceClient", mockBinance)
-	ctx = context.WithValue(ctx, "redisClient", mockRedis)
+	ctx := context.WithValue(req.Context(), binanceClientKey, mockBinance)
+	ctx = context.WithValue(ctx, redisClientKey, mockRedis)
 	req = req.WithContext(ctx)
 
 	handler.HandleHealth(w, req)

--- a/app/router/internal/orders/bracket.go
+++ b/app/router/internal/orders/bracket.go
@@ -75,7 +75,7 @@ func (m *Manager) placeSpotBracket(ctx context.Context, client *binance.Client, 
 	// For STOP_LOSS_LIMIT:
 	// - stopPrice is the trigger price
 	// - price is the limit price (slightly worse than stop to ensure fill)
-	slLimitPrice := req.StopLossPrice
+	var slLimitPrice decimal.Decimal
 	if req.Side == "BUY" {
 		// For long positions, SL sells below stop price
 		slLimitPrice = req.StopLossPrice.Mul(decimal.NewFromFloat(0.995))
@@ -289,10 +289,11 @@ func (m *Manager) CloseAllPositions(ctx context.Context, req *CloseAllRequest) e
 		}
 
 		// For futures, also close position with market order
-		if req.IsFutures {
-			// In production, check actual position size
-			// For now, skip position closing
-		}
+		// TODO: Implement futures position closing logic
+		// if req.IsFutures {
+		//     In production, check actual position size
+		//     and close with appropriate market order
+		// }
 	}
 
 	return lastErr

--- a/app/router/internal/websocket/connection_test.go
+++ b/app/router/internal/websocket/connection_test.go
@@ -386,7 +386,6 @@ func TestConnection_Reconnection(t *testing.T) {
 		server := newMockWebSocketServer(t, func(conn *websocket.Conn) {
 			defer conn.Close()
 			// Always close immediately
-			return
 		})
 		defer server.Close()
 
@@ -418,7 +417,7 @@ func TestConnection_Reconnection(t *testing.T) {
 	t.Run("uses exponential backoff for reconnection", func(t *testing.T) {
 		server := newMockWebSocketServer(t, func(conn *websocket.Conn) {
 			defer conn.Close()
-			return // Always fail immediately
+			// Always fail immediately
 		})
 		defer server.Close()
 


### PR DESCRIPTION
## Summary
This PR completes the Go Router linting fixes by addressing all remaining staticcheck, ineffassign, and unused warnings.

## Changes Made

### Fixed ineffassign warning:
- `bracket.go`: Changed initial assignment to var declaration for `slLimitPrice`

### Fixed staticcheck warnings:
- `health_test.go`: Added custom context key type to avoid SA1029 (using built-in string as context key)
- `bracket.go`: Replaced empty branch with TODO comment to fix SA9003
- `connection_test.go`: Removed redundant return statements to fix S1023

### Fixed unused warnings:
- `exchange_info.go`: Commented out unused `parseFilters()` and `parseDecimalField()` functions
- `testnet_test.go`: Commented out unused `createTestnetFuturesClient()` function

## Testing
- Ran `make lint-router` - all linting passes with no staticcheck, ineffassign, or unused warnings
- No functional changes, only satisfying linter requirements

## Next Steps
- Review commented-out functions and either remove permanently or implement their usage

Completes the linting fixes started in PR #30
Fixes remaining issues for #26

🤖 Generated with [Claude Code](https://claude.ai/code)