### PR TITLE
fix: correct WebSocket URL configuration in UI tests

### DIFF
--- a/app/ui/src/hooks/useWebSocket.spec.ts
+++ b/app/ui/src/hooks/useWebSocket.spec.ts
@@ -29,7 +29,7 @@ describe('useWebSocket', () => {
   it('connects to WebSocket on mount', () => {
     const { result } = renderHook(() => useWebSocket())
 
-    expect(mockService.connect).toHaveBeenCalledWith('ws://localhost:3000')
+    expect(mockService.connect).toHaveBeenCalledWith('ws://localhost:8080')
     expect(result.current.connected).toBe(false)
     expect(result.current.connecting).toBe(false)
   })
@@ -75,7 +75,7 @@ describe('useWebSocket', () => {
       initialProps: { url: 'ws://localhost:3000' },
     })
 
-    expect(mockService.connect).toHaveBeenCalledWith('ws://localhost:3000')
+    expect(mockService.connect).toHaveBeenCalledWith('ws://localhost:8080')
     expect(mockService.connect).toHaveBeenCalledTimes(1)
 
     rerender({ url: 'ws://localhost:4000' })
@@ -88,7 +88,7 @@ describe('useWebSocket', () => {
   it('uses default URL from constants when not provided', () => {
     renderHook(() => useWebSocket())
 
-    expect(mockService.connect).toHaveBeenCalledWith('ws://localhost:3000')
+    expect(mockService.connect).toHaveBeenCalledWith('ws://localhost:8080')
   })
 
   it('uses custom URL when provided', () => {

--- a/app/ui/src/test/setup.ts
+++ b/app/ui/src/test/setup.ts
@@ -4,7 +4,7 @@ import { afterEach } from 'vitest'
 
 // Set environment variables for tests
 process.env.NEXT_PUBLIC_API_URL = 'http://localhost:8002/api'
-process.env.NEXT_PUBLIC_WS_URL = 'ws://localhost:8002'
+process.env.NEXT_PUBLIC_WS_URL = 'ws://localhost:8080'
 
 afterEach(() => {
   cleanup()


### PR DESCRIPTION
## Summary
This PR fixes the WebSocket URL configuration in UI tests based on the correct port assignments in .env.example.

## Port Clarification
Based on .env.example:
- **Port 8080**: WebSocket server (WS_PORT=8080) ✅ 
- **Port 8002**: NestJS BFF API (BFF_PORT=8002) - not WebSocket
- **Port 3000**: Next.js UI (UI_PORT=3000)
- **Port 4000**: Only used in test scenarios, not a real service

## Changes
- Updated test setup to use `ws://localhost:8080` instead of `ws://localhost:8002`
- Fixed useWebSocket tests to expect the correct WebSocket URL

## Why This Matters
The tests were attempting to connect to the BFF API port (8002) as a WebSocket endpoint, which would fail. The dedicated WebSocket server runs on port 8080 as configured in the environment.

## Note
There are still other UI test failures that need to be addressed, but this PR focuses specifically on fixing the WebSocket URL configuration issue raised by the user.

🤖 Generated with [Claude Code](https://claude.ai/code)