### PR TITLE
fix(alerts): stop silent telegram alert loss across restarts and execution modes

### DIFF
--- a/app/engine/adapters/alert/alert_subscriber.py
+++ b/app/engine/adapters/alert/alert_subscriber.py
@@ -245,6 +245,7 @@ def _error_event_to_text(event: ErrorEvent) -> str:
             "quantity",
         )
     ):
+
         def _pct(label: str, raw: object) -> str:
             try:
                 v = Decimal(str(raw))
@@ -297,9 +298,7 @@ def _error_event_to_text(event: ErrorEvent) -> str:
                     )
                 else:
                     lines.append(
-                        "Symbol Exposure: "
-                        f"{symbol_exposure} "
-                        f"({_pct('', ratio)} of equity)",
+                        f"Symbol Exposure: {symbol_exposure} ({_pct('', ratio)} of equity)",
                     )
             else:
                 lines.append(f"Symbol Exposure: {symbol_exposure}")
@@ -319,9 +318,7 @@ def _error_event_to_text(event: ErrorEvent) -> str:
                     )
                 else:
                     lines.append(
-                        "Total Exposure: "
-                        f"{total_exposure} "
-                        f"({ratio:.2f}x equity)",
+                        f"Total Exposure: {total_exposure} ({ratio:.2f}x equity)",
                     )
             else:
                 lines.append(f"Total Exposure: {total_exposure}")
@@ -444,6 +441,7 @@ class AlertSubscriber:
 
         self._subscription_id: str | None = None
         self._event_bus: _EventBus | None = None
+        self._dropped_source_log_keys: set[tuple[str, str]] = set()
 
     async def register(self, event_bus: _EventBus) -> None:
         """
@@ -546,9 +544,22 @@ class AlertSubscriber:
         event: TradingDecisionEvent | OrderUpdateEvent,
     ) -> bool:
         decision_source = event.metadata.get("decision_source")
-        if not isinstance(decision_source, str):
-            return False
-        return decision_source in self._allowed_decision_sources
+        if isinstance(decision_source, str) and decision_source in self._allowed_decision_sources:
+            return True
+
+        # Dropped alerts must be observable: WARN once per (event_type, source)
+        # so post-restart bursts (correlation metadata lost) do not storm logs.
+        log_key = (event.event_type.value, str(decision_source))
+        log = logger.debug if log_key in self._dropped_source_log_keys else logger.warning
+        self._dropped_source_log_keys.add(log_key)
+        log(
+            "Dropping %s alert for %s: decision_source=%r not in allowed sources %s",
+            event.event_type.value,
+            event.symbol,
+            decision_source,
+            sorted(self._allowed_decision_sources),
+        )
+        return False
 
     async def _notify_snapshot_for_decision(self, event: TradingDecisionEvent) -> None:
         """Trigger snapshot generation via BFF client for decision alerts.

--- a/app/engine/adapters/alert/telegram.py
+++ b/app/engine/adapters/alert/telegram.py
@@ -16,6 +16,31 @@ logger = logging.getLogger(__name__)
 
 _HTTP_OK = 200
 _HTTP_NOT_FOUND = 404
+_HTTP_TOO_MANY_REQUESTS = 429
+_HTTP_SERVER_ERROR = 500
+
+
+class _SendAttemptOutcome:
+    """Result of one sendMessage POST: sent, retryable failure, or fatal."""
+
+    __slots__ = ("kind", "message_id", "reason", "response_body", "response_status", "retry_after")
+
+    def __init__(
+        self,
+        kind: str,
+        *,
+        reason: str | None = None,
+        response_status: int | None = None,
+        response_body: str | None = None,
+        message_id: int | None = None,
+        retry_after: float | None = None,
+    ) -> None:
+        self.kind = kind  # "sent" | "retryable" | "fatal"
+        self.reason = reason
+        self.response_status = response_status
+        self.response_body = response_body
+        self.message_id = message_id
+        self.retry_after = retry_after
 
 
 class TelegramAlertAdapter:
@@ -27,11 +52,17 @@ class TelegramAlertAdapter:
         chat_id: str,
         rate_limit_per_minute: int = 30,
         db_adapter: Any | None = None,
+        send_max_attempts: int = 3,
+        send_retry_base_delay: float = 0.5,
+        send_retry_max_delay: float = 5.0,
     ) -> None:
         self.bot_token = bot_token
         self.chat_id = chat_id
         self.rate_limit_per_minute = rate_limit_per_minute
         self.db_adapter = db_adapter
+        self._send_max_attempts = max(1, send_max_attempts)
+        self._send_retry_base_delay = send_retry_base_delay
+        self._send_retry_max_delay = send_retry_max_delay
 
         self.base_url = f"https://api.telegram.org/bot{bot_token}"
         self.session: aiohttp.ClientSession | None = None
@@ -389,82 +420,118 @@ class TelegramAlertAdapter:
             )
             return False
 
-        try:
-            if not self.session:
-                logger.error("TelegramAlertAdapter session not initialized")
-                return False
+        if not self.session:
+            logger.error("TelegramAlertAdapter session not initialized")
+            return False
 
-            url = f"{self.base_url}/sendMessage"
-            request_payload = {
-                "chat_id": self.chat_id,
-                "text": message,
-                "parse_mode": "HTML",
-            }
+        # Rate-limit budget is consumed once per logical alert (already done
+        # above): retries deliver at most one message, and Telegram-side
+        # pressure is governed by 429 retry_after below.
+        outcome = _SendAttemptOutcome("fatal", reason="exception")
+        attempts = 0
+        for attempt in range(1, self._send_max_attempts + 1):
+            attempts = attempt
+            outcome = await self._post_send_message_once(message)
+            if outcome.kind != "retryable" or attempt == self._send_max_attempts:
+                break
+            delay = outcome.retry_after
+            if delay is None:
+                delay = self._send_retry_base_delay * (2 ** (attempt - 1))
+            await asyncio.sleep(min(delay, self._send_retry_max_delay))
 
-            async with self.session.post(url, json=request_payload) as response:
-                if response.status != _HTTP_OK:
-                    text = await response.text()
-                    logger.error(
-                        "Telegram HTTP error %s: %s",
-                        response.status,
-                        text,
-                    )
-                    self._schedule_audit_record(
-                        alert_type=alert_type,
-                        delivery_method="text",
-                        status="failed",
-                        reason="http_error",
-                        dedup_key=dedup_key,
-                        message_text=message,
-                        response_status=response.status,
-                        response_body=text,
-                        payload=payload,
-                    )
-                    return False
-
-                data = await response.json()
-                if data.get("ok"):
-                    logger.debug("Telegram alert sent successfully")
-                    result = data.get("result") or {}
-                    message_id = result.get("message_id")
-                    self._schedule_audit_record(
-                        alert_type=alert_type,
-                        delivery_method="text",
-                        status="sent",
-                        dedup_key=dedup_key,
-                        telegram_message_id=message_id if isinstance(message_id, int) else None,
-                        message_text=message,
-                        response_status=response.status,
-                        payload=payload,
-                    )
-                    return True
-
-                logger.error("Telegram API error: %s", data)
-                self._schedule_audit_record(
-                    alert_type=alert_type,
-                    delivery_method="text",
-                    status="failed",
-                    reason="api_error",
-                    dedup_key=dedup_key,
-                    message_text=message,
-                    response_status=response.status,
-                    response_body=str(data),
-                    payload=payload,
-                )
-                return False
-
-        except Exception:
-            logger.exception("Error sending Telegram alert")
+        if outcome.kind == "sent":
+            logger.debug("Telegram alert sent successfully")
             self._schedule_audit_record(
                 alert_type=alert_type,
                 delivery_method="text",
-                status="failed",
-                reason="exception",
+                status="sent",
+                reason=f"sent_after_retry(attempts={attempts})" if attempts > 1 else None,
                 dedup_key=dedup_key,
+                telegram_message_id=outcome.message_id,
                 message_text=message,
+                response_status=outcome.response_status,
                 payload=payload,
             )
-            return False
+            return True
+
+        reason = outcome.reason or "exception"
+        if attempts > 1:
+            reason = f"{reason};attempts={attempts}"
+        self._schedule_audit_record(
+            alert_type=alert_type,
+            delivery_method="text",
+            status="failed",
+            reason=reason,
+            dedup_key=dedup_key,
+            message_text=message,
+            response_status=outcome.response_status,
+            response_body=outcome.response_body,
+            payload=payload,
+        )
+        return False
+
+    async def _post_send_message_once(self, message: str) -> _SendAttemptOutcome:
+        """POST one sendMessage and classify the outcome for the retry loop."""
+        assert self.session is not None
+        url = f"{self.base_url}/sendMessage"
+        request_payload = {
+            "chat_id": self.chat_id,
+            "text": message,
+            "parse_mode": "HTML",
+        }
+
+        try:
+            async with self.session.post(url, json=request_payload) as response:
+                if response.status == _HTTP_OK:
+                    data = await response.json()
+                    if data.get("ok"):
+                        result = data.get("result") or {}
+                        message_id = result.get("message_id")
+                        return _SendAttemptOutcome(
+                            "sent",
+                            response_status=response.status,
+                            message_id=message_id if isinstance(message_id, int) else None,
+                        )
+                    logger.error("Telegram API error: %s", data)
+                    return _SendAttemptOutcome(
+                        "fatal",
+                        reason="api_error",
+                        response_status=response.status,
+                        response_body=str(data),
+                    )
+
+                text = await response.text()
+                logger.error("Telegram HTTP error %s: %s", response.status, text)
+                if response.status == _HTTP_TOO_MANY_REQUESTS:
+                    retry_after: float | None = None
+                    try:
+                        body = await response.json()
+                        raw = (body.get("parameters") or {}).get("retry_after")
+                        if isinstance(raw, (int, float)):
+                            retry_after = float(raw)
+                    except Exception:
+                        retry_after = None
+                    return _SendAttemptOutcome(
+                        "retryable",
+                        reason="http_error",
+                        response_status=response.status,
+                        response_body=text,
+                        retry_after=retry_after,
+                    )
+                kind = "retryable" if response.status >= _HTTP_SERVER_ERROR else "fatal"
+                return _SendAttemptOutcome(
+                    kind,
+                    reason="http_error",
+                    response_status=response.status,
+                    response_body=text,
+                )
+
+        except (aiohttp.ClientError, TimeoutError):
+            logger.exception("Network error sending Telegram alert")
+            return _SendAttemptOutcome("retryable", reason="exception")
+        except Exception:
+            logger.exception("Error sending Telegram alert")
+            return _SendAttemptOutcome("fatal", reason="exception")
 
     async def send_error_alert(self, message: str, *, dedup_key: str | None = None) -> bool:
         """Send an error alert with optional Redis-backed deduplication."""

--- a/app/engine/execution/order_update_correlation.py
+++ b/app/engine/execution/order_update_correlation.py
@@ -3,7 +3,15 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import Any
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from app.engine.adapters.redis.redis_adapter import RedisAdapter
+
+logger = logging.getLogger(__name__)
+
+ORDER_UPDATE_CORRELATION_PREFIX = "order_update_correlation"
 
 
 @dataclass(frozen=True)
@@ -14,10 +22,21 @@ class OrderUpdateCorrelation:
 
 
 class OrderUpdateCorrelationStore:
-    def __init__(self, *, ttl_seconds: int) -> None:
+    """Correlates client order ids with decision metadata for alert routing.
+
+    In-memory state is wiped on every engine restart/reload, which silently
+    drops order-update alerts (the allowlist gate needs decision_source from
+    this store). When ``redis`` is provided, correlations write through to
+    Redis with the same TTL and are rehydrated on memory misses; Redis errors
+    fail open to the in-memory behavior, mirroring SignalCooldown.
+    """
+
+    def __init__(self, *, ttl_seconds: int, redis: RedisAdapter | None = None) -> None:
         if ttl_seconds <= 0:
             raise ValueError("ttl_seconds must be > 0")
         self._ttl = timedelta(seconds=ttl_seconds)
+        self._ttl_seconds = ttl_seconds
+        self._redis = redis
         self._lock = asyncio.Lock()
         self._by_client_order_id: dict[str, OrderUpdateCorrelation] = {}
 
@@ -36,6 +55,25 @@ class OrderUpdateCorrelationStore:
                 created_at=now,
             )
 
+        if self._redis is not None:
+            try:
+                await self._redis.set(
+                    client_order_id,
+                    {
+                        "client_order_id": client_order_id,
+                        "metadata": metadata,
+                        "created_at": now.isoformat(),
+                    },
+                    expire=self._ttl_seconds,
+                    prefix=ORDER_UPDATE_CORRELATION_PREFIX,
+                )
+            except Exception:
+                logger.warning(
+                    "Redis write-through failed for order correlation %s; "
+                    "correlation will not survive restart",
+                    client_order_id,
+                )
+
     async def get(self, *, client_order_id: str) -> OrderUpdateCorrelation | None:
         if not client_order_id:
             return None
@@ -45,13 +83,74 @@ class OrderUpdateCorrelationStore:
 
         async with self._lock:
             self._prune_locked(now)
-            return self._by_client_order_id.get(client_order_id)
+            cached = self._by_client_order_id.get(client_order_id)
+        if cached is not None:
+            return cached
+
+        if self._redis is None:
+            return None
+        return await self._rehydrate_from_redis(client_order_id, now)
 
     async def delete(self, *, client_order_id: str) -> None:
         if not client_order_id:
             return
         async with self._lock:
             self._by_client_order_id.pop(client_order_id, None)
+        if self._redis is not None:
+            try:
+                await self._redis.delete(
+                    client_order_id,
+                    prefix=ORDER_UPDATE_CORRELATION_PREFIX,
+                )
+            except Exception:
+                logger.warning(
+                    "Redis delete failed for order correlation %s",
+                    client_order_id,
+                )
+
+    async def _rehydrate_from_redis(
+        self,
+        client_order_id: str,
+        now: datetime,
+    ) -> OrderUpdateCorrelation | None:
+        assert self._redis is not None
+        try:
+            raw = await self._redis.get(
+                client_order_id,
+                prefix=ORDER_UPDATE_CORRELATION_PREFIX,
+            )
+        except Exception:
+            logger.warning(
+                "Redis read failed for order correlation %s",
+                client_order_id,
+            )
+            return None
+
+        if not isinstance(raw, dict):
+            return None
+
+        metadata = raw.get("metadata")
+        if not isinstance(metadata, dict):
+            return None
+
+        created_at = now
+        raw_created_at = raw.get("created_at")
+        if isinstance(raw_created_at, str):
+            try:
+                created_at = datetime.fromisoformat(raw_created_at)
+            except ValueError:
+                created_at = now
+        if created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=UTC)
+
+        correlation = OrderUpdateCorrelation(
+            client_order_id=client_order_id,
+            metadata=metadata,
+            created_at=created_at,
+        )
+        async with self._lock:
+            self._by_client_order_id[client_order_id] = correlation
+        return correlation
 
     def _prune_locked(self, now: datetime) -> None:
         cutoff = now - self._ttl

--- a/app/engine/main.py
+++ b/app/engine/main.py
@@ -214,7 +214,12 @@ def _pipeline_health_alerts_enabled_from_env() -> bool:
 
 
 def _telegram_execution_decision_alerts_enabled_from_env() -> bool:
-    value = os.getenv("TELEGRAM_EXECUTION_DECISION_ALERTS_ENABLED", "0").strip().lower()
+    """Decision alerts in execution mode are opt-out: unset means enabled.
+
+    Switching EXECUTION_MODE must not silently stop signal alerts; set
+    TELEGRAM_EXECUTION_DECISION_ALERTS_ENABLED=0 to opt out explicitly.
+    """
+    value = os.getenv("TELEGRAM_EXECUTION_DECISION_ALERTS_ENABLED", "1").strip().lower()
     return value in {"1", "true", "yes", "on"}
 
 
@@ -439,7 +444,10 @@ async def initialize_services(config: EngineConfig) -> None:  # noqa: PLR0915, C
             correlation_ttl_seconds = int(
                 os.getenv("ORDER_UPDATE_CORRELATION_TTL_SECONDS", "21600")
             )
-            correlation_store = OrderUpdateCorrelationStore(ttl_seconds=correlation_ttl_seconds)
+            correlation_store = OrderUpdateCorrelationStore(
+                ttl_seconds=correlation_ttl_seconds,
+                redis=redis_adapter,
+            )
             services["order_update_correlation_store"] = correlation_store
 
             async def execution_readiness_check() -> tuple[bool, str | None, dict[str, object]]:

--- a/app/engine/tests/unit/test_alert_subscriber.py
+++ b/app/engine/tests/unit/test_alert_subscriber.py
@@ -883,3 +883,53 @@ class TestErrorEventToText:
         assert "Total Exposure:" in text
         assert "New Notional:" in text
         assert "Entry:" in text
+
+
+class TestAlertSubscriberDropLogging:
+    """Dropped trade alerts must be observable, not silent."""
+
+    @pytest.mark.asyncio
+    async def test_drop_logs_warning_with_event_type_symbol_and_source(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        mock_telegram = MagicMock()
+        mock_telegram._handle_decision = AsyncMock()
+        subscriber = AlertSubscriber(telegram_adapter=mock_telegram)
+
+        event = _make_trading_decision_event(timestamp=datetime.now(UTC))
+        event.metadata.pop("decision_source", None)
+
+        with caplog.at_level("WARNING", logger="app.engine.adapters.alert.alert_subscriber"):
+            await subscriber._handle_event(event)
+
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 1
+        message = warnings[0].getMessage()
+        assert "BTCUSDT" in message
+        assert "None" in message
+
+    @pytest.mark.asyncio
+    async def test_repeated_drop_same_source_logs_warning_once(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        mock_telegram = MagicMock()
+        mock_telegram._handle_decision = AsyncMock()
+        subscriber = AlertSubscriber(telegram_adapter=mock_telegram)
+
+        first = _make_trading_decision_event(timestamp=datetime.now(UTC))
+        first.metadata.pop("decision_source", None)
+        second = _make_trading_decision_event(timestamp=datetime.now(UTC))
+        second.metadata.pop("decision_source", None)
+        third = _make_trading_decision_event(timestamp=datetime.now(UTC))
+        third.metadata["decision_source"] = "signal_emitter_bypass"
+
+        with caplog.at_level("WARNING", logger="app.engine.adapters.alert.alert_subscriber"):
+            await subscriber._handle_event(first)
+            await subscriber._handle_event(second)
+            await subscriber._handle_event(third)
+
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        # One per distinct (event_type, source): missing-source once, bypass once.
+        assert len(warnings) == 2

--- a/app/engine/tests/unit/test_main_execution_wiring.py
+++ b/app/engine/tests/unit/test_main_execution_wiring.py
@@ -400,3 +400,29 @@ class TestMainExecutionWiring:
         assert _CapturingAlertSubscriber.last_kwargs["execution_decision_alerts_enabled"] is True
         assert _StubTelegramAdapter.last_kwargs is not None
         assert _StubTelegramAdapter.last_kwargs["db_adapter"] is not None
+
+
+class TestTelegramExecutionDecisionAlertsDefault:
+    """Decision alerts in execution mode are opt-out (default enabled)."""
+
+    def test_helper_defaults_to_enabled_when_env_unset(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from app.engine import main as main_mod
+
+        monkeypatch.delenv("TELEGRAM_EXECUTION_DECISION_ALERTS_ENABLED", raising=False)
+
+        assert main_mod._telegram_execution_decision_alerts_enabled_from_env() is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off"])
+    def test_helper_opt_out_values_disable(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        value: str,
+    ) -> None:
+        from app.engine import main as main_mod
+
+        monkeypatch.setenv("TELEGRAM_EXECUTION_DECISION_ALERTS_ENABLED", value)
+
+        assert main_mod._telegram_execution_decision_alerts_enabled_from_env() is False

--- a/app/engine/tests/unit/test_order_update_correlation.py
+++ b/app/engine/tests/unit/test_order_update_correlation.py
@@ -1,0 +1,134 @@
+"""Tests for OrderUpdateCorrelationStore Redis write-through persistence.
+
+The store correlates client_order_ids with decision metadata so order-update
+alerts survive the allowlist gate. In-memory state is wiped on every engine
+restart/reload, so correlations must round-trip through Redis (fail-open when
+Redis is unavailable), mirroring the SignalCooldown dual-backend pattern.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.engine.execution.order_update_correlation import (
+    ORDER_UPDATE_CORRELATION_PREFIX,
+    OrderUpdateCorrelationStore,
+)
+
+TTL_SECONDS = 21600
+CLIENT_ORDER_ID = "ord-abc123"
+METADATA = {"decision_source": "retest_decision_publisher", "signal_id": "sig-1"}
+
+
+class FakeRedisAdapter:
+    def __init__(self) -> None:
+        self.store: dict[str, Any] = {}
+        self.set_calls: list[dict[str, Any]] = []
+        self.delete_calls: list[dict[str, Any]] = []
+        self.get_calls: list[dict[str, Any]] = []
+
+    async def set(
+        self,
+        key: str,
+        value: Any,
+        expire: int | None = None,
+        prefix: str = "cache",
+    ) -> bool:
+        self.set_calls.append({"key": key, "value": value, "expire": expire, "prefix": prefix})
+        self.store[f"{prefix}:{key}"] = value
+        return True
+
+    async def get(self, key: str, prefix: str = "cache") -> Any | None:
+        self.get_calls.append({"key": key, "prefix": prefix})
+        return self.store.get(f"{prefix}:{key}")
+
+    async def delete(self, key: str, prefix: str = "cache") -> bool:
+        self.delete_calls.append({"key": key, "prefix": prefix})
+        return self.store.pop(f"{prefix}:{key}", None) is not None
+
+
+class RaisingRedisAdapter:
+    async def set(self, *args: Any, **kwargs: Any) -> bool:
+        raise ConnectionError("redis down")
+
+    async def get(self, *args: Any, **kwargs: Any) -> Any | None:
+        raise ConnectionError("redis down")
+
+    async def delete(self, *args: Any, **kwargs: Any) -> bool:
+        raise ConnectionError("redis down")
+
+
+class TestOrderUpdateCorrelationRedisBackend:
+    @pytest.mark.asyncio
+    async def test_register_writes_through_to_redis_with_ttl(self) -> None:
+        redis = FakeRedisAdapter()
+        store = OrderUpdateCorrelationStore(ttl_seconds=TTL_SECONDS, redis=redis)
+
+        await store.register(client_order_id=CLIENT_ORDER_ID, metadata=METADATA)
+
+        assert len(redis.set_calls) == 1
+        call = redis.set_calls[0]
+        assert call["key"] == CLIENT_ORDER_ID
+        assert call["expire"] == TTL_SECONDS
+        assert call["prefix"] == ORDER_UPDATE_CORRELATION_PREFIX
+        assert call["value"]["metadata"] == METADATA
+        assert isinstance(call["value"]["created_at"], str)
+
+    @pytest.mark.asyncio
+    async def test_get_memory_hit_does_not_read_redis(self) -> None:
+        redis = FakeRedisAdapter()
+        store = OrderUpdateCorrelationStore(ttl_seconds=TTL_SECONDS, redis=redis)
+        await store.register(client_order_id=CLIENT_ORDER_ID, metadata=METADATA)
+
+        correlation = await store.get(client_order_id=CLIENT_ORDER_ID)
+
+        assert correlation is not None
+        assert correlation.metadata == METADATA
+        assert redis.get_calls == []
+
+    @pytest.mark.asyncio
+    async def test_get_after_restart_rehydrates_from_redis(self) -> None:
+        redis = FakeRedisAdapter()
+        first = OrderUpdateCorrelationStore(ttl_seconds=TTL_SECONDS, redis=redis)
+        await first.register(client_order_id=CLIENT_ORDER_ID, metadata=METADATA)
+
+        # Fresh store instance with empty memory simulates an engine restart.
+        second = OrderUpdateCorrelationStore(ttl_seconds=TTL_SECONDS, redis=redis)
+        correlation = await second.get(client_order_id=CLIENT_ORDER_ID)
+
+        assert correlation is not None
+        assert correlation.client_order_id == CLIENT_ORDER_ID
+        assert correlation.metadata == METADATA
+
+        # Rehydration caches in memory: the second read must not hit Redis.
+        redis.get_calls.clear()
+        again = await second.get(client_order_id=CLIENT_ORDER_ID)
+        assert again is not None
+        assert redis.get_calls == []
+
+    @pytest.mark.asyncio
+    async def test_redis_errors_fail_open(self) -> None:
+        store = OrderUpdateCorrelationStore(ttl_seconds=TTL_SECONDS, redis=RaisingRedisAdapter())
+
+        await store.register(client_order_id=CLIENT_ORDER_ID, metadata=METADATA)
+        correlation = await store.get(client_order_id=CLIENT_ORDER_ID)
+
+        assert correlation is not None  # in-memory path still works
+        assert correlation.metadata == METADATA
+
+        missing = await store.get(client_order_id="never-registered")
+        assert missing is None
+
+    @pytest.mark.asyncio
+    async def test_delete_removes_from_memory_and_redis(self) -> None:
+        redis = FakeRedisAdapter()
+        store = OrderUpdateCorrelationStore(ttl_seconds=TTL_SECONDS, redis=redis)
+        await store.register(client_order_id=CLIENT_ORDER_ID, metadata=METADATA)
+
+        await store.delete(client_order_id=CLIENT_ORDER_ID)
+
+        assert await store.get(client_order_id=CLIENT_ORDER_ID) is None
+        assert len(redis.delete_calls) == 1
+        assert redis.delete_calls[0]["prefix"] == ORDER_UPDATE_CORRELATION_PREFIX

--- a/app/engine/tests/unit/test_telegram_alerts.py
+++ b/app/engine/tests/unit/test_telegram_alerts.py
@@ -188,11 +188,12 @@ async def test_send_alert_persists_http_failure_audit(telegram_adapter):
     mock_session.post = MagicMock(return_value=mock_context)
     telegram_adapter.session = mock_session
 
-    success = await telegram_adapter._send_alert(
-        "Failure outbound message",
-        alert_type="error",
-        payload={"component": "pipeline_health"},
-    )
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        success = await telegram_adapter._send_alert(
+            "Failure outbound message",
+            alert_type="error",
+            payload={"component": "pipeline_health"},
+        )
     await asyncio.sleep(0)
 
     assert success is False
@@ -706,3 +707,125 @@ async def test_rate_limiting(telegram_adapter):
     # Next message should be rate limited
     success = await telegram_adapter._send_alert("Test message")
     assert success is False
+
+
+def _response_context(status: int, *, json_body: dict | None = None, text: str = "") -> AsyncMock:
+    response = MagicMock()
+    response.status = status
+    response.json = AsyncMock(return_value=json_body if json_body is not None else {})
+    response.text = AsyncMock(return_value=text or str(json_body))
+    context = AsyncMock()
+    context.__aenter__ = AsyncMock(return_value=response)
+    context.__aexit__ = AsyncMock(return_value=None)
+    return context
+
+
+def _session_with_responses(*contexts: AsyncMock) -> MagicMock:
+    session = MagicMock()
+    session.post = MagicMock(side_effect=list(contexts))
+    return session
+
+
+class TestSendAlertRetries:
+    """Transient send failures retry with backoff; permanent ones do not."""
+
+    @pytest.mark.asyncio
+    async def test_retries_on_500_then_succeeds(self, telegram_adapter) -> None:
+        telegram_adapter.session = _session_with_responses(
+            _response_context(500, text="Server error"),
+            _response_context(200, json_body={"ok": True, "result": {"message_id": 7}}),
+        )
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as sleep_mock:
+            success = await telegram_adapter._send_alert("msg", alert_type="error")
+        await asyncio.sleep(0)
+
+        assert success is True
+        assert telegram_adapter.session.post.call_count == 2
+        assert sleep_mock.await_count == 1
+        audit_calls = telegram_adapter._test_audit_adapter.calls
+        assert len(audit_calls) == 1
+        assert audit_calls[0]["status"] == "sent"
+
+    @pytest.mark.asyncio
+    async def test_429_honors_retry_after(self, telegram_adapter) -> None:
+        telegram_adapter.session = _session_with_responses(
+            _response_context(
+                429,
+                json_body={"ok": False, "error_code": 429, "parameters": {"retry_after": 2}},
+                text='{"ok":false,"error_code":429}',
+            ),
+            _response_context(200, json_body={"ok": True, "result": {"message_id": 8}}),
+        )
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as sleep_mock:
+            success = await telegram_adapter._send_alert("msg")
+        await asyncio.sleep(0)
+
+        assert success is True
+        sleep_mock.assert_awaited_once_with(2)
+
+    @pytest.mark.asyncio
+    async def test_does_not_retry_client_4xx(self, telegram_adapter) -> None:
+        telegram_adapter.session = _session_with_responses(
+            _response_context(400, text="Bad Request: chat not found"),
+        )
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as sleep_mock:
+            success = await telegram_adapter._send_alert("msg")
+        await asyncio.sleep(0)
+
+        assert success is False
+        assert telegram_adapter.session.post.call_count == 1
+        assert sleep_mock.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_retries_on_network_error_then_succeeds(self, telegram_adapter) -> None:
+        import aiohttp
+
+        ok_context = _response_context(200, json_body={"ok": True, "result": {"message_id": 9}})
+        session = MagicMock()
+        session.post = MagicMock(
+            side_effect=[aiohttp.ClientConnectionError("dns failure"), ok_context],
+        )
+        telegram_adapter.session = session
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            success = await telegram_adapter._send_alert("msg")
+        await asyncio.sleep(0)
+
+        assert success is True
+        assert session.post.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_gives_up_after_max_attempts_with_single_audit(self, telegram_adapter) -> None:
+        telegram_adapter.session = _session_with_responses(
+            _response_context(500, text="Server error"),
+            _response_context(502, text="Bad gateway"),
+            _response_context(503, text="Unavailable"),
+        )
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            success = await telegram_adapter._send_alert("msg", alert_type="error")
+        await asyncio.sleep(0)
+
+        assert success is False
+        assert telegram_adapter.session.post.call_count == 3
+        audit_calls = telegram_adapter._test_audit_adapter.calls
+        assert len(audit_calls) == 1
+        assert audit_calls[0]["status"] == "failed"
+        assert audit_calls[0]["response_status"] == 503
+
+    @pytest.mark.asyncio
+    async def test_retried_send_consumes_single_rate_limit_slot(self, telegram_adapter) -> None:
+        telegram_adapter.session = _session_with_responses(
+            _response_context(500, text="Server error"),
+            _response_context(200, json_body={"ok": True, "result": {"message_id": 10}}),
+        )
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            success = await telegram_adapter._send_alert("msg")
+        await asyncio.sleep(0)
+
+        assert success is True
+        assert len(telegram_adapter._message_times) == 1

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -85,7 +85,6 @@ services:
     container_name: trading-engine-dev
     restart: unless-stopped
     dns:
-      - 127.0.0.11
       - 1.1.1.1
       - 8.8.8.8
     dns_opt:
@@ -158,7 +157,6 @@ services:
     container_name: trading-router-dev
     restart: unless-stopped
     dns:
-      - 127.0.0.11
       - 1.1.1.1
       - 8.8.8.8
     dns_opt:


### PR DESCRIPTION
## Summary

Item 2 of the system-review action plan (docs/reviews/2026-07-04-system-review.md): Telegram alerts stopped arriving because five independent drop points silently discarded them.

- **Mode gate**: decision alerts in execution modes were opt-in (`TELEGRAM_EXECUTION_DECISION_ALERTS_ENABLED` defaulted `0`), so setting `EXECUTION_MODE=spot_testnet` silently killed signal alerts. Now opt-out (default enabled), keeping the env var as a kill switch.
- **Silent allowlist drop**: `_is_allowed_trade_alert_event` returned False with no logging when `decision_source` metadata was missing (always the case after a restart). Drops now WARN once per (event_type, source), DEBUG on repeats.
- **Correlation store persistence**: `OrderUpdateCorrelationStore` was in-memory only — every `--reload` wiped decision metadata, so order fills never alerted again. Now writes through to Redis (SETEX, same TTL, prefix `order_update_correlation`), rehydrates on memory miss preserving `created_at`, and fails open to in-memory behavior on Redis errors (mirrors the `SignalCooldown` dual-backend pattern).
- **Send retry**: `_send_alert` dropped alerts forever on any failure. Transient failures (network errors, 5xx, 429 honoring Telegram's `parameters.retry_after`) retry up to 3 attempts with exponential backoff capped at 5s; other 4xx / `ok:false` stay fatal. Exactly one audit record and one client-side rate-limit slot per logical alert.
- **DNS footgun**: `docker-compose.dev.yml` listed Docker's embedded resolver `127.0.0.11` as an explicit `dns:` upstream (self-forwarding loop that burned an attempt during the Feb 20 DNS outage). Removed for engine and router; the embedded resolver still serves service names on user-defined networks, so inter-service resolution is unaffected.

## Test plan

- 18 new tests: env-default opt-out semantics, once-per-key drop warnings, Redis write-through/rehydration/fail-open/delete for the correlation store, and retry behavior (500-then-success, 429 retry_after honored, no retry on 400, network-error retry, max-attempts exhaustion with single audit, single rate-limit slot).
- Full engine unit suite: 1519 passed, 4 skipped; affected files 3× stable; ruff/mypy clean; `docker compose -f docker-compose.dev.yml config` validates.

## Ops notes

- To opt out of decision alerts in execution modes: `TELEGRAM_EXECUTION_DECISION_ALERTS_ENABLED=0`.
- First restart after deploy may emit a short burst of late order-update alerts (correlations now survive restarts — by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
