### PR TITLE
fix(risk): default risk_per_trade to documented 0.5% fixed-fractional

### DIFF
--- a/app/engine/main.py
+++ b/app/engine/main.py
@@ -327,7 +327,8 @@ def load_configuration() -> EngineConfig:
             max_position_size=Decimal(os.getenv("MAX_POSITION_SIZE", "0.1")),
             max_daily_loss=Decimal(os.getenv("MAX_DAILY_LOSS", "0.05")),
             max_drawdown=Decimal(os.getenv("MAX_DRAWDOWN", "0.15")),
-            risk_per_trade=Decimal(os.getenv("RISK_PER_TRADE", "0.02")),
+            # 0.5% fixed-fractional per trade — the documented risk profile.
+            risk_per_trade=Decimal(os.getenv("RISK_PER_TRADE", "0.005")),
             max_correlation=Decimal(os.getenv("MAX_CORRELATION", "0.7")),
             max_open_positions=int(os.getenv("MAX_OPEN_POSITIONS", "5")),
             max_total_exposure_leverage=Decimal(

--- a/app/engine/tests/unit/test_main_execution_wiring.py
+++ b/app/engine/tests/unit/test_main_execution_wiring.py
@@ -426,3 +426,33 @@ class TestTelegramExecutionDecisionAlertsDefault:
         monkeypatch.setenv("TELEGRAM_EXECUTION_DECISION_ALERTS_ENABLED", value)
 
         assert main_mod._telegram_execution_decision_alerts_enabled_from_env() is False
+
+
+class TestRiskPerTradeDefault:
+    """Documented risk is 0.5% fixed-fractional per trade (CLAUDE.md)."""
+
+    def test_load_configuration_defaults_risk_per_trade_to_half_percent(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from app.engine import main as main_mod
+
+        monkeypatch.delenv("RISK_PER_TRADE", raising=False)
+        monkeypatch.setenv("TRADING_SYMBOLS", "BTCUSDT")
+
+        cfg = main_mod.load_configuration()
+
+        assert cfg.risk_parameters.risk_per_trade == Decimal("0.005")
+
+    def test_load_configuration_env_overrides_risk_per_trade(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from app.engine import main as main_mod
+
+        monkeypatch.setenv("RISK_PER_TRADE", "0.02")
+        monkeypatch.setenv("TRADING_SYMBOLS", "BTCUSDT")
+
+        cfg = main_mod.load_configuration()
+
+        assert cfg.risk_parameters.risk_per_trade == Decimal("0.02")


### PR DESCRIPTION
## Summary

Item 3 of the system-review action plan: the wired `RISK_PER_TRADE` default was `0.02` (2%) while CLAUDE.md documents 0.5% fixed-fractional per trade. This 4× oversizing was the root cause of the `max_position_notional_exceeded` rejection storm documented in the 2026-03-01 coding logs (with 2% risk, any stop tighter than 20% of price exceeded the 10% notional cap).

The other two parts of this action item — resize-instead-of-reject at the notional cap, and equity-before-notional check ordering — already landed on main since the review snapshot, so this PR is only the default truth-up.

## Test plan

Two new tests pin the default (`0.005` when env unset) and the env override path. Full engine unit suite: 1521 passed. ruff/format clean.

## Ops note

If you intentionally want 2% risk, set `RISK_PER_TRADE=0.02` explicitly in `.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
