### PR TITLE
feat(bff): enforce JWT auth at websocket handshake

### DIFF
--- a/app/bff/src/alerts/alerts.gateway.spec.ts
+++ b/app/bff/src/alerts/alerts.gateway.spec.ts
@@ -68,6 +68,7 @@ describe('AlertsGateway', () => {
     // Mock Socket.io server
     mockServer = {
       emit: jest.fn(),
+      use: jest.fn(),
       to: jest.fn().mockReturnThis(),
       in: jest.fn().mockReturnThis(),
     } as any;
@@ -293,6 +294,28 @@ describe('AlertsGateway', () => {
           title: 'Order FILLED: ETHUSDT',
         }),
       );
+    });
+  });
+
+  describe('handshake auth middleware', () => {
+    it('registers a middleware that rejects token-less sockets with an error', async () => {
+      gateway.afterInit(mockServer);
+
+      const useMock = (mockServer as unknown as { use: jest.Mock }).use;
+      expect(useMock).toHaveBeenCalledTimes(1);
+      const middleware = useMock.mock.calls[0][0] as (
+        socket: unknown,
+        next: (err?: Error) => void,
+      ) => Promise<void>;
+
+      const next = jest.fn();
+      await middleware(
+        { id: 'anon', handshake: { auth: {}, headers: {}, query: {} }, data: {} },
+        next,
+      );
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith(expect.any(Error));
     });
   });
 });

--- a/app/bff/src/alerts/alerts.gateway.ts
+++ b/app/bff/src/alerts/alerts.gateway.ts
@@ -7,11 +7,14 @@ import {
   OnGatewayDisconnect,
 } from '@nestjs/websockets';
 import { Logger, UseGuards } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
 import { Server, Socket } from 'socket.io';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { CONTRACT_TOPICS } from '../contracts/topics';
 import { AlertsService } from './alerts.service';
 import { WsJwtGuard } from '../auth/guards/ws-jwt.guard';
+import { createWsAuthMiddleware } from '../auth/ws-auth.middleware';
 import type { JwtPayload } from '../auth/interfaces/jwt-payload.interface';
 import type { Alert } from './dto/alert.dto';
 import type { DecisionEvent, OrderUpdateEvent } from '../trading/trading.service';
@@ -31,10 +34,15 @@ export class AlertsGateway implements OnGatewayInit, OnGatewayConnection, OnGate
   constructor(
     private readonly alertsService: AlertsService,
     private readonly eventEmitter: EventEmitter2,
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
   ) {}
 
   afterInit(server: Server) {
     this.server = server;
+    // Populates socket.data.user before handleConnection runs; without it
+    // the user check below rejected every client, authenticated or not.
+    server.use(createWsAuthMiddleware(this.jwtService, this.configService));
     this.logger.log('Alerts WebSocket Gateway initialized');
 
     // Subscribe to alert events

--- a/app/bff/src/auth/ws-auth.middleware.spec.ts
+++ b/app/bff/src/auth/ws-auth.middleware.spec.ts
@@ -1,0 +1,128 @@
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import type { Socket } from 'socket.io';
+import { createWsAuthMiddleware, extractHandshakeToken } from './ws-auth.middleware';
+
+const JWT_SECRET = 'test-secret';
+const VALID_PAYLOAD = { sub: 'user-1', username: 'trader', roles: ['operator'] };
+
+function makeSocket(handshake: Partial<Socket['handshake']>): Socket {
+  return {
+    id: 'socket-1',
+    handshake: { auth: {}, headers: {}, query: {}, ...handshake },
+    data: {},
+  } as unknown as Socket;
+}
+
+function makeConfigService(secret: string | null = JWT_SECRET): ConfigService {
+  return {
+    get: jest.fn((key: string) => (key === 'JWT_SECRET' && secret !== null ? secret : undefined)),
+  } as unknown as ConfigService;
+}
+
+describe('extractHandshakeToken', () => {
+  it('reads token from handshake.auth', () => {
+    const socket = makeSocket({ auth: { token: 'abc' } });
+    expect(extractHandshakeToken(socket)).toBe('abc');
+  });
+
+  it('falls back to Authorization header and strips Bearer prefix', () => {
+    const socket = makeSocket({ headers: { authorization: 'Bearer xyz' } });
+    expect(extractHandshakeToken(socket)).toBe('xyz');
+  });
+
+  it('does not read tokens from the query string', () => {
+    const socket = makeSocket({ query: { token: 'leaky' } });
+    expect(extractHandshakeToken(socket)).toBeUndefined();
+  });
+
+  it.each([[{}], [123], [['a']], [true]])(
+    'treats non-string auth token %p as absent instead of throwing',
+    (badToken) => {
+      const socket = makeSocket({ auth: { token: badToken as never } });
+      expect(extractHandshakeToken(socket)).toBeUndefined();
+    },
+  );
+
+  it('treats a bare Bearer prefix as absent', () => {
+    const socket = makeSocket({ headers: { authorization: 'Bearer ' } });
+    expect(extractHandshakeToken(socket)).toBeUndefined();
+  });
+});
+
+describe('createWsAuthMiddleware', () => {
+  let jwtService: JwtService;
+
+  beforeEach(() => {
+    jwtService = new JwtService({ secret: JWT_SECRET });
+  });
+
+  it('sets socket.data.user and calls next() for a valid token', async () => {
+    const token = jwtService.sign(VALID_PAYLOAD, { secret: JWT_SECRET });
+    const middleware = createWsAuthMiddleware(jwtService, makeConfigService());
+    const socket = makeSocket({ auth: { token } });
+    const next = jest.fn();
+
+    await middleware(socket, next);
+
+    expect(next).toHaveBeenCalledWith();
+    expect(socket.data.user).toMatchObject(VALID_PAYLOAD);
+  });
+
+  it('rejects a missing token with an unauthorized error', async () => {
+    const middleware = createWsAuthMiddleware(jwtService, makeConfigService());
+    const socket = makeSocket({});
+    const next = jest.fn();
+
+    await middleware(socket, next);
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+    expect(socket.data.user).toBeUndefined();
+  });
+
+  it('rejects an invalid token with an unauthorized error', async () => {
+    const middleware = createWsAuthMiddleware(jwtService, makeConfigService());
+    const socket = makeSocket({ auth: { token: 'not-a-jwt' } });
+    const next = jest.fn();
+
+    await middleware(socket, next);
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+    expect(socket.data.user).toBeUndefined();
+  });
+
+  it('rejects when the JWT secret is not configured', async () => {
+    const token = jwtService.sign(VALID_PAYLOAD, { secret: JWT_SECRET });
+    const middleware = createWsAuthMiddleware(jwtService, makeConfigService(null));
+    const socket = makeSocket({ auth: { token } });
+    const next = jest.fn();
+
+    await middleware(socket, next);
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it('rejects a non-string token with an unauthorized error instead of crashing', async () => {
+    const middleware = createWsAuthMiddleware(jwtService, makeConfigService());
+    const socket = makeSocket({ auth: { token: { $evil: true } as never } });
+    const next = jest.fn();
+
+    await expect(middleware(socket, next)).resolves.toBeUndefined();
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+    expect(socket.data.user).toBeUndefined();
+  });
+
+  it('rejects an expired token', async () => {
+    const token = jwtService.sign(VALID_PAYLOAD, { secret: JWT_SECRET, expiresIn: '-1s' });
+    const middleware = createWsAuthMiddleware(jwtService, makeConfigService());
+    const socket = makeSocket({ auth: { token } });
+    const next = jest.fn();
+
+    await middleware(socket, next);
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+    expect(socket.data.user).toBeUndefined();
+  });
+});

--- a/app/bff/src/auth/ws-auth.middleware.ts
+++ b/app/bff/src/auth/ws-auth.middleware.ts
@@ -1,0 +1,79 @@
+import { Logger } from '@nestjs/common';
+import type { ConfigService } from '@nestjs/config';
+import type { JwtService } from '@nestjs/jwt';
+import type { Socket } from 'socket.io';
+import type { JwtPayload } from './interfaces/jwt-payload.interface';
+
+type WsNextFunction = (err?: Error) => void;
+
+export type WsAuthMiddleware = (socket: Socket, next: WsNextFunction) => Promise<void>;
+
+const logger = new Logger('WsAuthMiddleware');
+
+export function extractHandshakeToken(socket: Socket): string | undefined {
+  // handshake.auth is attacker-controlled JSON: token may be any type, and a
+  // non-string here must not be able to throw (unhandled middleware rejections
+  // kill the process on modern Node).
+  const raw: unknown = socket.handshake.auth?.token;
+  let token = typeof raw === 'string' ? raw : undefined;
+
+  if (!token) {
+    const header = socket.handshake.headers?.authorization;
+    if (typeof header === 'string' && header.length > 0) {
+      token = header;
+    }
+  }
+
+  if (token?.startsWith('Bearer ')) {
+    token = token.slice(7);
+  }
+
+  return token || undefined;
+}
+
+/**
+ * Socket.io handshake middleware enforcing JWT auth at connection time.
+ *
+ * NestJS guards run only on message handlers, never on the connection
+ * itself, so without this middleware anonymous sockets complete the
+ * handshake and receive every room broadcast. Rejected sockets never
+ * reach handleConnection; accepted ones carry the payload in
+ * socket.data.user.
+ */
+export function createWsAuthMiddleware(
+  jwtService: JwtService,
+  configService: ConfigService,
+): WsAuthMiddleware {
+  return async (socket: Socket, next: WsNextFunction): Promise<void> => {
+    // socket.io does not await or catch middleware rejections, so any throw
+    // escaping this function becomes an unhandled rejection that can kill the
+    // process — everything stays inside this try/catch.
+    try {
+      const token = extractHandshakeToken(socket);
+
+      if (!token) {
+        logger.warn(`Rejecting socket ${socket.id}: no token in handshake`);
+        next(new Error('unauthorized'));
+        return;
+      }
+
+      const secret =
+        configService.get<string>('JWT_SECRET') ?? configService.get<string>('jwt.secret');
+
+      if (!secret) {
+        logger.error('JWT secret is not configured; rejecting socket connection');
+        next(new Error('unauthorized'));
+        return;
+      }
+
+      const payload = await jwtService.verifyAsync<JwtPayload>(token, { secret });
+      socket.data.user = payload;
+      next();
+    } catch (error) {
+      logger.warn(
+        `Rejecting socket ${socket.id}: ${error instanceof Error ? error.message : 'invalid token'}`,
+      );
+      next(new Error('unauthorized'));
+    }
+  };
+}

--- a/app/bff/src/market-data/market-data.gateway.spec.ts
+++ b/app/bff/src/market-data/market-data.gateway.spec.ts
@@ -58,6 +58,7 @@ describe('MarketDataGateway', () => {
     // Mock Socket.io server
     mockServer = {
       emit: jest.fn(),
+      use: jest.fn(),
       to: jest.fn().mockReturnThis(),
       in: jest.fn().mockReturnThis(),
     } as any;
@@ -262,6 +263,28 @@ describe('MarketDataGateway', () => {
           { symbol: 'ETHUSDT', timeframe: '5m' },
         ],
       });
+    });
+  });
+
+  describe('handshake auth middleware', () => {
+    it('registers a middleware that rejects token-less sockets with an error', async () => {
+      gateway.afterInit(mockServer);
+
+      const useMock = (mockServer as unknown as { use: jest.Mock }).use;
+      expect(useMock).toHaveBeenCalledTimes(1);
+      const middleware = useMock.mock.calls[0][0] as (
+        socket: unknown,
+        next: (err?: Error) => void,
+      ) => Promise<void>;
+
+      const next = jest.fn();
+      await middleware(
+        { id: 'anon', handshake: { auth: {}, headers: {}, query: {} }, data: {} },
+        next,
+      );
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith(expect.any(Error));
     });
   });
 });

--- a/app/bff/src/market-data/market-data.gateway.ts
+++ b/app/bff/src/market-data/market-data.gateway.ts
@@ -8,10 +8,12 @@ import {
   OnGatewayDisconnect,
 } from '@nestjs/websockets';
 import { Logger, UseGuards } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
 import { Server, Socket } from 'socket.io';
 import { EngineClientService } from '../engine-client/engine-client.service';
 import { ConfigService } from '@nestjs/config';
 import { WsJwtGuard } from '../auth/guards/ws-jwt.guard';
+import { createWsAuthMiddleware } from '../auth/ws-auth.middleware';
 import type { JwtPayload } from '../auth/interfaces/jwt-payload.interface';
 import type {
   CandlesV1,
@@ -27,6 +29,9 @@ interface SubscriptionData {
 }
 
 @WebSocketGateway({
+  // COLLISION: TradingGateway also declares '/trading'. This module is
+  // currently disabled in app.module.ts; move to its own namespace (or merge
+  // into TradingGateway) before re-enabling, or both connection handlers fire.
   namespace: '/trading',
   cors: {
     origin: true,
@@ -41,10 +46,12 @@ export class MarketDataGateway implements OnGatewayInit, OnGatewayConnection, On
   constructor(
     private readonly engineClient: EngineClientService,
     private readonly configService: ConfigService,
+    private readonly jwtService: JwtService,
   ) {}
 
   afterInit(server: Server) {
     this.server = server;
+    server.use(createWsAuthMiddleware(this.jwtService, this.configService));
     this.logger.log('MarketData WebSocket Gateway initialized');
 
     // Subscribe to engine events

--- a/app/bff/src/trading/trading.gateway.spec.ts
+++ b/app/bff/src/trading/trading.gateway.spec.ts
@@ -80,6 +80,7 @@ describe('TradingGateway', () => {
     // Mock Socket.io server
     mockServer = {
       emit: jest.fn(),
+      use: jest.fn(),
       to: jest.fn().mockReturnThis(),
     } as any;
 
@@ -280,6 +281,28 @@ describe('TradingGateway', () => {
 
       expect(result).toEqual(orders);
       expect(tradingService.getActiveOrders).toHaveBeenCalled();
+    });
+  });
+
+  describe('handshake auth middleware', () => {
+    it('registers a middleware that rejects token-less sockets with an error', async () => {
+      gateway.afterInit(mockServer);
+
+      const useMock = (mockServer as unknown as { use: jest.Mock }).use;
+      expect(useMock).toHaveBeenCalledTimes(1);
+      const middleware = useMock.mock.calls[0][0] as (
+        socket: unknown,
+        next: (err?: Error) => void,
+      ) => Promise<void>;
+
+      const next = jest.fn();
+      await middleware(
+        { id: 'anon', handshake: { auth: {}, headers: {}, query: {} }, data: {} },
+        next,
+      );
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith(expect.any(Error));
     });
   });
 });

--- a/app/bff/src/trading/trading.gateway.ts
+++ b/app/bff/src/trading/trading.gateway.ts
@@ -8,6 +8,8 @@ import {
   OnGatewayDisconnect,
 } from '@nestjs/websockets';
 import { Logger, UseGuards } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
 import { Server, Socket } from 'socket.io';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { CommandBus } from '@nestjs/cqrs';
@@ -15,6 +17,7 @@ import { TradingService } from './trading.service';
 import { OrderRequest } from '../router-client/router-client.service';
 import { CONTRACT_TOPICS } from '../contracts/topics';
 import { WsJwtGuard } from '../auth/guards/ws-jwt.guard';
+import { createWsAuthMiddleware } from '../auth/ws-auth.middleware';
 import type { JwtPayload } from '../auth/interfaces/jwt-payload.interface';
 import { PlaceOrderCommand } from './commands/place-order.command';
 import { CancelOrderCommand } from './commands/cancel-order.command';
@@ -42,10 +45,15 @@ export class TradingGateway implements OnGatewayInit, OnGatewayConnection, OnGat
     private readonly tradingService: TradingService,
     private readonly eventEmitter: EventEmitter2,
     private readonly commandBus: CommandBus,
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
   ) {}
 
   afterInit(server: Server) {
     this.server = server;
+    // Guards never run at connection time; without handshake auth anonymous
+    // sockets would join 'trading' and receive every broadcast.
+    server.use(createWsAuthMiddleware(this.jwtService, this.configService));
     this.logger.log('Trading WebSocket Gateway initialized');
 
     // Subscribe to trading events and forward to clients


### PR DESCRIPTION
## Summary

Item 4 of the system-review action plan (auth boundaries). Two of the three sub-scopes — engine control-plane token auth and router API-key middleware — already landed on main since the review snapshot, so this PR delivers the remaining one: **WebSocket handshake authentication in the BFF**.

NestJS `@UseGuards` runs only on `@SubscribeMessage` handlers, never at connection time. Consequences before this PR: anonymous sockets joined the `trading` room and received every order/position/PnL/decision broadcast, and the alerts gateway's connection-time user check disconnected **every** client (the user object was never populated at that point).

- New `createWsAuthMiddleware`: verifies the JWT from `handshake.auth.token` or the `Authorization` header (query-string tokens deliberately rejected — they land in access logs), sets `socket.data.user`, else rejects with `unauthorized`. Registered via `server.use(...)` in `afterInit` of the trading, alerts, and market-data gateways. Verified against socket.io 4.8.1 internals: middleware runs before `handleConnection`, rejected sockets never connect.
- Hardened against a QCHECK-found CRITICAL: handshake payloads are attacker-controlled, and a non-string token would have thrown outside try/catch in an unawaited async middleware — an unhandled rejection that kills the process on Node ≥20. Token extraction is type-guarded and the middleware body is fully wrapped.
- `/ws` health gateway intentionally left unauthenticated (emits nothing sensitive).

## Known follow-ups (out of scope, tracked)

- UI has no `connect_error` handler; a rejected handshake leaves it stuck at "connecting" until re-login (goes to item 9, BFF/UI real-time repair).
- `WsJwtGuard` still accepts query-string tokens at message level (only reachable post-handshake-auth); align later.
- MarketDataGateway shares the `/trading` namespace with TradingGateway — collision documented in-code; must be resolved before re-enabling MarketDataModule (item 9).

## Test plan

- 15 middleware tests (valid/missing/invalid/expired token, Bearer stripping, non-string token DoS regression, bare Bearer prefix, query-string exclusion, unconfigured secret) + per-gateway tests that capture the registered middleware and assert a token-less socket is rejected with an Error.
- Full BFF suite: 338 passed. `tsc --noEmit` clean, eslint clean. (`pnpm build` fails identically on baseline — pre-existing Node 26 / glob@10.5.0 ESM incompatibility, unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
