### PR TITLE
fix(engine): auto-reactivate failed subscribers and unblock bus publish

### DIFF
--- a/app/engine/bus.py
+++ b/app/engine/bus.py
@@ -22,6 +22,7 @@ from .core.error_handling import (
     handle_error,
 )
 from .core.event_bus_factory import EventBusConfig
+from .core.event_processor import CIRCUIT_BREAKER_OPEN_ERROR_TYPE
 from .core.interfaces import (
     EventProcessorInterface,
     SubscriptionManagerInterface,
@@ -252,12 +253,15 @@ class EventBus:
             event.metadata["published_at"] = asyncio.get_event_loop().time()
 
             # Add to processing queue respecting queue mode
+            # put_nowait keeps the hot publish path non-blocking: a full
+            # queue sheds the event via the QueueFull handler below instead of
+            # stalling the WebSocket ingest caller.
             if self._use_priority_queue:
-                await self._event_queue.put(
+                self._event_queue.put_nowait(
                     (-priority, asyncio.get_event_loop().time(), event),
                 )
             else:
-                await self._event_queue.put(event)
+                self._event_queue.put_nowait(event)
             logger.debug(f"Published event {event.event_type} for {event.symbol}")
             return True
 
@@ -276,6 +280,7 @@ class EventBus:
                 context=context,
             )
             await handle_error(error)
+            await self._maybe_enqueue_dead_letter(event, "publish_queue_full")
             return False
         except Exception as e:
             context = create_error_context(
@@ -491,6 +496,11 @@ class EventBus:
 
         # Update subscription manager with success/failure tracking
         for error in result.errors:
+            # An open breaker owns recovery via half-open probes; recording it
+            # as a failure would deactivate the subscription before the
+            # breaker can recover.
+            if error.error_type == CIRCUIT_BREAKER_OPEN_ERROR_TYPE:
+                continue
             await self._subscription_manager.record_subscription_failure(
                 error.subscription_id,
                 error.error_message,
@@ -512,7 +522,7 @@ class EventBus:
             event.metadata["dead_letter_timestamp"] = datetime.now(
                 UTC,
             ).isoformat()
-            await self._dead_letter_queue.put(event)
+            self._dead_letter_queue.put_nowait(event)
         except asyncio.QueueFull:
             logger.error("Dead letter queue full, dropping event")
 
@@ -528,7 +538,7 @@ class EventBus:
             except asyncio.QueueEmpty:
                 break
         for ev in tmp:
-            await self._dead_letter_queue.put(ev)
+            self._dead_letter_queue.put_nowait(ev)
             if len(events) < limit:
                 events.append(ev)
         return events

--- a/app/engine/core/event_bus_factory.py
+++ b/app/engine/core/event_bus_factory.py
@@ -117,6 +117,10 @@ class EventBusConfig:
             "default_max_retries": int(
                 secure_config.get("SUBSCRIPTION_DEFAULT_RETRIES", 3),
             ),
+            "reactivation_cooldown_seconds": max(
+                1.0,
+                float(secure_config.get("SUBSCRIPTION_REACTIVATION_COOLDOWN_SECONDS", 60.0)),
+            ),
         }
 
     @staticmethod

--- a/app/engine/core/event_processor.py
+++ b/app/engine/core/event_processor.py
@@ -31,6 +31,9 @@ class EventProcessingConfig:
     timeout_seconds: float = 60.0
 
 
+CIRCUIT_BREAKER_OPEN_ERROR_TYPE = "CircuitBreakerOpen"
+
+
 @dataclass
 class EventProcessingError:
     """Error information for failed event processing."""
@@ -145,7 +148,7 @@ class EventProcessor:
                         subscription.subscriber_id,
                     )
                     if not await circuit_breaker.should_allow_request():
-                        return False, subscription, RuntimeError("CircuitBreakerOpen")
+                        return False, subscription, RuntimeError(CIRCUIT_BREAKER_OPEN_ERROR_TYPE)
 
                 # Process with semaphore + timeout
                 await self._process_subscription(event, subscription)
@@ -202,8 +205,8 @@ class EventProcessor:
                 failed_handlers += 1
                 error_type = type(exc).__name__ if exc is not None else "ProcessingError"
                 error_message = str(exc) if exc is not None else "Unknown error"
-                if error_message == "CircuitBreakerOpen":
-                    error_type = "CircuitBreakerOpen"
+                if error_message == CIRCUIT_BREAKER_OPEN_ERROR_TYPE:
+                    error_type = CIRCUIT_BREAKER_OPEN_ERROR_TYPE
                 errors.append(
                     EventProcessingError(
                         subscription_id=sub.subscription_id,

--- a/app/engine/core/subscription_manager.py
+++ b/app/engine/core/subscription_manager.py
@@ -8,11 +8,13 @@ from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+import logging
 from typing import Any
 from uuid import uuid4
 
 from app.engine.models import BaseEvent, EventType
 
+from .clock import Clock, SystemClock
 from .error_handling import (
     ErrorCategory,
     ErrorSeverity,
@@ -20,6 +22,8 @@ from .error_handling import (
     create_error_context,
     handle_error,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -29,6 +33,9 @@ class SubscriptionConfig:
     max_subscriptions: int = 1000
     default_priority: int = 0
     default_max_retries: int = 3
+    # How long a subscription that exceeded max_retries stays deactivated
+    # before the dispatch-time lookup reactivates it with reset retry state.
+    reactivation_cooldown_seconds: float = 60.0
 
 
 @dataclass
@@ -46,6 +53,10 @@ class EventSubscription:
     retry_count: int = 0
     last_error: str | None = None
     is_active: bool = True
+    # Monotonic deadline after which a failure-deactivated subscription is
+    # reactivated; None on an inactive subscription means manually disabled
+    # (never auto-reactivated).
+    deactivated_until: float | None = None
     created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
 
     def __lt__(self, other: "EventSubscription") -> bool:
@@ -66,9 +77,14 @@ class SubscriptionManager:
     with proper priority ordering and retry tracking.
     """
 
-    def __init__(self, config: SubscriptionConfig | None = None):
+    def __init__(
+        self,
+        config: SubscriptionConfig | None = None,
+        clock: Clock | None = None,
+    ):
         """Initialize subscription manager with optional config."""
         self._config = config or SubscriptionConfig()
+        self._clock = clock if clock is not None else SystemClock()
 
         # Subscriptions by event type
         self._specific_subscriptions: dict[EventType, list[EventSubscription]] = defaultdict(list)
@@ -221,17 +237,22 @@ class SubscriptionManager:
             list[Any] of active subscriptions sorted by priority (descending)
         """
         async with self._lock:
+            now = self._clock.monotonic()
             subscriptions = []
 
             # Add specific event type subscriptions
             if event_type in self._specific_subscriptions:
                 subscriptions.extend(
-                    [sub for sub in self._specific_subscriptions[event_type] if sub.is_active],
+                    [
+                        sub
+                        for sub in self._specific_subscriptions[event_type]
+                        if self._is_dispatchable(sub, now)
+                    ],
                 )
 
             # Add all-events subscriptions
             subscriptions.extend(
-                [sub for sub in self._all_event_subscriptions if sub.is_active],
+                [sub for sub in self._all_event_subscriptions if self._is_dispatchable(sub, now)],
             )
 
             # Remove duplicates and sort by priority
@@ -243,6 +264,29 @@ class SubscriptionManager:
             )
 
             return sorted_subscriptions
+
+    def _is_dispatchable(self, sub: EventSubscription, now: float) -> bool:
+        """Check dispatch eligibility, reactivating expired cooldowns.
+
+        Must be called under self._lock. A subscription deactivated by
+        failure tracking carries a deactivated_until deadline; once it
+        passes, the subscription is reactivated with reset retry state.
+        Inactive subscriptions without a deadline stay off permanently.
+        """
+        if sub.is_active:
+            return True
+        if sub.deactivated_until is None or now < sub.deactivated_until:
+            return False
+
+        sub.is_active = True
+        sub.retry_count = 0
+        sub.deactivated_until = None
+        logger.warning(
+            "Reactivating subscription %s (subscriber %s) after failure cooldown",
+            sub.subscription_id,
+            sub.subscriber_id,
+        )
+        return True
 
     async def get_subscription_count(self) -> int:
         """Get total number of subscriptions."""
@@ -290,9 +334,21 @@ class SubscriptionManager:
             subscription.retry_count += 1
             subscription.last_error = error_message
 
-            # Disable if max retries exceeded
-            if subscription.retry_count > subscription.max_retries:
+            # Deactivate for a cooldown if max retries exceeded; the
+            # dispatch-time lookup reactivates it once the cooldown expires.
+            if subscription.retry_count > subscription.max_retries and subscription.is_active:
+                cooldown = self._config.reactivation_cooldown_seconds
                 subscription.is_active = False
+                subscription.deactivated_until = self._clock.monotonic() + cooldown
+                logger.warning(
+                    "Deactivating subscription %s (subscriber %s) after %d failures; "
+                    "last error: %s; reactivating in %.0fs",
+                    subscription_id,
+                    subscription.subscriber_id,
+                    subscription.retry_count,
+                    error_message,
+                    cooldown,
+                )
 
     async def record_subscription_success(self, subscription_id: str) -> None:
         """
@@ -324,6 +380,11 @@ class SubscriptionManager:
 
             subscription.retry_count = 0
             subscription.last_error = None
+            # Only clear the cooldown on an active subscription: a stale
+            # success from an in-flight dispatch racing a deactivation must
+            # not erase the deadline, which would deactivate it permanently.
+            if subscription.is_active:
+                subscription.deactivated_until = None
 
     async def get_subscription_by_id(
         self,

--- a/app/engine/tests/unit/test_event_bus_cb_failure_exclusion.py
+++ b/app/engine/tests/unit/test_event_bus_cb_failure_exclusion.py
@@ -1,0 +1,103 @@
+"""An open circuit breaker must not count as a subscription failure.
+
+The breaker owns recovery (half-open probes); recording CircuitBreakerOpen
+results as failures raced the breaker and permanently deactivated the
+subscription before it could recover. Such results are excluded from both
+failure AND success recording (success would reset retry_count and mask
+real pre-open failures).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.engine.bus import set_event_bus
+from app.engine.core.event_bus_factory import EventBusConfig, EventBusFactory
+from app.engine.core.event_processor import EventProcessingError, EventProcessingResult
+from app.engine.models import ErrorEvent
+
+SUB_ID = "sub-1"
+
+
+def _make_bus():
+    cfg = EventBusConfig(
+        use_priority_queue=False,
+        dlq_on_any_failure=False,
+        num_workers=1,
+        max_queue_size=100,
+        dead_letter_queue_size=10,
+    )
+    return EventBusFactory().create_with_config(cfg)
+
+
+def _make_event() -> ErrorEvent:
+    return ErrorEvent(
+        timestamp=datetime.now(UTC),
+        component="test",
+        error_type="probe",
+        error_message="probe",
+        symbol="BTCUSDT",
+        metadata={},
+    )
+
+
+def _result_with(error_type: str) -> EventProcessingResult:
+    event = _make_event()
+    return EventProcessingResult(
+        event_id=event.event_id,
+        successful_handlers=0,
+        failed_handlers=1,
+        errors=[
+            EventProcessingError(
+                subscription_id=SUB_ID,
+                subscriber_id="features",
+                error_type=error_type,
+                error_message=error_type,
+            ),
+        ],
+        processing_time=0.001,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _bus_context():
+    bus = _make_bus()
+    set_event_bus(bus)
+    yield bus
+    set_event_bus(None)
+
+
+async def _dispatch_with(bus, error_type: str) -> tuple[AsyncMock, AsyncMock]:
+    bus._event_processor.process_event = AsyncMock(return_value=_result_with(error_type))
+    fake_sub = type("FakeSub", (), {"subscription_id": SUB_ID})()
+    bus._subscription_manager.get_subscriptions_for_event = AsyncMock(return_value=[fake_sub])
+    failure = AsyncMock()
+    success = AsyncMock()
+    bus._subscription_manager.record_subscription_failure = failure
+    bus._subscription_manager.record_subscription_success = success
+    await bus._process_event_with_subscriptions(_make_event())
+    return failure, success
+
+
+class TestCircuitBreakerOpenExclusion:
+    @pytest.mark.asyncio
+    async def test_cb_open_does_not_record_failure(self, _bus_context) -> None:
+        failure, _ = await _dispatch_with(_bus_context, "CircuitBreakerOpen")
+
+        failure.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_cb_open_does_not_record_success_either(self, _bus_context) -> None:
+        _, success = await _dispatch_with(_bus_context, "CircuitBreakerOpen")
+
+        success.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_real_errors_still_recorded_as_failures(self, _bus_context) -> None:
+        failure, success = await _dispatch_with(_bus_context, "RuntimeError")
+
+        failure.assert_awaited_once()
+        success.assert_not_awaited()

--- a/app/engine/tests/unit/test_event_bus_publish_overflow.py
+++ b/app/engine/tests/unit/test_event_bus_publish_overflow.py
@@ -1,0 +1,108 @@
+"""Publish must shed load when the bounded queue is full, never block.
+
+A blocking put on a bounded asyncio.Queue never raises QueueFull, so the
+overflow branch was dead code and overload blocked the WebSocket ingest
+caller indefinitely. Overflowed events are dropped to the dead-letter queue
+with a reason and publish returns False.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+
+import pytest
+
+from app.engine.bus import set_event_bus
+from app.engine.core.event_bus_factory import EventBusConfig, EventBusFactory
+from app.engine.models import ErrorEvent
+
+QUEUE_SIZE = 4
+PUBLISH_TIMEOUT = 0.5
+
+
+def _make_bus(*, use_priority_queue: bool, dead_letter_queue_size: int = 10):
+    cfg = EventBusConfig(
+        use_priority_queue=use_priority_queue,
+        dlq_on_any_failure=False,
+        num_workers=1,
+        max_queue_size=QUEUE_SIZE,
+        dead_letter_queue_size=dead_letter_queue_size,
+    )
+    bus = EventBusFactory().create_with_config(cfg)
+    # Accept publishes without starting workers so nothing drains the queue
+    # (start() treats num_workers=0 as "use config default").
+    bus._running = True
+    set_event_bus(bus)
+    return bus
+
+
+def _make_event(n: int) -> ErrorEvent:
+    return ErrorEvent(
+        timestamp=datetime.now(UTC),
+        component="test",
+        error_type=f"probe-{n}",
+        error_message="probe",
+        symbol="BTCUSDT",
+        metadata={},
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_bus():
+    yield
+    set_event_bus(None)
+
+
+class TestPublishOverflow:
+    @pytest.mark.asyncio
+    async def test_publish_does_not_block_when_queue_full_fifo(self) -> None:
+        bus = _make_bus(use_priority_queue=False)
+        for n in range(QUEUE_SIZE):
+            assert await bus.publish(_make_event(n)) is True
+
+        result = await asyncio.wait_for(
+            bus.publish(_make_event(QUEUE_SIZE)),
+            timeout=PUBLISH_TIMEOUT,
+        )
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_publish_does_not_block_when_queue_full_priority(self) -> None:
+        bus = _make_bus(use_priority_queue=True)
+        for n in range(QUEUE_SIZE):
+            assert await bus.publish(_make_event(n), priority=n) is True
+
+        result = await asyncio.wait_for(
+            bus.publish(_make_event(QUEUE_SIZE), priority=9),
+            timeout=PUBLISH_TIMEOUT,
+        )
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_overflow_dropped_event_lands_in_dlq_with_reason(self) -> None:
+        bus = _make_bus(use_priority_queue=False)
+        for n in range(QUEUE_SIZE):
+            await bus.publish(_make_event(n))
+        dropped = _make_event(QUEUE_SIZE)
+
+        await asyncio.wait_for(bus.publish(dropped), timeout=PUBLISH_TIMEOUT)
+
+        dlq_events = await bus.get_dead_letter_events()
+        assert [e.event_id for e in dlq_events] == [dropped.event_id]
+        assert dlq_events[0].metadata["dead_letter_reason"] == "publish_queue_full"
+
+    @pytest.mark.asyncio
+    async def test_full_dlq_drops_without_blocking(self) -> None:
+        bus = _make_bus(use_priority_queue=False, dead_letter_queue_size=1)
+        for n in range(QUEUE_SIZE):
+            await bus.publish(_make_event(n))
+
+        first = await asyncio.wait_for(bus.publish(_make_event(100)), timeout=PUBLISH_TIMEOUT)
+        second = await asyncio.wait_for(bus.publish(_make_event(101)), timeout=PUBLISH_TIMEOUT)
+
+        assert first is False
+        assert second is False
+        assert len(await bus.get_dead_letter_events()) == 1

--- a/app/engine/tests/unit/test_subscription_manager_cooldown.py
+++ b/app/engine/tests/unit/test_subscription_manager_cooldown.py
@@ -1,0 +1,164 @@
+"""Tests for cooldown-based subscriber reactivation.
+
+A subscriber that exceeds max_retries must not be silently and permanently
+deactivated: a brief downstream outage would otherwise kill a pipeline stage
+until process restart. Deactivation now carries a cooldown after which the
+dispatch-time lookup reactivates the subscription with reset retry state.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.engine.core.clock import FakeClock
+from app.engine.core.subscription_manager import SubscriptionConfig, SubscriptionManager
+from app.engine.models import EventType
+
+COOLDOWN_SECONDS = 60.0
+MAX_RETRIES = 3
+
+
+async def _handler(event: object) -> None:
+    del event
+
+
+async def _make_deactivated_subscription(
+    manager: SubscriptionManager,
+) -> str:
+    sub_id = await manager.add_subscription(
+        subscriber_id="features",
+        handler=_handler,
+        event_types=[EventType.CANDLE_UPDATE],
+        max_retries=MAX_RETRIES,
+    )
+    for _ in range(MAX_RETRIES + 1):
+        await manager.record_subscription_failure(sub_id, "db down")
+    return sub_id
+
+
+class TestCooldownReactivation:
+    @pytest.mark.asyncio
+    async def test_deactivation_sets_cooldown_and_warns(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        clock = FakeClock()
+        manager = SubscriptionManager(
+            SubscriptionConfig(reactivation_cooldown_seconds=COOLDOWN_SECONDS),
+            clock=clock,
+        )
+
+        with caplog.at_level("WARNING", logger="app.engine.core.subscription_manager"):
+            sub_id = await _make_deactivated_subscription(manager)
+
+        subscription = manager._subscriptions_by_id[sub_id]
+        assert subscription.is_active is False
+        assert subscription.deactivated_until == clock.monotonic() + COOLDOWN_SECONDS
+        assert any("deactivat" in r.getMessage().lower() for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_dispatch_lookup_reactivates_after_cooldown(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        clock = FakeClock()
+        manager = SubscriptionManager(
+            SubscriptionConfig(reactivation_cooldown_seconds=COOLDOWN_SECONDS),
+            clock=clock,
+        )
+        sub_id = await _make_deactivated_subscription(manager)
+
+        clock.advance(seconds=COOLDOWN_SECONDS + 1)
+        with caplog.at_level("WARNING", logger="app.engine.core.subscription_manager"):
+            subs = await manager.get_subscriptions_for_event(EventType.CANDLE_UPDATE)
+
+        assert [s.subscription_id for s in subs] == [sub_id]
+        subscription = manager._subscriptions_by_id[sub_id]
+        assert subscription.is_active is True
+        assert subscription.retry_count == 0
+        assert subscription.deactivated_until is None
+        assert any("reactivat" in r.getMessage().lower() for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_stays_deactivated_within_cooldown(self) -> None:
+        clock = FakeClock()
+        manager = SubscriptionManager(
+            SubscriptionConfig(reactivation_cooldown_seconds=COOLDOWN_SECONDS),
+            clock=clock,
+        )
+        await _make_deactivated_subscription(manager)
+
+        clock.advance(seconds=COOLDOWN_SECONDS - 1)
+        subs = await manager.get_subscriptions_for_event(EventType.CANDLE_UPDATE)
+
+        assert subs == []
+
+    @pytest.mark.asyncio
+    async def test_manual_deactivation_without_cooldown_never_reactivates(self) -> None:
+        clock = FakeClock()
+        manager = SubscriptionManager(SubscriptionConfig(), clock=clock)
+        sub_id = await manager.add_subscription(
+            subscriber_id="features",
+            handler=_handler,
+            event_types=[EventType.CANDLE_UPDATE],
+        )
+        manager._subscriptions_by_id[sub_id].is_active = False
+
+        clock.advance(seconds=COOLDOWN_SECONDS * 100)
+        subs = await manager.get_subscriptions_for_event(EventType.CANDLE_UPDATE)
+
+        assert subs == []
+
+    @pytest.mark.asyncio
+    async def test_success_clears_cooldown_state(self) -> None:
+        clock = FakeClock()
+        manager = SubscriptionManager(
+            SubscriptionConfig(reactivation_cooldown_seconds=COOLDOWN_SECONDS),
+            clock=clock,
+        )
+        sub_id = await _make_deactivated_subscription(manager)
+        clock.advance(seconds=COOLDOWN_SECONDS + 1)
+        await manager.get_subscriptions_for_event(EventType.CANDLE_UPDATE)
+
+        await manager.record_subscription_success(sub_id)
+
+        subscription = manager._subscriptions_by_id[sub_id]
+        assert subscription.retry_count == 0
+        assert subscription.deactivated_until is None
+
+    @pytest.mark.asyncio
+    async def test_stale_success_does_not_clear_cooldown_on_inactive_sub(self) -> None:
+        """A success racing a deactivation (multi-worker dispatch snapshot)
+        must not erase the cooldown deadline — that would deactivate the
+        subscription permanently, the exact defect this module fixes."""
+        clock = FakeClock()
+        manager = SubscriptionManager(
+            SubscriptionConfig(reactivation_cooldown_seconds=COOLDOWN_SECONDS),
+            clock=clock,
+        )
+        sub_id = await _make_deactivated_subscription(manager)
+
+        await manager.record_subscription_success(sub_id)
+
+        subscription = manager._subscriptions_by_id[sub_id]
+        assert subscription.is_active is False
+        assert subscription.deactivated_until is not None
+
+        clock.advance(seconds=COOLDOWN_SECONDS + 1)
+        subs = await manager.get_subscriptions_for_event(EventType.CANDLE_UPDATE)
+        assert [s.subscription_id for s in subs] == [sub_id]
+
+    @pytest.mark.asyncio
+    async def test_cooldown_is_configurable(self) -> None:
+        clock = FakeClock()
+        short_cooldown = 5.0
+        manager = SubscriptionManager(
+            SubscriptionConfig(reactivation_cooldown_seconds=short_cooldown),
+            clock=clock,
+        )
+        sub_id = await _make_deactivated_subscription(manager)
+
+        clock.advance(seconds=short_cooldown + 1)
+        subs = await manager.get_subscriptions_for_event(EventType.CANDLE_UPDATE)
+
+        assert [s.subscription_id for s in subs] == [sub_id]


### PR DESCRIPTION
## Summary

Item 5 of the system-review action plan: two event-pipeline resilience defects that could silently kill pipeline stages.

**Permanent silent subscriber deactivation.** `record_subscription_failure` set `is_active = False` after `max_retries` (3) with no reactivation path anywhere — a brief DB outage permanently killed a pipeline stage (features/SMC/decision) while the process reported healthy. Worse, an open circuit breaker's `CircuitBreakerOpen` results were recorded as failures, so deactivation deterministically raced the breaker's own half-open recovery.

- Deactivation now sets a monotonic cooldown (`SUBSCRIPTION_REACTIVATION_COOLDOWN_SECONDS`, default 60s, clamped ≥1s); the dispatch-time lookup reactivates expired cooldowns with reset retry state; WARNING logged in both directions. Manual `is_active = False` (no deadline) stays off permanently.
- `CircuitBreakerOpen` results are excluded from **both** failure and success recording (success would reset `retry_count` and mask real pre-open failures).
- QCHECK found a multi-worker race — a stale success recorded against a cooldown-deactivated subscription cleared the deadline, re-creating the permanent kill — fixed and pinned with a regression test.

**Blocking publish with dead overflow handling.** `publish()` used a blocking `put` on the bounded queue, so `except asyncio.QueueFull` was unreachable and overload stalled the WebSocket ingest caller indefinitely. Now `put_nowait` (priority tuple form preserved): overflowed events go through `handle_error` at HIGH severity and are retained in the DLQ with reason `publish_queue_full`; publish returns False. DLQ inserts are non-blocking for the same reason.

## Accepted trade-off (explicit)

Overflow now sheds load instead of exerting blocking backpressure. Publish callers log-but-ignore `False` today; the drop is observable via the HIGH-severity `QueueError` (pipeline-health alerting) and DLQ retention. Suggested follow-up: a candle-gap backfill trigger keyed on `publish_queue_full` drops (fits item 9/monitoring work). Blocking the ingest hot path for all symbols was strictly worse.

## Test plan

14 new tests: cooldown deactivation/reactivation/boundaries/manual-off/success-reset/configurability + the stale-success race regression; CB-open excluded from failure and success recording with real errors still recorded; overflow non-blocking in both queue modes with DLQ reason and full-DLQ shedding. Full engine suite: 1535 passed. ruff/format/mypy clean, 3× flakiness stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
