### PR TITLE
fix(router): fetch futures exchange info and parse real symbol filters

### DIFF
--- a/app/router/internal/binance/client.go
+++ b/app/router/internal/binance/client.go
@@ -607,6 +607,28 @@ func (c *Client) RoundPrice(ctx context.Context, symbol string, price decimal.De
 	return c.exchangeInfoCache.RoundPrice(ctx, symbol, price, c.isFutures)
 }
 
+// RoundPriceDirection rounds a price onto the tick grid in a fixed
+// direction (see ExchangeInfoCache.RoundPriceDirectional).
+func (c *Client) RoundPriceDirection(ctx context.Context, symbol string, price decimal.Decimal, dir RoundDir) (decimal.Decimal, error) {
+	if c.exchangeInfoCache == nil {
+		return price, nil // No rounding if cache not available
+	}
+	return c.exchangeInfoCache.RoundPriceDirectional(ctx, symbol, price, dir, c.isFutures)
+}
+
+// StepSize returns the lot step size for a symbol, or zero when no
+// exchange info cache is wired (permissive test mode).
+func (c *Client) StepSize(ctx context.Context, symbol string) (decimal.Decimal, error) {
+	if c.exchangeInfoCache == nil {
+		return decimal.Zero, nil
+	}
+	info, err := c.exchangeInfoCache.GetSymbolInfo(ctx, symbol, c.isFutures)
+	if err != nil {
+		return decimal.Zero, err
+	}
+	return info.StepSize, nil
+}
+
 // RoundQuantity rounds a quantity according to symbol rules
 func (c *Client) RoundQuantity(ctx context.Context, symbol string, quantity decimal.Decimal) (decimal.Decimal, error) {
 	if c.exchangeInfoCache == nil {

--- a/app/router/internal/binance/exchange_info.go
+++ b/app/router/internal/binance/exchange_info.go
@@ -2,6 +2,7 @@ package binance
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -16,6 +17,7 @@ type ExchangeInfoCache struct {
 	spotClient    *rest.Client
 	futuresClient *rest.Client
 	cache         map[string]*SymbolInfo
+	futuresCache  map[string]*SymbolInfo
 	cacheMu       sync.RWMutex
 	cacheTime     time.Time
 	cacheTTL      time.Duration
@@ -53,12 +55,29 @@ type Filter struct {
 	MinNotional decimal.Decimal `json:"minNotional,omitempty"`
 }
 
+// Rounding-boundary violations are surfaced as errors instead of silently
+// clamping: inflating a quantity to minQty would violate risk sizing.
+var (
+	ErrQtyBelowMin = errors.New("quantity below symbol minimum")
+	ErrQtyAboveMax = errors.New("quantity above symbol maximum")
+)
+
+// RoundDir selects the tick-rounding direction for trigger-sensitive prices.
+type RoundDir int
+
+const (
+	RoundNearest RoundDir = iota
+	RoundDown
+	RoundUp
+)
+
 // NewExchangeInfoCache creates a new exchange info cache
 func NewExchangeInfoCache(spotClient, futuresClient *rest.Client, cacheTTL time.Duration, logger zerolog.Logger) *ExchangeInfoCache {
 	return &ExchangeInfoCache{
 		spotClient:    spotClient,
 		futuresClient: futuresClient,
 		cache:         make(map[string]*SymbolInfo),
+		futuresCache:  make(map[string]*SymbolInfo),
 		cacheTTL:      cacheTTL,
 		logger:        logger,
 	}
@@ -68,9 +87,9 @@ func NewExchangeInfoCache(spotClient, futuresClient *rest.Client, cacheTTL time.
 func (e *ExchangeInfoCache) GetSymbolInfo(ctx context.Context, symbol string, isFutures bool) (*SymbolInfo, error) {
 	e.cacheMu.RLock()
 	if time.Since(e.cacheTime) < e.cacheTTL {
-		info, exists := e.cache[symbol]
+		info, exists := e.marketCache(isFutures)[symbol]
 		e.cacheMu.RUnlock()
-		if exists && info.IsFutures == isFutures {
+		if exists {
 			return info, nil
 		}
 	} else {
@@ -83,19 +102,22 @@ func (e *ExchangeInfoCache) GetSymbolInfo(ctx context.Context, symbol string, is
 	}
 
 	e.cacheMu.RLock()
-	info, exists := e.cache[symbol]
+	info, exists := e.marketCache(isFutures)[symbol]
 	e.cacheMu.RUnlock()
 
 	if !exists {
-		return nil, fmt.Errorf("symbol %s not found", symbol)
-	}
-
-	if info.IsFutures != isFutures {
-		return nil, fmt.Errorf("symbol %s is %s but requested %s", symbol,
-			boolToMarket(info.IsFutures), boolToMarket(isFutures))
+		return nil, fmt.Errorf("symbol %s not found on %s", symbol, boolToMarket(isFutures))
 	}
 
 	return info, nil
+}
+
+// marketCache must be called with cacheMu held.
+func (e *ExchangeInfoCache) marketCache(isFutures bool) map[string]*SymbolInfo {
+	if isFutures {
+		return e.futuresCache
+	}
+	return e.cache
 }
 
 // RoundPrice rounds price according to symbol filters
@@ -130,22 +152,59 @@ func (e *ExchangeInfoCache) RoundQuantity(ctx context.Context, symbol string, qu
 		return decimal.Zero, err
 	}
 
-	// Check quantity bounds
-	if quantity.LessThan(info.MinQuantity) {
-		return info.MinQuantity, nil
-	}
-	if quantity.GreaterThan(info.MaxQuantity) {
-		return info.MaxQuantity, nil
-	}
-
-	// Round to step size
+	// Round to step size first, then enforce bounds: silently inflating a
+	// below-minimum quantity to minQty would violate risk sizing.
+	rounded := quantity
 	if info.StepSize.IsPositive() {
 		steps := quantity.Div(info.StepSize).Floor()
-		return steps.Mul(info.StepSize), nil
+		rounded = steps.Mul(info.StepSize)
+	} else if info.QuantityPrecision > 0 {
+		rounded = quantity.Truncate(int32(info.QuantityPrecision))
 	}
 
-	// Fallback to precision rounding
-	return quantity.Truncate(int32(info.QuantityPrecision)), nil
+	if rounded.LessThan(info.MinQuantity) {
+		return decimal.Zero, fmt.Errorf("%w: %s < %s for %s",
+			ErrQtyBelowMin, rounded, info.MinQuantity, symbol)
+	}
+	if info.MaxQuantity.IsPositive() && rounded.GreaterThan(info.MaxQuantity) {
+		return decimal.Zero, fmt.Errorf("%w: %s > %s for %s",
+			ErrQtyAboveMax, rounded, info.MaxQuantity, symbol)
+	}
+
+	return rounded, nil
+}
+
+// RoundPriceDirectional rounds a price onto the tick grid in a fixed
+// direction so that rounding can never move a stop or take-profit across
+// its trigger relation.
+func (e *ExchangeInfoCache) RoundPriceDirectional(ctx context.Context, symbol string, price decimal.Decimal, dir RoundDir, isFutures bool) (decimal.Decimal, error) {
+	info, err := e.GetSymbolInfo(ctx, symbol, isFutures)
+	if err != nil {
+		return decimal.Zero, err
+	}
+
+	if !info.TickSize.IsPositive() {
+		return price.Round(int32(info.PricePrecision)), nil
+	}
+
+	ticks := price.Div(info.TickSize)
+	switch dir {
+	case RoundDown:
+		ticks = ticks.Floor()
+	case RoundUp:
+		ticks = ticks.Ceil()
+	default:
+		ticks = ticks.Round(0)
+	}
+	rounded := ticks.Mul(info.TickSize)
+
+	if info.MinPrice.IsPositive() && rounded.LessThan(info.MinPrice) {
+		return info.MinPrice, nil
+	}
+	if info.MaxPrice.IsPositive() && rounded.GreaterThan(info.MaxPrice) {
+		return info.MaxPrice, nil
+	}
+	return rounded, nil
 }
 
 // ValidateNotional checks if order value meets minimum notional requirement
@@ -199,35 +258,96 @@ func (e *ExchangeInfoCache) refreshCache(ctx context.Context) error {
 				QuoteAssetPrecision: symbol.QuoteAssetPrecision,
 				IsFutures:           false,
 			}
-
-			// TODO: Parse filters when Symbol type includes them
-			// For now, set default values
-			info.MinPrice = decimal.RequireFromString("0.01")
-			info.MaxPrice = decimal.RequireFromString("1000000")
-			info.TickSize = decimal.RequireFromString("0.01")
-			info.MinQuantity = decimal.RequireFromString("0.001")
-			info.MaxQuantity = decimal.RequireFromString("10000")
-			info.StepSize = decimal.RequireFromString("0.001")
-			info.MinNotional = decimal.RequireFromString("10")
-			info.PricePrecision = 2
-			info.QuantityPrecision = 3
+			applyRawFilters(info, symbol.Filters)
 
 			newCache[symbol.Symbol] = info
 		}
 	}
 
-	// For futures, we would need to make a different API call
-	// Since the REST client doesn't support futures exchange info yet,
-	// we'll skip it for now
+	// A futures outage must not take down spot ordering: keep the previous
+	// futures entries and refresh spot only.
+	newFuturesCache := e.futuresCache
+	if e.futuresClient != nil {
+		e.logger.Debug().Msg("Fetching futures exchange info")
+		futuresInfo, err := e.futuresClient.GetFuturesExchangeInfo(ctx)
+		if err != nil {
+			e.logger.Error().Err(err).Msg("Failed to get futures exchange info; keeping previous futures entries")
+			futuresInfo = &rest.FuturesExchangeInfo{}
+		} else {
+			newFuturesCache = make(map[string]*SymbolInfo)
+		}
+
+		for _, symbol := range futuresInfo.Symbols {
+			if symbol.Status != "TRADING" {
+				continue
+			}
+
+			info := &SymbolInfo{
+				Symbol:            symbol.Symbol,
+				BaseAsset:         symbol.BaseAsset,
+				QuoteAsset:        symbol.QuoteAsset,
+				PricePrecision:    symbol.PricePrecision,
+				QuantityPrecision: symbol.QuantityPrecision,
+				IsFutures:         true,
+			}
+			applyRawFilters(info, symbol.Filters)
+
+			newFuturesCache[symbol.Symbol] = info
+		}
+	}
 
 	e.cache = newCache
+	e.futuresCache = newFuturesCache
 	e.cacheTime = time.Now()
 
 	e.logger.Info().
-		Int("symbol_count", len(newCache)).
+		Int("spot_symbol_count", len(newCache)).
+		Int("futures_symbol_count", len(newFuturesCache)).
 		Msg("Exchange info cache refreshed")
 
 	return nil
+}
+
+// applyRawFilters populates trading rules from exchangeInfo filters.
+func applyRawFilters(info *SymbolInfo, rawFilters []rest.RawFilter) {
+	parse := func(v string) decimal.Decimal {
+		if v == "" {
+			return decimal.Zero
+		}
+		d, err := decimal.NewFromString(v)
+		if err != nil {
+			return decimal.Zero
+		}
+		return d
+	}
+
+	for _, f := range rawFilters {
+		switch f.FilterType {
+		case "PRICE_FILTER":
+			info.MinPrice = parse(f.MinPrice)
+			info.MaxPrice = parse(f.MaxPrice)
+			info.TickSize = parse(f.TickSize)
+			if info.PricePrecision == 0 {
+				info.PricePrecision = calculatePrecision(info.TickSize)
+			}
+		case "LOT_SIZE":
+			info.MinQuantity = parse(f.MinQty)
+			info.MaxQuantity = parse(f.MaxQty)
+			info.StepSize = parse(f.StepSize)
+			if info.QuantityPrecision == 0 {
+				info.QuantityPrecision = calculatePrecision(info.StepSize)
+			}
+		case "MIN_NOTIONAL":
+			// Spot uses minNotional, futures uses notional.
+			if f.MinNotional != "" {
+				info.MinNotional = parse(f.MinNotional)
+			} else {
+				info.MinNotional = parse(f.Notional)
+			}
+		case "NOTIONAL":
+			info.MinNotional = parse(f.MinNotional)
+		}
+	}
 }
 
 // calculatePrecision calculates decimal precision from step size

--- a/app/router/internal/binance/exchange_info_test.go
+++ b/app/router/internal/binance/exchange_info_test.go
@@ -2,12 +2,16 @@ package binance
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"router/internal/rest"
 )
 
 func TestRoundPrice(t *testing.T) {
@@ -86,6 +90,7 @@ func TestRoundQuantity(t *testing.T) {
 		minQuantity string
 		maxQuantity string
 		expected    string
+		wantErr     error
 	}{
 		{
 			name:        "round to step size",
@@ -104,20 +109,20 @@ func TestRoundQuantity(t *testing.T) {
 			expected:    "1.123",
 		},
 		{
-			name:        "below min quantity",
+			name:        "below min quantity errors",
 			quantity:    "0.0001",
 			stepSize:    "0.001",
 			minQuantity: "0.001",
 			maxQuantity: "9000",
-			expected:    "0.001",
+			wantErr:     ErrQtyBelowMin,
 		},
 		{
-			name:        "above max quantity",
+			name:        "above max quantity errors",
 			quantity:    "10000",
 			stepSize:    "0.001",
 			minQuantity: "0.001",
 			maxQuantity: "9000",
-			expected:    "9000",
+			wantErr:     ErrQtyAboveMax,
 		},
 		{
 			name:        "exact step multiple",
@@ -148,6 +153,10 @@ func TestRoundQuantity(t *testing.T) {
 			quantity := decimal.RequireFromString(tt.quantity)
 			rounded, err := cache.RoundQuantity(context.Background(), "BTCUSDT", quantity, false)
 
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, rounded.String())
 		})
@@ -242,6 +251,8 @@ func TestSymbolValidation(t *testing.T) {
 				Symbol:    "BTCUSDT",
 				IsFutures: false,
 			},
+		},
+		futuresCache: map[string]*SymbolInfo{
 			"BTCUSDT-PERP": {
 				Symbol:    "BTCUSDT-PERP",
 				IsFutures: true,
@@ -266,10 +277,129 @@ func TestSymbolValidation(t *testing.T) {
 	// Test spot symbol as futures - should fail
 	_, err = cache.GetSymbolInfo(context.Background(), "BTCUSDT", true)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "is spot but requested futures")
+	assert.Contains(t, err.Error(), "not found on futures")
 
 	// Test unknown symbol - should fail
 	_, err = cache.GetSymbolInfo(context.Background(), "UNKNOWN", false)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestRoundPriceDirectional(t *testing.T) {
+	cache := &ExchangeInfoCache{
+		cache: map[string]*SymbolInfo{
+			"BTCUSDT": {
+				Symbol:    "BTCUSDT",
+				TickSize:  decimal.RequireFromString("0.10"),
+				MinPrice:  decimal.RequireFromString("0.10"),
+				MaxPrice:  decimal.RequireFromString("1000000"),
+				IsFutures: false,
+			},
+		},
+		cacheTime: time.Now(),
+		cacheTTL:  time.Hour,
+	}
+
+	tests := []struct {
+		name     string
+		price    string
+		dir      RoundDir
+		expected string
+	}{
+		{"up rounds away", "100.01", RoundUp, "100.1"},
+		{"down rounds toward zero", "100.19", RoundDown, "100.1"},
+		{"exact tick unchanged up", "100.1", RoundUp, "100.1"},
+		{"exact tick unchanged down", "100.1", RoundDown, "100.1"},
+		{"nearest rounds half up", "100.15", RoundNearest, "100.2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			price := decimal.RequireFromString(tt.price)
+			rounded, err := cache.RoundPriceDirectional(context.Background(), "BTCUSDT", price, tt.dir, false)
+			require.NoError(t, err)
+			assert.True(t, rounded.Equal(decimal.RequireFromString(tt.expected)),
+				"got %s want %s", rounded, tt.expected)
+		})
+	}
+}
+
+func TestRefreshCacheParsesRealFiltersAndFetchesFutures(t *testing.T) {
+	spotServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v3/exchangeInfo", r.URL.Path)
+		_, _ = w.Write([]byte(`{"timezone":"UTC","serverTime":1,"symbols":[
+			{"symbol":"BTCUSDT","status":"TRADING","baseAsset":"BTC","baseAssetPrecision":8,
+			 "quoteAsset":"USDT","quoteAssetPrecision":8,
+			 "filters":[
+				{"filterType":"PRICE_FILTER","minPrice":"0.01000000","maxPrice":"1000000.00000000","tickSize":"0.01000000"},
+				{"filterType":"LOT_SIZE","minQty":"0.00001000","maxQty":"9000.00000000","stepSize":"0.00001000"},
+				{"filterType":"NOTIONAL","minNotional":"5.00000000"}
+			 ]}]}`))
+	}))
+	defer spotServer.Close()
+
+	futuresServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/fapi/v1/exchangeInfo", r.URL.Path)
+		_, _ = w.Write([]byte(`{"serverTime":1,"symbols":[
+			{"symbol":"BTCUSDT","status":"TRADING","baseAsset":"BTC","quoteAsset":"USDT",
+			 "pricePrecision":2,"quantityPrecision":3,
+			 "filters":[
+				{"filterType":"PRICE_FILTER","minPrice":"556.80","maxPrice":"4529764","tickSize":"0.10"},
+				{"filterType":"LOT_SIZE","minQty":"0.001","maxQty":"1000","stepSize":"0.001"},
+				{"filterType":"MIN_NOTIONAL","notional":"100"}
+			 ]}]}`))
+	}))
+	defer futuresServer.Close()
+
+	cache := NewExchangeInfoCache(
+		rest.NewClient(spotServer.URL, nil),
+		rest.NewClient(futuresServer.URL, nil),
+		time.Hour,
+		zerolog.Nop(),
+	)
+
+	spotInfo, err := cache.GetSymbolInfo(context.Background(), "BTCUSDT", false)
+	require.NoError(t, err)
+	assert.Equal(t, "0.01", spotInfo.TickSize.String())
+	assert.Equal(t, "0.00001", spotInfo.StepSize.String())
+	assert.Equal(t, "5", spotInfo.MinNotional.String())
+	assert.False(t, spotInfo.IsFutures)
+
+	// Regression: the deployed wiring produced an always-empty futures cache,
+	// failing every futures bracket at the rounding step.
+	futuresInfo, err := cache.GetSymbolInfo(context.Background(), "BTCUSDT", true)
+	require.NoError(t, err)
+	assert.Equal(t, "0.1", futuresInfo.TickSize.String())
+	assert.Equal(t, "0.001", futuresInfo.StepSize.String())
+	assert.Equal(t, "100", futuresInfo.MinNotional.String())
+	assert.True(t, futuresInfo.IsFutures)
+}
+
+func TestRefreshCacheSurvivesFuturesOutage(t *testing.T) {
+	spotServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"timezone":"UTC","serverTime":1,"symbols":[
+			{"symbol":"BTCUSDT","status":"TRADING","baseAsset":"BTC","baseAssetPrecision":8,
+			 "quoteAsset":"USDT","quoteAssetPrecision":8,
+			 "filters":[{"filterType":"LOT_SIZE","minQty":"0.00001","maxQty":"9000","stepSize":"0.00001"}]}]}`))
+	}))
+	defer spotServer.Close()
+
+	futuresServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer futuresServer.Close()
+
+	cache := NewExchangeInfoCache(
+		rest.NewClient(spotServer.URL, nil),
+		rest.NewClient(futuresServer.URL, nil),
+		time.Hour,
+		zerolog.Nop(),
+	)
+
+	spotInfo, err := cache.GetSymbolInfo(context.Background(), "BTCUSDT", false)
+	require.NoError(t, err)
+	assert.Equal(t, "0.00001", spotInfo.StepSize.String())
+
+	_, err = cache.GetSymbolInfo(context.Background(), "BTCUSDT", true)
+	assert.Error(t, err)
 }

--- a/app/router/internal/orders/bracket.go
+++ b/app/router/internal/orders/bracket.go
@@ -53,11 +53,14 @@ func (m *Manager) placeSpotBracket(ctx context.Context, client *binance.Client, 
 
 	// 2. Place take profit orders (as limit orders)
 	// For spot, we can place these immediately
+	tpStep, err := client.StepSize(ctx, req.Symbol)
+	if err != nil {
+		return result, fmt.Errorf("failed to resolve step size: %w", err)
+	}
+	tpQuantities := splitTakeProfitQuantities(req.Quantity, len(req.TakeProfitPrices), tpStep)
 	for i, tpPrice := range req.TakeProfitPrices {
 		tpID := plannedIDs.TakeProfits[i]
-
-		// Calculate quantity for this TP (split evenly for simplicity)
-		tpQuantity := req.Quantity.Div(decimal.NewFromInt(int64(len(req.TakeProfitPrices))))
+		tpQuantity := tpQuantities[i]
 
 		tpOrder := binance.SpotOrderRequest{
 			Symbol:           req.Symbol,
@@ -178,11 +181,14 @@ func (m *Manager) placeFuturesBracket(ctx context.Context, client *binance.Clien
 	result.Main = mainResp
 
 	// 2. Place take profit orders with ReduceOnly
+	tpStep, err := client.StepSize(ctx, req.Symbol)
+	if err != nil {
+		return result, fmt.Errorf("failed to resolve step size: %w", err)
+	}
+	tpQuantities := splitTakeProfitQuantities(req.Quantity, len(req.TakeProfitPrices), tpStep)
 	for i, tpPrice := range req.TakeProfitPrices {
 		tpID := plannedIDs.TakeProfits[i]
-
-		// Calculate quantity for this TP
-		tpQuantity := req.Quantity.Div(decimal.NewFromInt(int64(len(req.TakeProfitPrices))))
+		tpQuantity := tpQuantities[i]
 
 		tpOrder := binance.FuturesOrderRequest{
 			Symbol:           req.Symbol,
@@ -466,4 +472,30 @@ func (m *Manager) CloseAllPositions(ctx context.Context, req *CloseAllRequest) e
 	}
 
 	return lastErr
+}
+
+// splitTakeProfitQuantities splits a total quantity into n step-aligned
+// slices, assigning the rounding remainder to the last slice so the sum is
+// exactly the total. A zero step returns an even unrounded split.
+func splitTakeProfitQuantities(total decimal.Decimal, n int, step decimal.Decimal) []decimal.Decimal {
+	if n <= 0 {
+		return nil
+	}
+	quantities := make([]decimal.Decimal, n)
+	even := total.Div(decimal.NewFromInt(int64(n)))
+	if !step.IsPositive() {
+		for i := range quantities {
+			quantities[i] = even
+		}
+		return quantities
+	}
+
+	slice := even.Div(step).Floor().Mul(step)
+	allocated := decimal.Zero
+	for i := 0; i < n-1; i++ {
+		quantities[i] = slice
+		allocated = allocated.Add(slice)
+	}
+	quantities[n-1] = total.Sub(allocated)
+	return quantities
 }

--- a/app/router/internal/orders/manager.go
+++ b/app/router/internal/orders/manager.go
@@ -258,17 +258,21 @@ func (m *Manager) PlaceBracketOrder(ctx context.Context, req *PlaceBracketReques
 		req.EntryPrice = roundedPrice
 	}
 
-	// Round TP prices
+	// Round TP away from entry and SL away from entry so tick rounding can
+	// never collapse the validated TP > entry > SL (or mirrored) relation.
+	tpDir, slDir := binance.RoundUp, binance.RoundDown
+	if req.Side == "SELL" {
+		tpDir, slDir = binance.RoundDown, binance.RoundUp
+	}
 	for i, tp := range req.TakeProfitPrices {
-		rounded, err := client.RoundPrice(ctx, req.Symbol, tp)
+		rounded, err := client.RoundPriceDirection(ctx, req.Symbol, tp, tpDir)
 		if err != nil {
 			return nil, fmt.Errorf("failed to round TP price %d: %w", i, err)
 		}
 		req.TakeProfitPrices[i] = rounded
 	}
 
-	// Round SL price
-	roundedSL, err := client.RoundPrice(ctx, req.Symbol, req.StopLossPrice)
+	roundedSL, err := client.RoundPriceDirection(ctx, req.Symbol, req.StopLossPrice, slDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to round SL price: %w", err)
 	}
@@ -603,9 +607,9 @@ func (m *Manager) generateClientOrderID(bracketID, orderType string) string {
 
 // algoOrderTypes are Binance order types that count towards the MAX_NUM_ALGO_ORDERS limit.
 var algoOrderTypes = map[string]bool{
-	"STOP_LOSS":        true,
-	"STOP_LOSS_LIMIT":  true,
-	"TAKE_PROFIT":      true,
+	"STOP_LOSS":         true,
+	"STOP_LOSS_LIMIT":   true,
+	"TAKE_PROFIT":       true,
 	"TAKE_PROFIT_LIMIT": true,
 }
 

--- a/app/router/internal/orders/spot_phase1_test.go
+++ b/app/router/internal/orders/spot_phase1_test.go
@@ -66,7 +66,12 @@ func writeSpotExchangeInfo(w http.ResponseWriter) {
 				"icebergAllowed":false,
 				"ocoAllowed":false,
 				"isSpotTradingAllowed":true,
-				"isMarginTradingAllowed":false
+				"isMarginTradingAllowed":false,
+				"filters":[
+					{"filterType":"PRICE_FILTER","minPrice":"0.01","maxPrice":"1000000","tickSize":"0.01"},
+					{"filterType":"LOT_SIZE","minQty":"0.00001","maxQty":"9000","stepSize":"0.00001"},
+					{"filterType":"NOTIONAL","minNotional":"5"}
+				]
 			}
 		]
 	}`))

--- a/app/router/internal/orders/tp_split_test.go
+++ b/app/router/internal/orders/tp_split_test.go
@@ -1,0 +1,51 @@
+package orders
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitTakeProfitQuantities(t *testing.T) {
+	tests := []struct {
+		name     string
+		total    string
+		n        int
+		step     string
+		expected []string
+	}{
+		{"remainder goes to last slice", "0.01", 3, "0.001", []string{"0.003", "0.003", "0.004"}},
+		{"even split stays even", "0.009", 3, "0.001", []string{"0.003", "0.003", "0.003"}},
+		{"two way split", "1", 2, "0.1", []string{"0.5", "0.5"}},
+		{"single slice gets everything", "0.0123", 1, "0.001", []string{"0.0123"}},
+		{"zero step splits evenly unrounded", "1", 3, "0", []string{
+			"0.3333333333333333",
+			"0.3333333333333333",
+			"0.3333333333333333",
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			total := decimal.RequireFromString(tt.total)
+			quantities := splitTakeProfitQuantities(total, tt.n, decimal.RequireFromString(tt.step))
+
+			require.Len(t, quantities, tt.n)
+			sum := decimal.Zero
+			for i, q := range quantities {
+				assert.True(t, q.Equal(decimal.RequireFromString(tt.expected[i])),
+					"slice %d: got %s want %s", i, q, tt.expected[i])
+				sum = sum.Add(q)
+			}
+			if decimal.RequireFromString(tt.step).IsPositive() {
+				assert.True(t, sum.Equal(total), "sum %s != total %s", sum, total)
+			}
+		})
+	}
+}
+
+func TestSplitTakeProfitQuantitiesZeroSlices(t *testing.T) {
+	assert.Nil(t, splitTakeProfitQuantities(decimal.NewFromInt(1), 0, decimal.Zero))
+}

--- a/app/router/internal/rest/client.go
+++ b/app/router/internal/rest/client.go
@@ -119,6 +119,21 @@ func (c *Client) GetExchangeInfo(ctx context.Context) (*ExchangeInfo, error) {
 	return &exchangeInfo, nil
 }
 
+// GetFuturesExchangeInfo retrieves USD-M futures exchange information
+func (c *Client) GetFuturesExchangeInfo(ctx context.Context) (*FuturesExchangeInfo, error) {
+	body, err := c.doRequest(ctx, "GET", "/fapi/v1/exchangeInfo", nil, false)
+	if err != nil {
+		return nil, ErrorWithContext(err, "GetFuturesExchangeInfo")
+	}
+
+	var exchangeInfo FuturesExchangeInfo
+	if err := json.Unmarshal(body, &exchangeInfo); err != nil {
+		return nil, ErrorWithContext(err, "GetFuturesExchangeInfo")
+	}
+
+	return &exchangeInfo, nil
+}
+
 // GetOrderBook retrieves order book depth for a symbol
 func (c *Client) GetOrderBook(ctx context.Context, symbol string, limit int) (*OrderBook, error) {
 	if symbol == "" {

--- a/app/router/internal/rest/types.go
+++ b/app/router/internal/rest/types.go
@@ -103,17 +103,50 @@ type ExchangeInfo struct {
 
 // Symbol represents trading symbol information
 type Symbol struct {
-	Symbol                 string   `json:"symbol"`
-	Status                 string   `json:"status"`
-	BaseAsset              string   `json:"baseAsset"`
-	BaseAssetPrecision     int      `json:"baseAssetPrecision"`
-	QuoteAsset             string   `json:"quoteAsset"`
-	QuoteAssetPrecision    int      `json:"quoteAssetPrecision"`
-	OrderTypes             []string `json:"orderTypes"`
-	IcebergAllowed         bool     `json:"icebergAllowed"`
-	OcoAllowed             bool     `json:"ocoAllowed"`
-	IsSpotTradingAllowed   bool     `json:"isSpotTradingAllowed"`
-	IsMarginTradingAllowed bool     `json:"isMarginTradingAllowed"`
+	Symbol                 string      `json:"symbol"`
+	Status                 string      `json:"status"`
+	BaseAsset              string      `json:"baseAsset"`
+	BaseAssetPrecision     int         `json:"baseAssetPrecision"`
+	QuoteAsset             string      `json:"quoteAsset"`
+	QuoteAssetPrecision    int         `json:"quoteAssetPrecision"`
+	OrderTypes             []string    `json:"orderTypes"`
+	IcebergAllowed         bool        `json:"icebergAllowed"`
+	OcoAllowed             bool        `json:"ocoAllowed"`
+	IsSpotTradingAllowed   bool        `json:"isSpotTradingAllowed"`
+	IsMarginTradingAllowed bool        `json:"isMarginTradingAllowed"`
+	Filters                []RawFilter `json:"filters"`
+}
+
+// RawFilter is a symbol filter as returned by exchangeInfo. Numeric fields
+// arrive as strings; spot MIN_NOTIONAL/NOTIONAL uses minNotional while
+// futures MIN_NOTIONAL uses notional.
+type RawFilter struct {
+	FilterType  string `json:"filterType"`
+	MinPrice    string `json:"minPrice,omitempty"`
+	MaxPrice    string `json:"maxPrice,omitempty"`
+	TickSize    string `json:"tickSize,omitempty"`
+	MinQty      string `json:"minQty,omitempty"`
+	MaxQty      string `json:"maxQty,omitempty"`
+	StepSize    string `json:"stepSize,omitempty"`
+	MinNotional string `json:"minNotional,omitempty"`
+	Notional    string `json:"notional,omitempty"`
+}
+
+// FuturesExchangeInfo represents USD-M futures exchange information
+type FuturesExchangeInfo struct {
+	ServerTime int64           `json:"serverTime"`
+	Symbols    []FuturesSymbol `json:"symbols"`
+}
+
+// FuturesSymbol represents a USD-M futures trading symbol
+type FuturesSymbol struct {
+	Symbol            string      `json:"symbol"`
+	Status            string      `json:"status"`
+	BaseAsset         string      `json:"baseAsset"`
+	QuoteAsset        string      `json:"quoteAsset"`
+	PricePrecision    int         `json:"pricePrecision"`
+	QuantityPrecision int         `json:"quantityPrecision"`
+	Filters           []RawFilter `json:"filters"`
 }
 
 // OrderBook represents order book depth


### PR DESCRIPTION
## Summary

Item 8, PR A of C (exchange contract correctness). Fixes a **live futures outage**: the futures exchange-info cache was never populated (`refreshCache` had a TODO and `main.go` wires the futures client into a cache that only ever read spot), so every futures bracket failed with "symbol not found" at the rounding step. Spot rounding ran on hardcoded placeholder filters for all symbols.

- Real `GET /fapi/v1/exchangeInfo` fetch + real filter parsing for both markets (`RawFilter` handles spot `minNotional` vs futures `notional`); markets keyed in separate caches (no cross-market symbol collision).
- Futures API outage degrades to spot-only refresh (previous futures entries retained) — futures unavailability can no longer break spot ordering.
- `RoundQuantity` returns typed errors (`ErrQtyBelowMin`/`ErrQtyAboveMax`) instead of silently inflating a below-minimum quantity to minQty (a risk-sizing violation).
- New `RoundPriceDirectional`: SL/TP prices round away from entry (BUY: TP ceil/SL floor; SELL mirrored) so tick rounding never collapses the validated TP/entry/SL relation. Entry stays nearest-tick.
- `splitTakeProfitQuantities`: TP slices floor to stepSize with the remainder on the last slice — legs sum exactly to entry quantity (previously `qty/3` unrounded → LOT_SIZE rejects).
- Symbols with no published filters pass through unrounded instead of truncating to integer quantities.

PR B (idempotency + retry/transport: fresh-params re-sign fix, no blind POST retry, Postgres reservation, WS dispatch ordering) and PR C (bracket lifecycle: fill-triggered legs, closePosition-only SL, replay repair, startup reconciliation) follow sequentially per the hardening plan.

## Behavior changes to expect

Orders that previously slipped through placeholder rounding may now be rejected locally with actionable errors (that is the point). First futures soak after this merge is a first-light test — futures orders could never clear rounding before.

## Test plan

All 17 router packages pass (`go test ./...`), `go vet` clean. New/updated tests: futures fetch + real filter parsing regression (the outage case), futures-outage degradation, directional rounding table (up/down/exact-tick), below-min/above-max quantity errors, TP split remainder-on-last + sum invariant, spot fixture upgraded to realistic filters. Existing permissive-fake tests updated where they pinned the old clamp behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
