### PR TITLE
fix(router): make order transport retry-safe and race-free

### DIFF
--- a/app/router/internal/api/routes.go
+++ b/app/router/internal/api/routes.go
@@ -8,4 +8,3 @@ func RegisterHealthRoutes(mux *http.ServeMux, handlers *Handlers) {
 	mux.HandleFunc("/ready", handlers.ReadyzHandler)
 	mux.HandleFunc("/readyz", handlers.ReadyzHandler)
 }
-

--- a/app/router/internal/orders/bracket.go
+++ b/app/router/internal/orders/bracket.go
@@ -226,8 +226,9 @@ func (m *Manager) placeFuturesBracket(ctx context.Context, client *binance.Clien
 		StopPrice:        req.StopLossPrice, // Stop trigger price
 		TimeInForce:      "GTC",
 		NewClientOrderID: slID,
-		ReduceOnly:       true, // SL reduces position
-		ClosePosition:    true, // Close entire position on stop
+		// closePosition and reduceOnly are mutually exclusive on USD-M
+		// (-1106 "Parameter reduceonly sent when not required").
+		ClosePosition: true, // Close entire position on stop
 	}
 
 	slResp, err := client.PlaceFuturesOrder(ctx, slOrder)

--- a/app/router/internal/orders/manager.go
+++ b/app/router/internal/orders/manager.go
@@ -214,13 +214,34 @@ func (m *Manager) PlaceBracketOrder(ctx context.Context, req *PlaceBracketReques
 	}
 
 	if req.ClientOrderIDs != nil && req.ClientOrderIDs.Main != "" {
-		m.mu.RLock()
+		// Check-and-reserve under one write lock: with a read-lock check two
+		// concurrent identical requests both miss and both POST to Binance.
+		m.mu.Lock()
 		bracketID, exists := m.ordersByClient[req.ClientOrderIDs.Main]
 		var existing *BracketOrder
 		if exists {
 			existing = m.orders[bracketID]
+		} else {
+			m.ordersByClient[req.ClientOrderIDs.Main] = ""
 		}
-		m.mu.RUnlock()
+		m.mu.Unlock()
+
+		if exists && existing == nil {
+			return nil, fmt.Errorf("bracket for client order id %s is being placed", req.ClientOrderIDs.Main)
+		}
+
+		if !exists {
+			// Release the reservation on any failure path; success overwrites
+			// the placeholder with the real bracket id.
+			mainID := req.ClientOrderIDs.Main
+			defer func() {
+				m.mu.Lock()
+				if id, ok := m.ordersByClient[mainID]; ok && id == "" {
+					delete(m.ordersByClient, mainID)
+				}
+				m.mu.Unlock()
+			}()
+		}
 
 		if exists && existing != nil {
 			return &PlaceBracketResponse{

--- a/app/router/internal/orders/place_bracket_idempotency_test.go
+++ b/app/router/internal/orders/place_bracket_idempotency_test.go
@@ -195,3 +195,166 @@ func TestManager_PlaceBracketOrder_IsIdempotentByProvidedMainClientOrderID(t *te
 	assert.Equal(t, first.BracketOrderID, second.BracketOrderID)
 	assert.Equal(t, first.ClientOrderIDs, second.ClientOrderIDs)
 }
+
+func TestManager_PlaceBracketOrder_ConcurrentSameClientIDPlacesOnce(t *testing.T) {
+	var mainPosts atomic.Int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/fapi/v1/order" {
+			q := r.URL.Query()
+			if q.Get("newClientOrderId") == "race_entry" {
+				mainPosts.Add(1)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"orderId":       1,
+				"symbol":        q.Get("symbol"),
+				"status":        "NEW",
+				"clientOrderId": q.Get("newClientOrderId"),
+				"price":         "50000",
+				"avgPrice":      "0",
+				"origQty":       "0.001",
+				"executedQty":   "0",
+				"cumQty":        "0",
+				"cumQuote":      "0",
+				"timeInForce":   "GTC",
+				"type":          q.Get("type"),
+			})
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	signer := auth.NewSignerWithRecvWindow("key", "secret", 5000)
+	logger := zerolog.Nop()
+	futuresRest := rest.NewClient(server.URL, signer)
+	futuresClient, err := binance.NewFuturesClient(server.URL, signer, futuresRest, logger)
+	assert.NoError(t, err)
+	manager := NewManager(nil, futuresClient, nil, logger)
+
+	makeReq := func() *PlaceBracketRequest {
+		return &PlaceBracketRequest{
+			Symbol:           "BTCUSDT",
+			Side:             "SELL",
+			Quantity:         decimal.RequireFromString("0.001"),
+			EntryPrice:       decimal.RequireFromString("50000"),
+			TakeProfitPrices: []decimal.Decimal{decimal.RequireFromString("49000")},
+			StopLossPrice:    decimal.RequireFromString("51000"),
+			OrderType:        "LIMIT",
+			IsFutures:        true,
+			ClientOrderIDs: &ClientOrderIDs{
+				Main:        "race_entry",
+				TakeProfits: []string{"race_tp1"},
+				StopLoss:    "race_sl",
+			},
+		}
+	}
+
+	const racers = 8
+	var wg sync.WaitGroup
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = manager.PlaceBracketOrder(context.Background(), makeReq())
+		}()
+	}
+	wg.Wait()
+
+	// The check-and-reserve write lock guarantees exactly one racer POSTs
+	// the main order; the rest observe the reservation or the stored bracket.
+	assert.Equal(t, int64(1), mainPosts.Load())
+}
+
+func TestManager_PlaceBracketOrder_ReservationReleasedOnFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"code":-1013,"msg":"Filter failure: PRICE_FILTER"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	signer := auth.NewSignerWithRecvWindow("key", "secret", 5000)
+	logger := zerolog.Nop()
+	futuresRest := rest.NewClient(server.URL, signer)
+	futuresClient, err := binance.NewFuturesClient(server.URL, signer, futuresRest, logger)
+	assert.NoError(t, err)
+	manager := NewManager(nil, futuresClient, nil, logger)
+
+	req := &PlaceBracketRequest{
+		Symbol:           "BTCUSDT",
+		Side:             "SELL",
+		Quantity:         decimal.RequireFromString("0.001"),
+		EntryPrice:       decimal.RequireFromString("50000"),
+		TakeProfitPrices: []decimal.Decimal{decimal.RequireFromString("49000")},
+		StopLossPrice:    decimal.RequireFromString("51000"),
+		OrderType:        "LIMIT",
+		IsFutures:        true,
+		ClientOrderIDs: &ClientOrderIDs{
+			Main:        "fail_entry",
+			TakeProfits: []string{"fail_tp1"},
+			StopLoss:    "fail_sl",
+		},
+	}
+
+	_, err = manager.PlaceBracketOrder(context.Background(), req)
+	assert.Error(t, err)
+
+	// A failed placement must not leave a dangling reservation that bricks
+	// every retry with "is being placed".
+	_, err = manager.PlaceBracketOrder(context.Background(), req)
+	assert.Error(t, err)
+	assert.NotContains(t, err.Error(), "is being placed")
+}
+
+func TestManager_FuturesStopLossSendsClosePositionWithoutReduceOnly(t *testing.T) {
+	var slQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/fapi/v1/order" {
+			q := r.URL.Query()
+			if q.Get("type") == "STOP_MARKET" {
+				slQuery = r.URL.RawQuery
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"orderId":       1,
+				"symbol":        q.Get("symbol"),
+				"status":        "NEW",
+				"clientOrderId": q.Get("newClientOrderId"),
+				"price":         "0",
+				"avgPrice":      "0",
+				"origQty":       "0.001",
+				"executedQty":   "0",
+				"cumQty":        "0",
+				"cumQuote":      "0",
+				"timeInForce":   "GTC",
+				"type":          q.Get("type"),
+			})
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	signer := auth.NewSignerWithRecvWindow("key", "secret", 5000)
+	logger := zerolog.Nop()
+	futuresRest := rest.NewClient(server.URL, signer)
+	futuresClient, err := binance.NewFuturesClient(server.URL, signer, futuresRest, logger)
+	assert.NoError(t, err)
+	manager := NewManager(nil, futuresClient, nil, logger)
+
+	_, err = manager.PlaceBracketOrder(context.Background(), &PlaceBracketRequest{
+		Symbol:           "BTCUSDT",
+		Side:             "SELL",
+		Quantity:         decimal.RequireFromString("0.001"),
+		EntryPrice:       decimal.RequireFromString("50000"),
+		TakeProfitPrices: []decimal.Decimal{decimal.RequireFromString("49000")},
+		StopLossPrice:    decimal.RequireFromString("51000"),
+		OrderType:        "LIMIT",
+		IsFutures:        true,
+		ClientOrderIDs: &ClientOrderIDs{
+			Main:        "cp_entry",
+			TakeProfits: []string{"cp_tp1"},
+			StopLoss:    "cp_sl",
+		},
+	})
+	assert.NoError(t, err)
+
+	// USD-M rejects closePosition together with reduceOnly (-1106).
+	assert.Contains(t, slQuery, "closePosition=true")
+	assert.NotContains(t, slQuery, "reduceOnly")
+}

--- a/app/router/internal/rest/client.go
+++ b/app/router/internal/rest/client.go
@@ -709,18 +709,21 @@ func (c *Client) doRequest(ctx context.Context, method, path string, params url.
 			params = url.Values{}
 		}
 
-		// Sign request if required
+		// Sign a fresh copy per attempt: reusing the signed set would compute
+		// attempt N's HMAC over a query still containing attempt N-1's
+		// signature, which Binance rejects with -1022 on every retry.
+		attemptParams := cloneValues(params)
 		if signed {
 			if c.signer == nil {
 				return nil, fmt.Errorf("signer required for signed request")
 			}
-			params = c.signer.SignedRequest(params)
+			attemptParams = c.signer.SignedRequest(attemptParams)
 		}
 
 		// Binance API expects all parameters in query string, even for POST
 		requestURL = c.baseURL + path
-		if len(params) > 0 {
-			requestURL += "?" + params.Encode()
+		if len(attemptParams) > 0 {
+			requestURL += "?" + attemptParams.Encode()
 		}
 
 		// Create request
@@ -738,6 +741,12 @@ func (c *Client) doRequest(ctx context.Context, method, path string, params url.
 		resp, err := c.httpClient.Do(req)
 		if err != nil {
 			lastErr = err
+			// A POST that failed mid-flight may already have executed on the
+			// exchange; blind re-POSTing can double-execute an order. Surface
+			// the ambiguity so callers resolve via order lookup instead.
+			if method == http.MethodPost {
+				return nil, fmt.Errorf("%w: %s %s: %v", ErrAmbiguousSubmit, method, path, err)
+			}
 			if attempt < c.maxRetries && isNetworkError(err) {
 				c.waitForRetry(attempt)
 				continue
@@ -775,8 +784,12 @@ func (c *Client) doRequest(ctx context.Context, method, path string, params url.
 		apiErr := ParseAPIError(resp)
 		lastErr = apiErr
 
-		// Retry if error is retryable
+		// Retry if error is retryable. Server errors on a POST are ambiguous
+		// (the order may have executed before the 5xx) and must not re-POST.
 		if attempt < c.maxRetries && IsRetryableError(apiErr) {
+			if method == http.MethodPost && resp.StatusCode >= 500 {
+				return nil, fmt.Errorf("%w: %s %s: %v", ErrAmbiguousSubmit, method, path, apiErr)
+			}
 			c.waitForRetry(attempt)
 			continue
 		}
@@ -828,4 +841,39 @@ func isNetworkError(err error) bool {
 	}
 
 	return false
+}
+
+// cloneValues copies url.Values so per-attempt mutation (signing) cannot
+// leak into subsequent retry attempts.
+func cloneValues(src url.Values) url.Values {
+	dst := make(url.Values, len(src))
+	for k, vs := range src {
+		dst[k] = append([]string(nil), vs...)
+	}
+	return dst
+}
+
+// GetOrderByClientID queries an order by its client order id, resolving
+// ambiguous submits without re-POSTing. isFutures selects the venue path.
+func (c *Client) GetOrderByClientID(ctx context.Context, symbol, origClientOrderID string, isFutures bool) (*OrderResponse, error) {
+	params := url.Values{}
+	params.Set("symbol", symbol)
+	params.Set("origClientOrderId", origClientOrderID)
+
+	path := "/api/v3/order"
+	if isFutures {
+		path = "/fapi/v1/order"
+	}
+
+	body, err := c.doRequest(ctx, "GET", path, params, true)
+	if err != nil {
+		return nil, ErrorWithContext(err, "GetOrderByClientID")
+	}
+
+	var order OrderResponse
+	if err := json.Unmarshal(body, &order); err != nil {
+		return nil, ErrorWithContext(err, "GetOrderByClientID")
+	}
+
+	return &order, nil
 }

--- a/app/router/internal/rest/errors.go
+++ b/app/router/internal/rest/errors.go
@@ -92,6 +92,24 @@ func ParseAPIError(resp *http.Response) error {
 }
 
 // IsRetryableError determines if an error should trigger a retry
+// ErrAmbiguousSubmit marks a POST whose outcome is unknown: the request may
+// have executed on the exchange before the failure. Callers must resolve by
+// querying the order (GetOrderByClientID) rather than re-submitting.
+var ErrAmbiguousSubmit = errors.New("ambiguous order submit")
+
+// IsDuplicateClientOrderID reports whether the error is Binance rejecting a
+// reused newClientOrderId, which means the original submit succeeded.
+func IsDuplicateClientOrderID(err error) bool {
+	var binanceErr *BinanceError
+	if !errors.As(err, &binanceErr) {
+		return false
+	}
+	if binanceErr.Code == -2010 && strings.Contains(binanceErr.Message, "Duplicate order sent") {
+		return true
+	}
+	return binanceErr.Code == -4116
+}
+
 func IsRetryableError(err error) bool {
 	if err == nil {
 		return false

--- a/app/router/internal/rest/futures_test.go
+++ b/app/router/internal/rest/futures_test.go
@@ -277,22 +277,14 @@ func TestGetFuturesAccount_Success(t *testing.T) {
 	assert.Len(t, resp.Positions, 1)
 }
 
-func TestPlaceFuturesOrder_RetryOn5xx(t *testing.T) {
+func TestPlaceFuturesOrder_5xxIsAmbiguousNotRetried(t *testing.T) {
+	// A 5xx on an order POST is ambiguous: the order may have executed
+	// before the failure. Blind re-POSTing can double-execute, so the
+	// client must surface ErrAmbiguousSubmit after exactly one attempt.
 	attempts := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		attempts++
-		if attempts < 3 {
-			w.WriteHeader(http.StatusServiceUnavailable)
-			return
-		}
-
-		// Success on third attempt
-		resp := &FuturesOrderResponse{
-			OrderID: 999,
-			Symbol:  "BTCUSDT",
-			Status:  "NEW",
-		}
-		_ = json.NewEncoder(w).Encode(resp)
+		w.WriteHeader(http.StatusServiceUnavailable)
 	}))
 	defer server.Close()
 
@@ -306,10 +298,9 @@ func TestPlaceFuturesOrder_RetryOn5xx(t *testing.T) {
 		Quantity: decimal.RequireFromString("0.001"),
 	}
 
-	resp, err := client.PlaceFuturesOrder(context.Background(), req)
-	require.NoError(t, err)
-	assert.Equal(t, int64(999), resp.OrderID)
-	assert.Equal(t, 3, attempts)
+	_, err := client.PlaceFuturesOrder(context.Background(), req)
+	require.ErrorIs(t, err, ErrAmbiguousSubmit)
+	assert.Equal(t, 1, attempts)
 }
 
 func TestPlaceFuturesOrder_TimeSync(t *testing.T) {

--- a/app/router/internal/rest/transport_safety_test.go
+++ b/app/router/internal/rest/transport_safety_test.go
@@ -1,0 +1,93 @@
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"router/internal/auth"
+)
+
+func TestSignedRetrySignsFreshParamsPerAttempt(t *testing.T) {
+	// Reusing the signed param set across attempts computes attempt N's HMAC
+	// over a query still containing attempt N-1's signature (-1022 on every
+	// retry). Each attempt must carry exactly one signature.
+	var queries []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queries = append(queries, r.URL.RawQuery)
+		if len(queries) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write([]byte(`{"balances":[]}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, auth.NewSigner("key", "secret"), WithMaxRetries(2))
+	_, err := client.doRequest(context.Background(), "GET", "/api/v3/account", nil, true)
+	require.NoError(t, err)
+
+	require.Len(t, queries, 2)
+	for i, query := range queries {
+		values, parseErr := url.ParseQuery(query)
+		require.NoError(t, parseErr)
+		assert.Len(t, values["signature"], 1, "attempt %d must carry exactly one signature", i+1)
+		assert.Len(t, values["timestamp"], 1, "attempt %d must carry exactly one timestamp", i+1)
+	}
+}
+
+func TestPostNetworkFailureIsAmbiguousNotRetried(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		// Kill the connection mid-response: the client sees a network error
+		// but the order may already have been accepted.
+		hj, ok := w.(http.Hijacker)
+		require.True(t, ok)
+		conn, _, _ := hj.Hijack()
+		_ = conn.Close()
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, auth.NewSigner("key", "secret"), WithMaxRetries(3))
+	_, err := client.doRequest(context.Background(), "POST", "/api/v3/order", nil, true)
+
+	require.ErrorIs(t, err, ErrAmbiguousSubmit)
+	assert.Equal(t, 1, attempts)
+}
+
+func TestGetOrderByClientIDPaths(t *testing.T) {
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		assert.Equal(t, "ord-1", r.URL.Query().Get("origClientOrderId"))
+		_ = json.NewEncoder(w).Encode(OrderResponse{Symbol: "BTCUSDT", OrderID: 42, Status: "FILLED"})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, auth.NewSigner("key", "secret"))
+
+	spot, err := client.GetOrderByClientID(context.Background(), "BTCUSDT", "ord-1", false)
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), spot.OrderID)
+
+	futures, err := client.GetOrderByClientID(context.Background(), "BTCUSDT", "ord-1", true)
+	require.NoError(t, err)
+	assert.Equal(t, "FILLED", futures.Status)
+
+	assert.Equal(t, []string{"/api/v3/order", "/fapi/v1/order"}, paths)
+}
+
+func TestIsDuplicateClientOrderID(t *testing.T) {
+	assert.True(t, IsDuplicateClientOrderID(&BinanceError{Code: -2010, Message: "Duplicate order sent."}))
+	assert.True(t, IsDuplicateClientOrderID(&BinanceError{Code: -4116, Message: "clientOrderId is duplicated"}))
+	assert.False(t, IsDuplicateClientOrderID(&BinanceError{Code: -2010, Message: "Account has insufficient balance"}))
+	assert.False(t, IsDuplicateClientOrderID(&BinanceError{Code: -1013, Message: "Filter failure"}))
+	assert.False(t, IsDuplicateClientOrderID(nil))
+}


### PR DESCRIPTION
## Summary

Item 8, PR B of C (transport/idempotency safety). Four landmines around order placement, each pinned by a regression test:

- **Retry re-sign bug**: attempt N signed a param set still containing attempt N−1's `signature` → Binance `-1022` on *every* retry of a signed request, silently nullifying the rate-limit/timestamp recovery paths. Fresh param copy per attempt; test asserts exactly one signature per attempt.
- **Blind POST retries**: network errors and 5xx on order POSTs were retried, though the order may have executed before the failure — a double-execution risk. Order POSTs now fail fast with typed `ErrAmbiguousSubmit` (one attempt, asserted); new `GetOrderByClientID` (spot + futures) resolves ambiguous outcomes; `IsDuplicateClientOrderID` classifies `-2010 "Duplicate order sent."`/`-4116` as proof of prior success.
- **Idempotency TOCTOU**: RLock-check → unlock → place let concurrent identical brackets both POST. Single write-lock check-and-reserve; 8-way race test asserts exactly one main POST; failed placements release the reservation (no "is being placed" bricking, tested).
- **Futures SL `-1106`**: `reduceOnly` + `closePosition` sent together — USD-M rejects the combination, so every futures SL leg failed. Now `closePosition` only (request-level test asserts the parameter is absent).

## Remaining scope (PR C, planned and specced)

Fill-triggered TP/SL placement (fixes ReduceOnly-TP-before-fill `-2022`), spot OCO exits, Postgres-persisted idempotency reservation (survives restarts), leg-aware replay repair, startup reconciliation, and WS single-dispatcher ordering — behind a `BRACKET_LEGS_ON_FILL` rollout flag per the hardening plan. Requires the DB migration + testnet soak; deliberately not rushed into this PR.

## Test plan

All 17 router packages pass (`go test ./...`), `go vet` clean. 7 new tests as above; 1 rewritten test (retry-on-5xx → ambiguity contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
