### PR TITLE
fix(bff,ui): restore the real-time market-data path to the chart

### DIFF
--- a/app/bff/src/app.module.ts
+++ b/app/bff/src/app.module.ts
@@ -7,7 +7,7 @@ import { ServeStaticModule } from '@nestjs/serve-static';
 import { HealthModule } from './health/health.module';
 import { EngineClientModule } from './engine-client/engine-client.module';
 import { RouterClientModule } from './router-client/router-client.module';
-// import { MarketDataModule } from './market-data/market-data.module';
+import { MarketDataModule } from './market-data/market-data.module';
 import { TradingModule } from './trading/trading.module';
 import { AuthModule } from './auth/auth.module';
 import { DatabaseModule } from './database/database.module';
@@ -55,7 +55,7 @@ import { SignalsModule } from './signals/signals.module';
     HealthModule,
     EngineClientModule,
     RouterClientModule,
-    // MarketDataModule,
+    MarketDataModule,
     TradingModule,
     AlertsModule,
     SnapshotsModule,

--- a/app/bff/src/market-data/market-data.gateway.spec.ts
+++ b/app/bff/src/market-data/market-data.gateway.spec.ts
@@ -20,7 +20,7 @@ describe('MarketDataGateway', () => {
   const mockConfigService = {
     get: jest.fn((key: string) => {
       const config: any = {
-        'websocket.namespace': '/trading',
+        'websocket.namespace': '/market-data',
         'jwt.secret': 'test-secret',
       };
       return config[key];

--- a/app/bff/src/market-data/market-data.gateway.ts
+++ b/app/bff/src/market-data/market-data.gateway.ts
@@ -29,10 +29,7 @@ interface SubscriptionData {
 }
 
 @WebSocketGateway({
-  // COLLISION: TradingGateway also declares '/trading'. This module is
-  // currently disabled in app.module.ts; move to its own namespace (or merge
-  // into TradingGateway) before re-enabling, or both connection handlers fire.
-  namespace: '/trading',
+  namespace: '/market-data',
   cors: {
     origin: true,
     credentials: true,

--- a/app/ui/src/config/constants.ts
+++ b/app/ui/src/config/constants.ts
@@ -10,6 +10,12 @@ export function getWebSocketUrl(): string {
   return `${websocketBase}/trading`
 }
 
+export function getMarketDataWebSocketUrl(): string {
+  // BFF Socket.IO server namespace for realtime candles/features/smc/zones
+  const { websocketBase } = resolveApiEndpoints()
+  return `${websocketBase}/market-data`
+}
+
 export function getAlertsWebSocketUrl(): string {
   // BFF Socket.IO server namespace for realtime alerts
   const { websocketBase } = resolveApiEndpoints()

--- a/app/ui/src/hooks/useChart.spec.ts
+++ b/app/ui/src/hooks/useChart.spec.ts
@@ -142,6 +142,42 @@ describe('useChart', () => {
     expect(mockSetData).toHaveBeenCalledWith(candles)
   })
 
+  it('updates only the newest bar on incremental ticks', () => {
+    const mockSetData = vi.fn()
+    const mockUpdate = vi.fn()
+    const mockFitContent = vi.fn()
+    mockChart.addCandlestickSeries.mockReturnValueOnce({
+      setData: mockSetData,
+      update: mockUpdate,
+    })
+    mockChart.timeScale.mockReturnValue({ fitContent: mockFitContent })
+
+    const { result } = renderHook(() => useChart(containerRef))
+
+    const initial = [
+      { time: 1000 as any, open: 100, high: 110, low: 90, close: 105 },
+      { time: 2000 as any, open: 105, high: 115, low: 100, close: 110 },
+    ]
+    act(() => {
+      result.current.updateCandles(initial)
+    })
+
+    // First load seeds via setData + fitContent.
+    expect(mockSetData).toHaveBeenCalledTimes(1)
+    expect(mockFitContent).toHaveBeenCalledTimes(1)
+
+    const appended = [...initial, { time: 3000 as any, open: 110, high: 120, low: 108, close: 118 }]
+    act(() => {
+      result.current.updateCandles(appended)
+    })
+
+    // Live tick updates only the last bar; no full redraw, no viewport reset.
+    expect(mockUpdate).toHaveBeenCalledTimes(1)
+    expect(mockUpdate).toHaveBeenCalledWith(appended[2])
+    expect(mockSetData).toHaveBeenCalledTimes(1)
+    expect(mockFitContent).toHaveBeenCalledTimes(1)
+  })
+
   it('adds indicator series', () => {
     const { result } = renderHook(() => useChart(containerRef))
 

--- a/app/ui/src/hooks/useChart.ts
+++ b/app/ui/src/hooks/useChart.ts
@@ -50,6 +50,10 @@ export function useChart(containerRef: RefObject<HTMLDivElement>): UseChartRetur
     new Map(),
   )
   const priceLinesRef = useRef<Map<string, IPriceLine>>(new Map())
+  const candleSeedRef = useRef<{ length: number; firstTime: number | null }>({
+    length: 0,
+    firstTime: null,
+  })
 
   useEffect(() => {
     if (!containerRef.current) {
@@ -130,9 +134,27 @@ export function useChart(containerRef: RefObject<HTMLDivElement>): UseChartRetur
   }, [containerRef])
 
   const updateCandles = (candles: CandlestickData[]) => {
-    if (!candlestickSeries) return
-    candlestickSeries.setData(candles)
-    chart?.timeScale().fitContent()
+    if (!candlestickSeries || candles.length === 0) return
+
+    const firstBar = candles[0]
+    if (!firstBar) return
+    const firstTime = firstBar.time as number
+    const seed = candleSeedRef.current
+    const isAppendOrUpdate =
+      seed.firstTime === firstTime && candles.length >= seed.length && seed.length > 0
+
+    // Incremental tick: update only the newest bar. A full setData plus
+    // fitContent on every tick is O(n) and resets the viewport; reserve it
+    // for the initial load and reconnect-driven resets.
+    const lastBar = candles[candles.length - 1]
+    if (isAppendOrUpdate && lastBar) {
+      candlestickSeries.update(lastBar)
+    } else {
+      candlestickSeries.setData(candles)
+      chart?.timeScale().fitContent()
+    }
+
+    candleSeedRef.current = { length: candles.length, firstTime }
   }
 
   const addIndicator = (

--- a/app/ui/src/hooks/useMarketData.spec.ts
+++ b/app/ui/src/hooks/useMarketData.spec.ts
@@ -20,13 +20,26 @@ vi.mock('./useWebSocket', () => ({
   })),
 }))
 
+vi.mock('@/services/market-data', () => ({
+  marketDataService: {
+    getHistoricalCandles: vi.fn(async () => []),
+  },
+}))
+
 describe('useMarketData', () => {
   const mockSymbol = 'BTCUSDT' as Symbol
   const mockTimeframe = '1m' as Timeframe
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks()
     mockSubscribe.mockReturnValue(vi.fn()) // Return unsubscribe function
+    const { useWebSocket } = await import('./useWebSocket')
+    vi.mocked(useWebSocket).mockReturnValue({
+      service: mockService,
+      connected: true,
+      connecting: false,
+      reconnectAttempts: 0,
+    })
   })
 
   it('subscribes to candle data on mount', () => {
@@ -205,5 +218,77 @@ describe('useMarketData', () => {
 
     expect(mockEmit).not.toHaveBeenCalled()
     expect(mockSubscribe).not.toHaveBeenCalled()
+  })
+  it('upserts a re-emitted closed candle instead of duplicating it', async () => {
+    let capturedCallback: ((data: any) => void) | null = null
+    mockSubscribe.mockImplementation((event, callback) => {
+      if (event === 'candles.v1') {
+        capturedCallback = callback
+      }
+      return vi.fn()
+    })
+
+    const { result } = renderHook(() => useMarketData(mockSymbol, mockTimeframe))
+    const closeTime = '2026-01-31T00:00:00.000Z'
+    const emit = (close: string) =>
+      capturedCallback?.({
+        symbol: mockSymbol,
+        timeframe: mockTimeframe,
+        close_time: closeTime,
+        open: '50000',
+        high: '50100',
+        low: '49900',
+        close,
+        volume: '100',
+      })
+
+    act(() => {
+      emit('50050')
+    })
+    await waitFor(() => expect(result.current.candles).toHaveLength(1))
+
+    act(() => {
+      emit('50075')
+    })
+    await waitFor(() => {
+      expect(result.current.candles).toHaveLength(1)
+      expect(result.current.candles[0].close).toBe(50075)
+    })
+  })
+
+  it('drops an out-of-order candle older than the latest', async () => {
+    let capturedCallback: ((data: any) => void) | null = null
+    mockSubscribe.mockImplementation((event, callback) => {
+      if (event === 'candles.v1') {
+        capturedCallback = callback
+      }
+      return vi.fn()
+    })
+
+    const { result } = renderHook(() => useMarketData(mockSymbol, mockTimeframe))
+    const emit = (close_time: string, close: string) =>
+      capturedCallback?.({
+        symbol: mockSymbol,
+        timeframe: mockTimeframe,
+        close_time,
+        open: '50000',
+        high: '50100',
+        low: '49900',
+        close,
+        volume: '100',
+      })
+
+    act(() => {
+      emit('2026-01-31T00:01:00.000Z', '50100')
+    })
+    await waitFor(() => expect(result.current.candles).toHaveLength(1))
+
+    act(() => {
+      emit('2026-01-31T00:00:00.000Z', '49000')
+    })
+    await waitFor(() => {
+      expect(result.current.candles).toHaveLength(1)
+      expect(result.current.candles[0].close).toBe(50100)
+    })
   })
 })

--- a/app/ui/src/hooks/useMarketData.ts
+++ b/app/ui/src/hooks/useMarketData.ts
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react'
 import type { Candle, Symbol, Timeframe, SmcEvent, Zone } from '@/types'
 import { useWebSocket } from './useWebSocket'
+import { marketDataService } from '@/services/market-data'
+import { marketDataWebsocketService } from '@/services/websocket'
 
 type IndicatorData = {
   time: number
@@ -72,8 +74,26 @@ type UseMarketDataReturn = {
   setSymbol: (symbol: Symbol) => void
 }
 
+const MAX_CANDLES = 500
+const BACKFILL_WINDOW_MS = 3 * 24 * 60 * 60 * 1000
+
+function upsertCandle(prev: Candle[], candle: Candle): Candle[] {
+  // Closed candles can be re-emitted on reconnect replay; Lightweight Charts
+  // rejects duplicate or non-ascending timestamps, so upsert by time and
+  // keep the buffer bounded.
+  const last = prev[prev.length - 1]
+  if (last && candle.time === last.time) {
+    return [...prev.slice(0, -1), candle]
+  }
+  if (last && candle.time < last.time) {
+    return prev
+  }
+  const next = [...prev, candle]
+  return next.length > MAX_CANDLES ? next.slice(next.length - MAX_CANDLES) : next
+}
+
 export function useMarketData(symbol: Symbol, timeframe: Timeframe): UseMarketDataReturn {
-  const { service, connected } = useWebSocket()
+  const { service, connected } = useWebSocket(marketDataWebsocketService)
   const [currentSymbol, setCurrentSymbol] = useState<Symbol>(symbol)
   const [currentTimeframe, setCurrentTimeframe] = useState<Timeframe>(timeframe)
   const [candles, setCandles] = useState<Candle[]>([])
@@ -120,20 +140,49 @@ export function useMarketData(symbol: Symbol, timeframe: Timeframe): UseMarketDa
 
     service.emit('subscribe', { symbol: currentSymbol, timeframe: currentTimeframe })
 
+    // Seed the chart from REST so history exists on first load and gaps
+    // heal after a reconnect; live updates then merge on top.
+    let cancelled = false
+    marketDataService
+      .getHistoricalCandles(
+        currentSymbol,
+        currentTimeframe,
+        new Date(Date.now() - BACKFILL_WINDOW_MS),
+        new Date(),
+      )
+      .then(history => {
+        if (cancelled || history.length === 0) return
+        setCandles(prev => {
+          const merged = [...history]
+          for (const candle of prev) {
+            const index = merged.findIndex(existing => existing.time === candle.time)
+            if (index >= 0) {
+              merged[index] = candle
+            } else if (candle.time > (merged[merged.length - 1]?.time ?? 0)) {
+              merged.push(candle)
+            }
+          }
+          return merged.slice(-MAX_CANDLES)
+        })
+        setLoading(false)
+      })
+      .catch(() => {
+        // Backfill is best-effort; live updates still populate the chart.
+      })
+
     // Listen for candle updates
     const unsubscribeCandles = service.subscribe<CandlesV1>('candles.v1', data => {
       if (data.symbol !== currentSymbol || data.timeframe !== currentTimeframe) return
-      setCandles(prev => [
-        ...prev,
-        {
+      setCandles(prev =>
+        upsertCandle(prev, {
           time: Date.parse(data.close_time),
           open: Number(data.open),
           high: Number(data.high),
           low: Number(data.low),
           close: Number(data.close),
           volume: Number(data.volume),
-        },
-      ])
+        }),
+      )
       setLoading(false)
     })
 
@@ -194,6 +243,7 @@ export function useMarketData(symbol: Symbol, timeframe: Timeframe): UseMarketDa
 
     // Cleanup
     return () => {
+      cancelled = true
       service.emit('unsubscribe', { symbol: currentSymbol, timeframe: currentTimeframe })
       unsubscribeCandles()
       unsubscribeFeatures()

--- a/app/ui/src/hooks/useWebSocket.ts
+++ b/app/ui/src/hooks/useWebSocket.ts
@@ -1,39 +1,39 @@
 import { useEffect, useState } from 'react'
 import { websocketService } from '@/services/websocket'
-import type { ConnectionState } from '@/services/websocket.service'
+import type { ConnectionState, WebSocketService } from '@/services/websocket.service'
 
 type UseWebSocketReturn = {
-  service: typeof websocketService
+  service: WebSocketService
   connected: boolean
   connecting: boolean
   reconnectAttempts: number
 }
 
 /**
- * Hook to access the singleton WebSocket service.
- * Uses a shared connection across all components.
+ * Hook to access a singleton WebSocket service (the trading socket by
+ * default). Uses a shared connection across all components.
  * The connection is managed by the websocket module - do not disconnect manually.
  */
-export function useWebSocket(): UseWebSocketReturn {
+export function useWebSocket(service: WebSocketService = websocketService): UseWebSocketReturn {
   const [connectionState, setConnectionState] = useState<ConnectionState>({
-    connected: websocketService.isConnected(),
+    connected: service.isConnected(),
     connecting: false,
     reconnectAttempts: 0,
   })
 
   useEffect(() => {
     // Subscribe to connection state changes
-    const unsubscribe = websocketService.onConnectionStateChange(setConnectionState)
+    const unsubscribe = service.onConnectionStateChange(setConnectionState)
 
     return () => {
       unsubscribe()
       // Note: We don't disconnect here - the singleton stays connected
       // for use by other components
     }
-  }, [])
+  }, [service])
 
   return {
-    service: websocketService,
+    service,
     connected: connectionState.connected,
     connecting: connectionState.connecting,
     reconnectAttempts: connectionState.reconnectAttempts,

--- a/app/ui/src/services/market-data.ts
+++ b/app/ui/src/services/market-data.ts
@@ -1,4 +1,17 @@
+import { apiClient } from '@/services/api'
 import type { Candle } from '@/types'
+
+type CandleRow = {
+  openTime?: string
+  closeTime?: string
+  open_time?: string
+  close_time?: string
+  open: string | number
+  high: string | number
+  low: string | number
+  close: string | number
+  volume: string | number
+}
 
 class MarketDataService {
   async getHistoricalCandles(
@@ -7,14 +20,27 @@ class MarketDataService {
     startTime: Date,
     endTime: Date,
   ): Promise<Candle[]> {
-    // In a real implementation, this would fetch from the BFF API
-    // For now, return empty array to satisfy the type checker
-    // TODO: Implement API call using these parameters
-    void symbol
-    void timeframe
-    void startTime
-    void endTime
-    return []
+    const params = new URLSearchParams({
+      symbol,
+      tf: timeframe,
+      startTime: startTime.toISOString(),
+      endTime: endTime.toISOString(),
+      limit: '1000',
+    })
+    const rows = await apiClient.get<CandleRow[]>(`/market-data/candles?${params.toString()}`)
+    return rows
+      .map(
+        (row: CandleRow): Candle => ({
+          time: Date.parse(row.closeTime ?? row.close_time ?? row.openTime ?? row.open_time ?? ''),
+          open: Number(row.open),
+          high: Number(row.high),
+          low: Number(row.low),
+          close: Number(row.close),
+          volume: Number(row.volume),
+        }),
+      )
+      .filter((candle: Candle) => Number.isFinite(candle.time))
+      .sort((a: Candle, b: Candle) => a.time - b.time)
   }
 }
 

--- a/app/ui/src/services/websocket.service.ts
+++ b/app/ui/src/services/websocket.service.ts
@@ -215,6 +215,18 @@ export class WebSocketService {
       }
     })
 
+    // A rejected handshake (e.g. expired token) fires connect_error, never
+    // connect/disconnect; without this handler the UI hangs at "connecting".
+    this.socket.on('connect_error', (error: Error) => {
+      console.error('WebSocket connect_error:', error.message)
+      this.emitConnectionState({
+        connected: false,
+        connecting: false,
+        reconnectAttempts: this.reconnectAttempts,
+      })
+      this.attemptReconnect()
+    })
+
     this.socket.on('error', (error: Error) => {
       console.error('WebSocket error:', error)
     })

--- a/app/ui/src/services/websocket.spec.ts
+++ b/app/ui/src/services/websocket.spec.ts
@@ -15,6 +15,7 @@ vi.mock('./websocket.service', () => ({
 vi.mock('@/config/constants', () => ({
   getWebSocketUrl: () => 'ws://localhost:3001/trading',
   getAlertsWebSocketUrl: () => 'ws://localhost:3001/alerts',
+  getMarketDataWebSocketUrl: () => 'ws://localhost:3001/market-data',
 }))
 
 describe('websocket lifecycle module', () => {
@@ -30,16 +31,17 @@ describe('websocket lifecycle module', () => {
     expect(connectMock).not.toHaveBeenCalled()
   })
 
-  it('initWebsockets connects both namespaces and disconnectWebsockets closes both', async () => {
+  it('initWebsockets connects all namespaces and disconnectWebsockets closes all', async () => {
     vi.resetModules()
     const websocketModule = await import('./websocket')
 
     websocketModule.initWebsockets()
-    expect(connectMock).toHaveBeenCalledTimes(2)
+    expect(connectMock).toHaveBeenCalledTimes(3)
     expect(connectMock).toHaveBeenNthCalledWith(1, 'ws://localhost:3001/trading')
     expect(connectMock).toHaveBeenNthCalledWith(2, 'ws://localhost:3001/alerts')
+    expect(connectMock).toHaveBeenNthCalledWith(3, 'ws://localhost:3001/market-data')
 
     websocketModule.disconnectWebsockets()
-    expect(disconnectMock).toHaveBeenCalledTimes(2)
+    expect(disconnectMock).toHaveBeenCalledTimes(3)
   })
 })

--- a/app/ui/src/services/websocket.ts
+++ b/app/ui/src/services/websocket.ts
@@ -1,9 +1,14 @@
 import { WebSocketService } from './websocket.service'
-import { getAlertsWebSocketUrl, getWebSocketUrl } from '@/config/constants'
+import {
+  getAlertsWebSocketUrl,
+  getMarketDataWebSocketUrl,
+  getWebSocketUrl,
+} from '@/config/constants'
 
 export type { ConnectionState } from './websocket.service'
 export const tradingWebsocketService = new WebSocketService()
 export const alertsWebsocketService = new WebSocketService()
+export const marketDataWebsocketService = new WebSocketService()
 
 // Back-compat: most of the UI expects a single trading socket
 export const websocketService = tradingWebsocketService
@@ -11,15 +16,18 @@ export const websocketService = tradingWebsocketService
 export function reconnectAllWebsocketsWithAuth(): void {
   tradingWebsocketService.reconnectWithAuth()
   alertsWebsocketService.reconnectWithAuth()
+  marketDataWebsocketService.reconnectWithAuth()
 }
 
 export function initWebsockets(): void {
   if (typeof window === 'undefined') return
   tradingWebsocketService.connect(getWebSocketUrl())
   alertsWebsocketService.connect(getAlertsWebSocketUrl())
+  marketDataWebsocketService.connect(getMarketDataWebSocketUrl())
 }
 
 export function disconnectWebsockets(): void {
   tradingWebsocketService.disconnect()
   alertsWebsocketService.disconnect()
+  marketDataWebsocketService.disconnect()
 }


### PR DESCRIPTION
## Summary

Item 9 of the system-review action plan (the final item): the real-time market-data path was dead end to end, so the chart could not receive candles at all.

**BFF**: `MarketDataModule` was commented out of the root module — nothing forwarded engine `candles.v1`/`features.v1`/`smc_events.v1`/`zones.v1` to the UI. Re-enabled, and its gateway moved from the colliding `/trading` namespace to a dedicated `/market-data` namespace. The WS handshake auth from the earlier auth pass (#178) applies here automatically.

**UI**:
- `getHistoricalCandles` was a stub returning `[]` — now fetches `/api/market-data/candles` to seed the chart on mount and heal gaps after reconnect, merging live updates on top.
- Live candles were appended unbounded with no dedup — Lightweight Charts throws on duplicate/non-ascending timestamps (exactly what a reconnect replay produces). Now upserted by open time into a bounded (500-bar) ring buffer.
- The chart re-`setData`'d the entire series plus `fitContent()` on every tick (O(n), viewport reset, missed the <150ms target). Now `series.update()` for the newest bar; `setData` + `fitContent` reserved for initial load and reconnect resets.
- Added a `connect_error` handler (QCHECK-flagged during #178): a rejected handshake fired neither `connect` nor `disconnect`, leaving the UI stuck at "connecting" — now surfaced and retried.

## Test plan

BFF: 338 tests pass (incl. the /market-data namespace gateway spec). UI: `tsc` clean, 94 test files pass (the 1 failing file is a pre-existing jsdom `localStorage` issue in `AuthContext.spec` on baseline). New tests: incremental `series.update` vs full-redraw, candle upsert-on-reemit and out-of-order drop, three-namespace connect/disconnect lifecycle. My changed files are eslint-clean (3 pre-existing prettier errors in untouched `components/ui/*` remain on baseline).

## Remaining UI polish (tracked, not in scope)

Indicator series still stack across re-renders (`useChart` keys by `Date.now()`); the no-op overlay/chart-type hook stubs; JWT in `localStorage`. These are follow-ups from the review's "medium/low" UI findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
