### PR TITLE
docs(backtest): first real-data baseline report — no-go for mainnet, simulator defects filed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -541,3 +541,4 @@ artifacts/
 # Go compiled binaries
 app/router/main
 app/router/server
+data/backtest/

--- a/reports/backtest/2026-07-baseline.md
+++ b/reports/backtest/2026-07-baseline.md
@@ -1,0 +1,83 @@
+# Backtest Baseline Report — 2026-07-05
+
+First real-data backtest of the strategy pipeline in this project's history. Prior to
+PR #181 the backtester optimized a hardcoded mock; prior to PR #185 the runner could not
+actually load downloaded data (naive/aware datetime mismatch silently yielded zero candles,
+and the shell wrapper's import path never worked). Both are fixed; these are the first
+honest numbers.
+
+## Verdict: NO-GO for mainnet — and the numbers themselves are not yet trustworthy
+
+The strategy, as configured with engine defaults, loses catastrophically on 2 years of
+real data. But the run also exposed simulator bookkeeping defects (below) that distort
+per-trade accounting, so treat these numbers as "definitely not good", not as a precise
+measurement. Fix the bookkeeping (tracked follow-up), re-run, then judge the strategy.
+
+## Provenance
+
+|             |                                                                                                                                     |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Data        | Binance mainnet spot klines via `python -m app.engine.backtest.download` (keyless REST), fetched 2026-07-05                         |
+| Range       | 2024-07-01 → 2026-06-30 (2 years; 70,080 bars @15m, 17,520 @1h per symbol)                                                          |
+| Code        | git SHA `1c2d6a2` (post PR #185)                                                                                                    |
+| Config      | `reports/backtest/baseline-config.yaml` (engine defaults, explicit), hash `ef4c3b988d99a00b`                                        |
+| Balance     | 10,000 USDT, spot, 0.5% fixed-fractional risk per trade                                                                             |
+| Raw outputs | `artifacts/backtest/*_20240701_20260630/` (report.json copies committed beside this file; trades.csv and candle CSVs not committed) |
+
+## Headline results (as run)
+
+| Run         | Trades | Hit rate | Net PnL | PnL %   | Profit factor | Sharpe (tf-aware) | Max DD | Fees paid |
+| ----------- | ------ | -------- | ------- | ------- | ------------- | ----------------- | ------ | --------- |
+| BTCUSDT 15m | 3,136  | 28.1%    | −9,997  | −99.97% | 0.357         | −19.4             | 99.97% | 7,858     |
+| BTCUSDT 1h  | 689    | 32.1%    | −8,168  | −81.68% | 0.486         | −5.3              | 81.99% | 5,780     |
+| ETHUSDT 15m | 2,915  | 31.5%    | −9,995  | −99.95% | 0.349         | −14.5             | 99.95% | 7,248     |
+| ETHUSDT 1h  | 724    | 36.6%    | −7,242  | −72.42% | 0.636         | −3.4              | 73.49% | 5,651     |
+
+Exposure reads 100% in all runs (known TODO in metrics — always-in-market assumption).
+
+## Why it loses: the structural finding
+
+**Fees are approximately equal to the entire risked amount per trade.** Example
+(first BTC 15m trade): entry 62,874.98, stop 122 points away (~0.19%). Fixed-fractional
+sizing on that tight stop produced 0.159 BTC ≈ **$10,000 notional — 100% of equity — on a
+$19 risk**. Round-trip spot taker fees at 10 bps ≈ $20 ≥ the risked $19. Every trade
+starts ~−1R down on costs; SL exits realize −2.4R instead of −1R. With a ~30% hit rate
+that structure cannot be profitable at any parameter setting — TP wins are eaten too.
+
+Implications (strategy-level, beyond this campaign's plumbing scope):
+
+- Tight SMC stops + fixed-fractional sizing needs a **fee-aware minimum stop distance**
+  (or maker entries, or a notional-relative-to-stop cap). The live path shares this
+  sizing (`decision/sizing.py`), so this finding applies to live trading too.
+- The notional exposure cap did not bind at 100% of equity — verify
+  `RiskParameters` defaults used by the backtest (`backtest/types.py`).
+
+## Simulator defects exposed by this run (tracked follow-up)
+
+1. **Trade size/PnL bookkeeping inconsistency**: trades exist with `size=1e-28` yet
+   `net_pnl=−232` and `fees=116`; others with `size=2.7e-5` yet `net_pnl=+54`. PnL is
+   computed on a different quantity than the recorded size (bracket/partial-exit trade
+   assembly in `simulator.py`).
+2. **R metrics poisoned**: `avg_r`, `avg_win_r`, `avg_loss_r` at ±1e27 — near-zero risk
+   denominators (209 trades with |R| > 1000 in BTC 15m alone). Needs a guard and a
+   correct risk basis.
+3. **`total_slippage = 0.0`** in all runs despite slippage being applied inside fill
+   prices — cost applied but never accumulated into reporting.
+
+## Model caveats (by design, disclose when quoting numbers)
+
+- 10 bps taker fee both sides; no maker fills; slippage 2 bps (1.5× on market/stop)
+- Market entries fill at next-bar open; stop-first on same-bar TP+SL double-touch
+- No funding, no partial fills, no order-book depth
+- WFO sweeps only 7 parameters; `tp_ladder` and deep SMC/retest knobs are not sweepable
+- Sharpe/Sortino annualized on the 365-day crypto calendar per bar timeframe (PR #185)
+
+## Recommended next steps (in order)
+
+1. Fix the three simulator bookkeeping defects; re-run this exact baseline (config hash
+   must match) and update this report.
+2. Investigate the notional cap defaults in the backtest risk parameters.
+3. Strategy work: fee-aware stop-distance floor or maker-entry variant; re-baseline.
+4. Only after a profitable, trustworthy baseline: revisit the mainnet-unlock question.
+   Order-safety hardening (router C1–C7) proceeds regardless — it gates testnet soak,
+   not strategy viability.

--- a/reports/backtest/BTCUSDT_15m_20240701_20260630.report.json
+++ b/reports/backtest/BTCUSDT_15m_20240701_20260630.report.json
@@ -1,0 +1,50 @@
+{
+  "metadata": {
+    "git_sha": "1c2d6a2dd8099cd1f025c055cae9e4243f89bcb6",
+    "config_hash": "ef4c3b988d99a00b",
+    "runtime_ms": 216753,
+    "generated_at": "2026-07-04T21:37:33.078279+00:00"
+  },
+  "config": {
+    "fee_bps_spot": 10.0,
+    "slippage_bps": 2.0,
+    "funding_model": "disabled",
+    "tp_ladder": [
+      {
+        "r": 1.5,
+        "size": 0.4
+      },
+      {
+        "r": 2.0,
+        "size": 0.3
+      },
+      {
+        "r": 3.0,
+        "size": 0.3
+      }
+    ]
+  },
+  "metrics": {
+    "total_pnl": -9997.243149925365,
+    "total_pnl_pct": -99.97243149925366,
+    "profit_factor": 0.3565109652225593,
+    "sharpe_ratio": -19.421020647431103,
+    "sortino_ratio": -15.762463115337953,
+    "calmar_ratio": -0.9999973630451761,
+    "max_drawdown_pct": 99.97269512273432,
+    "max_drawdown_duration_hours": 17506,
+    "total_trades": 3136,
+    "winning_trades": 882,
+    "losing_trades": 2254,
+    "hit_rate_pct": 28.125,
+    "avg_win_r": 2.0349657518561986e+27,
+    "avg_loss_r": -1.8117771201740895e+27,
+    "avg_r": -7.298806874155709e+26,
+    "largest_win_r": 5.692742014934925e+29,
+    "largest_loss_r": -2.0120631255435605e+30,
+    "exposure_pct": 100.0,
+    "total_fees": 7857.847943843689,
+    "total_slippage": 0.0,
+    "total_funding": 0.0
+  }
+}

--- a/reports/backtest/BTCUSDT_1h_20240701_20260630.report.json
+++ b/reports/backtest/BTCUSDT_1h_20240701_20260630.report.json
@@ -1,0 +1,50 @@
+{
+  "metadata": {
+    "git_sha": "1c2d6a2dd8099cd1f025c055cae9e4243f89bcb6",
+    "config_hash": "ef4c3b988d99a00b",
+    "runtime_ms": 54121,
+    "generated_at": "2026-07-04T21:38:34.976794+00:00"
+  },
+  "config": {
+    "fee_bps_spot": 10.0,
+    "slippage_bps": 2.0,
+    "funding_model": "disabled",
+    "tp_ladder": [
+      {
+        "r": 1.5,
+        "size": 0.4
+      },
+      {
+        "r": 2.0,
+        "size": 0.3
+      },
+      {
+        "r": 3.0,
+        "size": 0.3
+      }
+    ]
+  },
+  "metrics": {
+    "total_pnl": -8168.079261188339,
+    "total_pnl_pct": -81.68079261188339,
+    "profit_factor": 0.48643064994009677,
+    "sharpe_ratio": -5.302411158638438,
+    "sortino_ratio": -4.041712848944828,
+    "calmar_ratio": -0.996186710798,
+    "max_drawdown_pct": 81.99345737753579,
+    "max_drawdown_duration_hours": 17394,
+    "total_trades": 689,
+    "winning_trades": 221,
+    "losing_trades": 468,
+    "hit_rate_pct": 32.075471698113205,
+    "avg_win_r": 7.090024534273394e+27,
+    "avg_loss_r": -6.431821071117463e+26,
+    "avg_r": 1.8372804005023553e+27,
+    "largest_win_r": 1.2906362761219452e+30,
+    "largest_loss_r": -6.51871414629375e+28,
+    "exposure_pct": 100.0,
+    "total_fees": 5780.357963673891,
+    "total_slippage": 0.0,
+    "total_funding": 0.0
+  }
+}

--- a/reports/backtest/ETHUSDT_15m_20240701_20260630.report.json
+++ b/reports/backtest/ETHUSDT_15m_20240701_20260630.report.json
@@ -1,0 +1,50 @@
+{
+  "metadata": {
+    "git_sha": "1c2d6a2dd8099cd1f025c055cae9e4243f89bcb6",
+    "config_hash": "ef4c3b988d99a00b",
+    "runtime_ms": 218785,
+    "generated_at": "2026-07-04T21:42:35.461849+00:00"
+  },
+  "config": {
+    "fee_bps_spot": 10.0,
+    "slippage_bps": 2.0,
+    "funding_model": "disabled",
+    "tp_ladder": [
+      {
+        "r": 1.5,
+        "size": 0.4
+      },
+      {
+        "r": 2.0,
+        "size": 0.3
+      },
+      {
+        "r": 3.0,
+        "size": 0.3
+      }
+    ]
+  },
+  "metrics": {
+    "total_pnl": -9994.691341558693,
+    "total_pnl_pct": -99.94691341558693,
+    "profit_factor": 0.3494528749794813,
+    "sharpe_ratio": -14.48079159745498,
+    "sortino_ratio": -11.306193572529537,
+    "calmar_ratio": -0.9999970718614791,
+    "max_drawdown_pct": 99.9472060748511,
+    "max_drawdown_duration_hours": 17490,
+    "total_trades": 2915,
+    "winning_trades": 918,
+    "losing_trades": 1997,
+    "hit_rate_pct": 31.49228130360206,
+    "avg_win_r": 3.9481558071610226e+27,
+    "avg_loss_r": -1.3491217847591642e+27,
+    "avg_r": 3.1911177592101805e+26,
+    "largest_win_r": 7.774734266863947e+29,
+    "largest_loss_r": -3.416279237416498e+29,
+    "exposure_pct": 100.0,
+    "total_fees": 7248.3148660459765,
+    "total_slippage": 0.0,
+    "total_funding": 0.0
+  }
+}

--- a/reports/backtest/ETHUSDT_1h_20240701_20260630.report.json
+++ b/reports/backtest/ETHUSDT_1h_20240701_20260630.report.json
@@ -1,0 +1,50 @@
+{
+  "metadata": {
+    "git_sha": "1c2d6a2dd8099cd1f025c055cae9e4243f89bcb6",
+    "config_hash": "ef4c3b988d99a00b",
+    "runtime_ms": 53783,
+    "generated_at": "2026-07-04T21:43:36.384483+00:00"
+  },
+  "config": {
+    "fee_bps_spot": 10.0,
+    "slippage_bps": 2.0,
+    "funding_model": "disabled",
+    "tp_ladder": [
+      {
+        "r": 1.5,
+        "size": 0.4
+      },
+      {
+        "r": 2.0,
+        "size": 0.3
+      },
+      {
+        "r": 3.0,
+        "size": 0.3
+      }
+    ]
+  },
+  "metrics": {
+    "total_pnl": -7241.881841414149,
+    "total_pnl_pct": -72.41881841414148,
+    "profit_factor": 0.6361001794140887,
+    "sharpe_ratio": -3.381744605522387,
+    "sortino_ratio": -2.550814948845137,
+    "calmar_ratio": -0.9854624639943387,
+    "max_drawdown_pct": 73.48714036312349,
+    "max_drawdown_duration_hours": 16967,
+    "total_trades": 724,
+    "winning_trades": 265,
+    "losing_trades": 459,
+    "hit_rate_pct": 36.60220994475138,
+    "avg_win_r": 1.1670003744046064e+27,
+    "avg_loss_r": -5.075087303422216e+26,
+    "avg_r": 1.0539860772118919e+26,
+    "largest_win_r": 9.70767359290814e+28,
+    "largest_loss_r": -6.093924416823034e+28,
+    "exposure_pct": 100.0,
+    "total_fees": 5650.8208183573915,
+    "total_slippage": 0.0,
+    "total_funding": 0.0
+  }
+}

--- a/reports/backtest/baseline-config.yaml
+++ b/reports/backtest/baseline-config.yaml
@@ -1,0 +1,19 @@
+backtest:
+  fee_bps_spot: 10
+  slippage_bps: 2
+  funding_model: disabled
+  pivot_n: 3
+  retest_max_wait_bars: 8
+  cooldown_seconds: 300
+  risk_per_trade: 0.005
+  warmup_bars: 50
+  rr:
+    tp_ladder:
+      - r: 1.5
+        size: 0.4
+      - r: 2.0
+        size: 0.3
+      - r: 3.0
+        size: 0.3
+    move_to_breakeven_on: TP1
+    trail_after: TP2


### PR DESCRIPTION
## Summary

W0-2 of the five-gap campaign: the first real backtest ever run on this strategy, on 2 years (2024-07-01 → 2026-06-30) of Binance mainnet BTCUSDT/ETHUSDT 15m+1h data, using the tooling from #185.

**Verdict: NO-GO for mainnet.** All four runs lose catastrophically (−72% to −99.97%, PF 0.35–0.64, hit rate 28–37%). The dominant cause is structural: with ~0.2%-wide SMC stops, fixed-fractional sizing puts ~100% of equity in notional per trade, so 10bps×2 taker fees ≈ the entire risked amount — every trade starts ~−1R down on costs. This applies to the live path too (shared sizing).

The run also exposed three simulator bookkeeping defects (trade size/PnL inconsistency, R-metrics poisoned by near-zero risk denominators, slippage applied to prices but never accumulated) — tracked as a follow-up; numbers are directionally damning but not yet precise.

Deliverables: `reports/backtest/2026-07-baseline.md` (full analysis, provenance, caveats, next steps), per-run `report.json` copies, the explicit `baseline-config.yaml` (hash ef4c3b988d99a00b), and `data/backtest/` gitignored.

## Test plan

Docs + config only; no runtime code. Full engine suite green on the base commit (1429 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)