### PR TITLE
fix(engine): track prior-bar MACD histogram in the live retest path

### DIFF
--- a/app/engine/pytest.ini
+++ b/app/engine/pytest.ini
@@ -8,4 +8,4 @@ markers =
     chaos: chaos engineering scenarios
     performance: performance/benchmark tests
     redis: tests requiring a real Redis connection
-norecursedirs = adapters ingest database plugins retest services smc tests/performance tests/integration tests/chaos tests/e2e
+norecursedirs = adapters ingest database plugins services smc tests/performance tests/integration tests/chaos tests/e2e

--- a/app/engine/retest/engine.py
+++ b/app/engine/retest/engine.py
@@ -245,6 +245,7 @@ class RetestEngine:
         self._zones: dict[str, list[Any]] = {}
         self._bos_events: dict[str, deque[Any]] = {}
         self._features: dict[str, TechnicalIndicators] = {}
+        self._prev_macd_hist: dict[str, Decimal | None] = {}
 
         # Configuration
         self.max_wait_bars = config.get("retest", {}).get("max_wait_bars", 8)
@@ -336,6 +337,8 @@ class RetestEngine:
         try:
             features = event.features
             key = f"{features.symbol}:{features.timeframe.value}"
+            previous = self._features.get(key)
+            self._prev_macd_hist[key] = previous.macd_histogram if previous is not None else None
             self._features[key] = features
 
         except Exception:
@@ -417,6 +420,16 @@ class RetestEngine:
         if not features or not candles:
             return
 
+        # Incomplete indicators: skip the bar, mirroring the simulator's warm-up
+        macd_hist_prev = self._prev_macd_hist.get(key)
+        if (
+            macd_hist_prev is None
+            or features.macd_histogram is None
+            or features.atr_14 is None
+            or features.rsi_14 is None
+        ):
+            return
+
         # Analyze retest
         signal_data = await analyze_retest(
             venue=candle.venue,
@@ -426,10 +439,10 @@ class RetestEngine:
             zones=zones,
             bos_events=bos_events,
             features={
-                "atr": features.atr_14 or Decimal(0),
-                "macd_hist": features.macd_histogram or Decimal(0),
-                "macd_hist_prev": Decimal(0),  # Would need to track previous
-                "rsi": features.rsi_14 or Decimal(50),
+                "atr": features.atr_14,
+                "macd_hist": features.macd_histogram,
+                "macd_hist_prev": macd_hist_prev,
+                "rsi": features.rsi_14,
             },
         )
 

--- a/app/engine/tests/unit/retest/test_macd_prev_tracking.py
+++ b/app/engine/tests/unit/retest/test_macd_prev_tracking.py
@@ -1,0 +1,179 @@
+"""
+Unit tests for previous-bar MACD histogram tracking in the live retest path.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from app.engine.models import Candle, FeaturesCalculatedEvent, TechnicalIndicators, TimeFrame
+from app.engine.retest import engine as retest_engine_module
+from app.engine.retest.engine import RetestEngine
+
+# Accessing engine internals is intentional in these unit tests.
+# ruff: noqa: SLF001
+
+BAR_TIME = datetime(2024, 1, 2, tzinfo=UTC)
+
+
+def _features_event(
+    symbol: str,
+    macd_histogram: Decimal | None,
+    timeframe: TimeFrame = TimeFrame.M15,
+) -> FeaturesCalculatedEvent:
+    return FeaturesCalculatedEvent(
+        timestamp=BAR_TIME,
+        symbol=symbol,
+        timeframe=timeframe,
+        features=TechnicalIndicators(
+            symbol=symbol,
+            timeframe=timeframe,
+            timestamp=BAR_TIME,
+            macd_histogram=macd_histogram,
+            atr_14=Decimal(100),
+            rsi_14=Decimal(50),
+        ),
+    )
+
+
+def _candle(symbol: str, timeframe: TimeFrame = TimeFrame.M15) -> Candle:
+    return Candle(
+        venue="SPOT",
+        symbol=symbol,
+        timeframe=timeframe,
+        open_time=BAR_TIME,
+        close_time=BAR_TIME,
+        open_price=Decimal(100),
+        high_price=Decimal(101),
+        low_price=Decimal(99),
+        close_price=Decimal("100.5"),
+        volume=Decimal(10),
+        quote_volume=Decimal(1000),
+        trades=10,
+        taker_buy_base_volume=Decimal(5),
+        taker_buy_quote_volume=Decimal(500),
+    )
+
+
+@pytest.fixture
+def engine_and_capture(monkeypatch: pytest.MonkeyPatch):
+    from app.engine.backtest.capture_bus import CapturingEventBus
+    from app.engine.bus import get_event_bus, set_event_bus
+
+    try:
+        previous_bus = get_event_bus()
+    except RuntimeError:
+        previous_bus = None
+    set_event_bus(CapturingEventBus())
+    captured: list[dict] = []
+
+    async def capturing_analyze_retest(**kwargs):
+        captured.append(kwargs["features"])
+        return None
+
+    monkeypatch.setattr(retest_engine_module, "analyze_retest", capturing_analyze_retest)
+    engine = RetestEngine(config={})
+    yield engine, captured
+    if previous_bus is not None:
+        set_event_bus(previous_bus)
+
+
+def _seed_candles(engine: RetestEngine, symbol: str) -> Candle:
+    candle = _candle(symbol)
+    key = f"{symbol}:{candle.timeframe.value}"
+    engine._recent_candles[key] = deque([candle])
+    return candle
+
+
+@pytest.mark.asyncio
+async def test_passes_previous_bar_macd_histogram_to_confluence(
+    engine_and_capture: tuple[RetestEngine, list[dict]],
+) -> None:
+    engine, captured = engine_and_capture
+    candle = _seed_candles(engine, "BTCUSDT")
+
+    await engine._process_features_event(_features_event("BTCUSDT", Decimal(1)))
+    await engine._process_features_event(_features_event("BTCUSDT", Decimal("2.5")))
+    await engine._check_for_retests(candle)
+
+    assert captured == [
+        {
+            "atr": Decimal(100),
+            "macd_hist": Decimal("2.5"),
+            "macd_hist_prev": Decimal(1),
+            "rsi": Decimal(50),
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_first_features_event_skips_signal_check_like_simulator(
+    engine_and_capture: tuple[RetestEngine, list[dict]],
+) -> None:
+    engine, captured = engine_and_capture
+    candle = _seed_candles(engine, "BTCUSDT")
+
+    await engine._process_features_event(_features_event("BTCUSDT", Decimal(1)))
+    await engine._check_for_retests(candle)
+
+    assert captured == []
+
+
+@pytest.mark.asyncio
+async def test_previous_histogram_tracked_per_symbol_and_timeframe(
+    engine_and_capture: tuple[RetestEngine, list[dict]],
+) -> None:
+    engine, captured = engine_and_capture
+    btc_candle = _seed_candles(engine, "BTCUSDT")
+    eth_candle = _seed_candles(engine, "ETHUSDT")
+
+    await engine._process_features_event(_features_event("BTCUSDT", Decimal(1)))
+    await engine._process_features_event(_features_event("ETHUSDT", Decimal(7)))
+    await engine._process_features_event(_features_event("BTCUSDT", Decimal(2)))
+    await engine._process_features_event(_features_event("ETHUSDT", Decimal(8)))
+    await engine._check_for_retests(btc_candle)
+    await engine._check_for_retests(eth_candle)
+
+    assert [(f["macd_hist"], f["macd_hist_prev"]) for f in captured] == [
+        (Decimal(2), Decimal(1)),
+        (Decimal(8), Decimal(7)),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_missing_previous_histogram_value_skips_until_available(
+    engine_and_capture: tuple[RetestEngine, list[dict]],
+) -> None:
+    engine, captured = engine_and_capture
+    candle = _seed_candles(engine, "BTCUSDT")
+
+    await engine._process_features_event(_features_event("BTCUSDT", None))
+    await engine._process_features_event(_features_event("BTCUSDT", Decimal(3)))
+    await engine._check_for_retests(candle)
+
+    assert captured == []
+
+    await engine._process_features_event(_features_event("BTCUSDT", Decimal(4)))
+    await engine._check_for_retests(candle)
+
+    assert [(f["macd_hist"], f["macd_hist_prev"]) for f in captured] == [
+        (Decimal(4), Decimal(3)),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_current_histogram_none_skips_instead_of_fabricating_zero(
+    engine_and_capture: tuple[RetestEngine, list[dict]],
+) -> None:
+    engine, captured = engine_and_capture
+    candle = _seed_candles(engine, "BTCUSDT")
+
+    await engine._process_features_event(_features_event("BTCUSDT", Decimal(3)))
+    await engine._process_features_event(_features_event("BTCUSDT", None))
+    await engine._check_for_retests(candle)
+
+    assert captured == []


### PR DESCRIPTION
## Summary

W0-4 of the five-gap campaign (gap 5a). The live retest path passed a hardcoded `macd_hist_prev=Decimal(0)` into confluence, so 'MACD improving/declining' actually meant 'sign of current histogram' — while the backtest simulator used the real prior-bar value. Live and backtest disagreed on every momentum gate.

- `RetestEngine` now tracks the previous histogram per `symbol:timeframe`, stashed when each features event arrives (atomic on the event loop — verified against the bus's dispatch model in review).
- `_check_for_retests` skips the bar when prev/current histogram, ATR, or RSI is missing — exactly the simulator's warm-up semantics (`simulator.py:193-208`), instead of fabricating zeros. QCHECK found the asymmetric twin bug (current=None after a valid bar → fabricated 0 could spuriously pass the SHORT gate) — also fixed and tested.
- Un-hides `tests/unit/retest` from the default suite (`norecursedirs`), same debt class as backtest (#181) and paper (#186). `smc` stays hidden (known-broken pre-existing test — tracked separately).

Note: live signal frequency WILL change — that is the point. Worth watching testnet signal counts for a day after deploy.

## Test plan

- 7 retest tests (5 new: prev-bar value passed, first-bar skip, per-key isolation, None→valid recovery, valid→None skip), ×3 stable
- Full engine suite: 1436 passed, 3 skipped
- ruff check/format clean; QCHECK verdict PASS-WITH-NITS, nits taken (None-parity fix + fixture bus teardown + companion test)

CI billing-locked — local gates; admin squash-merge to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)