### PR TITLE
feat(config): router live-trading gate + engine/router execution-env cross-check

### DIFF
--- a/app/engine/execution/router_execution_subscriber.py
+++ b/app/engine/execution/router_execution_subscriber.py
@@ -201,6 +201,8 @@ class RouterExecutionSubscriber:
         | None = None,
         router_max_attempts: int = 3,
         router_backoff_config: BackoffConfig | None = None,
+        router_env_probe_attempts: int = 1,
+        router_env_probe_delay_seconds: float = 3.0,
     ) -> None:
         self._bus = bus
         self._router_client = router_client
@@ -218,6 +220,10 @@ class RouterExecutionSubscriber:
             raise ValueError("router_max_attempts must be >= 1")
         self._router_max_attempts = router_max_attempts
         self._router_backoff_config = router_backoff_config
+        if router_env_probe_attempts < 1:
+            raise ValueError("router_env_probe_attempts must be >= 1")
+        self._router_env_probe_attempts = router_env_probe_attempts
+        self._router_env_probe_delay_seconds = router_env_probe_delay_seconds
         self._subscription_id: str | None = None
         self._symbol_locks: dict[str, asyncio.Lock] = {}
 
@@ -369,12 +375,69 @@ class RouterExecutionSubscriber:
         if self._execution_mode == ExecutionMode.DISABLED:
             return
 
+        await self._verify_router_execution_env()
+
         self._subscription_id = await self._bus.subscribe(
             subscriber_id="router-execution",
             handler=self._on_trading_decision,
             event_types=[EventType.TRADING_DECISION],
             priority=5,
         )
+
+    async def _verify_router_execution_env(self) -> None:
+        """Cross-check EXECUTION_MODE against the router's execution env.
+
+        Hard-fails only on a confirmed mismatch; an unreachable router or an
+        older router without the health field logs a warning and proceeds.
+        Probes retry so a router still booting (compose starts it after the
+        engine) can be observed before giving up.
+        """
+        health_check = getattr(self._router_client, "health_check", None)
+        if health_check is None:
+            return
+
+        router_env: str | None = None
+        last_health: dict[str, Any] | None = None
+        for attempt in range(self._router_env_probe_attempts):
+            try:
+                health = await health_check()
+            except Exception as exc:
+                health = {"status": "unreachable", "error": str(exc)}
+            if isinstance(health, dict):
+                last_health = health
+                value = health.get("execution_env")
+                if isinstance(value, str):
+                    router_env = value.strip().lower()
+                    break
+            if attempt < self._router_env_probe_attempts - 1:
+                await asyncio.sleep(self._router_env_probe_delay_seconds)
+
+        if router_env not in {"testnet", "mainnet"}:
+            detail = ""
+            if isinstance(last_health, dict):
+                detail = (
+                    f" (last status={last_health.get('status')!r},"
+                    f" error={last_health.get('error')!r})"
+                )
+            logger.warning(
+                "Router execution env unverified after %d probe(s)%s; EXECUTION_MODE=%s",
+                self._router_env_probe_attempts,
+                detail,
+                self._execution_mode.value,
+            )
+            return
+
+        mode_is_mainnet = self._execution_mode in {
+            ExecutionMode.SPOT_MAINNET,
+            ExecutionMode.FUTURES_MAINNET,
+        }
+        router_is_mainnet = router_env == "mainnet"
+        if mode_is_mainnet != router_is_mainnet:
+            raise RuntimeError(
+                f"EXECUTION_MODE={self._execution_mode.value} but the router at "
+                f"ROUTER_URL reports execution_env={router_env}; refusing to start "
+                "execution against the wrong venue",
+            )
 
     async def stop(self) -> None:
         if self._subscription_id is None:

--- a/app/engine/main.py
+++ b/app/engine/main.py
@@ -204,6 +204,10 @@ def _binance_data_testnet_from_env() -> bool:
     if data_source == "mainnet":
         return False
     if data_source == "testnet":
+        logger.warning(
+            "BINANCE_DATA_SOURCE=testnet: testnet market data is thin and unrealistic "
+            "for signal generation; prefer mainnet data with ROUTER_EXECUTION_ENV=testnet",
+        )
         return True
     raise ValueError("BINANCE_DATA_SOURCE must be 'mainnet' or 'testnet'")
 
@@ -508,6 +512,7 @@ async def initialize_services(config: EngineConfig) -> None:  # noqa: PLR0915, C
                 min_confidence=min_confidence,
                 max_position_size=config.risk_parameters.max_position_size,
                 execution_readiness_check=execution_readiness_check,
+                router_env_probe_attempts=5,
             )
             logger.info(
                 "Execution subscriber enabled: %s (min_confidence=%s, cooldown=%ss)",

--- a/app/engine/tests/unit/test_binance_data_source_warning.py
+++ b/app/engine/tests/unit/test_binance_data_source_warning.py
@@ -1,0 +1,35 @@
+"""
+Unit tests for the BINANCE_DATA_SOURCE thin-data warning.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from app.engine.main import _binance_data_testnet_from_env
+
+
+def test_testnet_data_source_logs_thin_data_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("BINANCE_DATA_SOURCE", "testnet")
+
+    with caplog.at_level(logging.WARNING):
+        result = _binance_data_testnet_from_env()
+
+    assert (result, "thin" in caplog.text) == (True, True)
+
+
+def test_mainnet_data_source_logs_no_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("BINANCE_DATA_SOURCE", "mainnet")
+
+    with caplog.at_level(logging.WARNING):
+        result = _binance_data_testnet_from_env()
+
+    assert (result, caplog.text) == (False, "")

--- a/app/engine/tests/unit/test_router_env_verification.py
+++ b/app/engine/tests/unit/test_router_env_verification.py
@@ -1,0 +1,207 @@
+"""
+Unit tests for engine↔router execution-environment cross-validation at startup.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+import logging
+from typing import Any
+
+import pytest
+
+from app.engine.execution.router_execution_subscriber import (
+    ExecutionMode,
+    OrderUpdateCorrelationStore,
+    RouterExecutionSubscriber,
+)
+from app.engine.models import RiskParameters
+
+
+class _FakeBus:
+    def __init__(self) -> None:
+        self.subscriptions: list[dict[str, Any]] = []
+
+    async def subscribe(self, **kwargs: Any) -> str:
+        self.subscriptions.append(kwargs)
+        return "sub-1"
+
+    async def unsubscribe(self, subscription_id: str) -> None:
+        return None
+
+
+class _FakeRouterClient:
+    def __init__(self, health: dict[str, Any] | Exception | None):
+        self._health = health
+
+    async def place_bracket_order(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return {}
+
+    async def health_check(self) -> dict[str, Any]:
+        if isinstance(self._health, Exception):
+            raise self._health
+        return self._health or {}
+
+
+class _ClientWithoutHealth:
+    async def place_bracket_order(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return {}
+
+
+def _risk() -> RiskParameters:
+    return RiskParameters(
+        max_position_size=Decimal("999999"),
+        max_daily_loss=Decimal("1"),
+        max_drawdown=Decimal("1"),
+        risk_per_trade=Decimal("0.01"),
+        max_correlation=Decimal("1"),
+        max_open_positions=100,
+        max_total_exposure_leverage=Decimal("100"),
+        max_symbol_exposure_pct=Decimal("1"),
+        max_position_notional_pct=Decimal("1"),
+        risk_data_max_age_seconds=86400,
+        drawdown_lookback_days=30,
+    )
+
+
+def _subscriber(client: Any, mode: ExecutionMode) -> tuple[RouterExecutionSubscriber, _FakeBus]:
+    bus = _FakeBus()
+    subscriber = RouterExecutionSubscriber(
+        bus=bus,  # type: ignore[arg-type]
+        router_client=client,
+        db_adapter=object(),  # type: ignore[arg-type]
+        risk=_risk(),
+        venue="SPOT",
+        execution_mode=mode,
+        order_update_correlation_store=OrderUpdateCorrelationStore(ttl_seconds=3600),
+    )
+    return subscriber, bus
+
+
+@pytest.mark.asyncio
+async def test_start_aborts_when_testnet_mode_hits_mainnet_router() -> None:
+    client = _FakeRouterClient({"status": "healthy", "execution_env": "mainnet"})
+    subscriber, bus = _subscriber(client, ExecutionMode.SPOT_TESTNET)
+
+    with pytest.raises(RuntimeError, match="mainnet"):
+        await subscriber.start()
+
+    assert bus.subscriptions == []
+
+
+@pytest.mark.asyncio
+async def test_start_aborts_when_mainnet_mode_hits_testnet_router() -> None:
+    client = _FakeRouterClient({"status": "healthy", "execution_env": "testnet"})
+    subscriber, bus = _subscriber(client, ExecutionMode.SPOT_MAINNET)
+
+    with pytest.raises(RuntimeError, match="testnet"):
+        await subscriber.start()
+
+    assert bus.subscriptions == []
+
+
+@pytest.mark.asyncio
+async def test_start_subscribes_when_environments_match() -> None:
+    client = _FakeRouterClient({"status": "healthy", "execution_env": "testnet"})
+    subscriber, bus = _subscriber(client, ExecutionMode.FUTURES_TESTNET)
+
+    await subscriber.start()
+
+    assert len(bus.subscriptions) == 1
+
+
+@pytest.mark.asyncio
+async def test_start_warns_and_proceeds_when_router_lacks_env_field(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    client = _FakeRouterClient({"status": "healthy"})
+    subscriber, bus = _subscriber(client, ExecutionMode.SPOT_TESTNET)
+
+    with caplog.at_level(logging.WARNING):
+        await subscriber.start()
+
+    assert (len(bus.subscriptions), "execution env" in caplog.text.lower()) == (1, True)
+
+
+@pytest.mark.asyncio
+async def test_start_warns_and_proceeds_when_router_unreachable(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    client = _FakeRouterClient(ConnectionError("refused"))
+    subscriber, bus = _subscriber(client, ExecutionMode.SPOT_TESTNET)
+
+    with caplog.at_level(logging.WARNING):
+        await subscriber.start()
+
+    assert (len(bus.subscriptions), "unverified" in caplog.text) == (1, True)
+
+
+@pytest.mark.asyncio
+async def test_start_proceeds_when_client_has_no_health_check() -> None:
+    subscriber, bus = _subscriber(_ClientWithoutHealth(), ExecutionMode.SPOT_TESTNET)
+
+    await subscriber.start()
+
+    assert len(bus.subscriptions) == 1
+
+
+@pytest.mark.asyncio
+async def test_start_subscribes_when_mainnet_environments_match() -> None:
+    client = _FakeRouterClient({"status": "healthy", "execution_env": "mainnet"})
+    subscriber, bus = _subscriber(client, ExecutionMode.SPOT_MAINNET)
+
+    await subscriber.start()
+
+    assert len(bus.subscriptions) == 1
+
+
+@pytest.mark.asyncio
+async def test_uppercase_router_env_still_hard_fails_on_mismatch() -> None:
+    client = _FakeRouterClient({"status": "healthy", "execution_env": " MAINNET "})
+    subscriber, bus = _subscriber(client, ExecutionMode.SPOT_TESTNET)
+
+    with pytest.raises(RuntimeError, match="mainnet"):
+        await subscriber.start()
+
+    assert bus.subscriptions == []
+
+
+class _EventuallyHealthyClient:
+    """Router that is still booting for the first probes (compose ordering)."""
+
+    def __init__(self, failures_before_healthy: int, execution_env: str):
+        self._remaining_failures = failures_before_healthy
+        self._execution_env = execution_env
+        self.probes = 0
+
+    async def place_bracket_order(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return {}
+
+    async def health_check(self) -> dict[str, Any]:
+        self.probes += 1
+        if self._remaining_failures > 0:
+            self._remaining_failures -= 1
+            return {"status": "unhealthy", "error": "connection refused"}
+        return {"status": "healthy", "execution_env": self._execution_env}
+
+
+@pytest.mark.asyncio
+async def test_probe_retries_until_router_boots_then_verifies() -> None:
+    client = _EventuallyHealthyClient(failures_before_healthy=2, execution_env="mainnet")
+    bus = _FakeBus()
+    subscriber = RouterExecutionSubscriber(
+        bus=bus,  # type: ignore[arg-type]
+        router_client=client,
+        db_adapter=object(),  # type: ignore[arg-type]
+        risk=_risk(),
+        venue="SPOT",
+        execution_mode=ExecutionMode.SPOT_TESTNET,
+        order_update_correlation_store=OrderUpdateCorrelationStore(ttl_seconds=3600),
+        router_env_probe_attempts=5,
+        router_env_probe_delay_seconds=0,
+    )
+
+    with pytest.raises(RuntimeError, match="mainnet"):
+        await subscriber.start()
+
+    assert (client.probes, bus.subscriptions) == (3, [])

--- a/app/router/cmd/router/main.go
+++ b/app/router/cmd/router/main.go
@@ -202,6 +202,11 @@ func main() {
 
 	// Create HTTP handlers
 	handlers := api.NewHandlers(orderManager, logger, intentPersister, spotTradeProcessor)
+	if cfg.Binance.Testnet {
+		handlers.SetExecutionEnv("testnet")
+	} else {
+		handlers.SetExecutionEnv("mainnet")
+	}
 
 	// Create and configure HTTP server
 	mux := http.NewServeMux()

--- a/app/router/internal/api/handlers.go
+++ b/app/router/internal/api/handlers.go
@@ -27,6 +27,12 @@ type Handlers struct {
 	intentPersister    IntentPersister
 	executionPersister SpotExecutionPersister
 	logger             zerolog.Logger
+	executionEnv       string
+}
+
+// SetExecutionEnv records the execution environment exposed on health responses.
+func (h *Handlers) SetExecutionEnv(env string) {
+	h.executionEnv = env
 }
 
 type SpotExecutionPersister interface {
@@ -367,10 +373,14 @@ func (h *Handlers) HealthzHandler(w http.ResponseWriter, r *http.Request) {
 		Str("remote_addr", r.RemoteAddr).
 		Msg("Health check requested")
 
-	writeJSON(w, http.StatusOK, map[string]string{
+	body := map[string]string{
 		"status":  "healthy",
 		"service": "order-router",
-	})
+	}
+	if h.executionEnv != "" {
+		body["execution_env"] = h.executionEnv
+	}
+	writeJSON(w, http.StatusOK, body)
 }
 
 // ReadyzHandler handles GET /readyz

--- a/app/router/internal/api/handlers_test.go
+++ b/app/router/internal/api/handlers_test.go
@@ -927,3 +927,21 @@ func TestParseDecimalArray(t *testing.T) {
 		})
 	}
 }
+
+func TestHealthzHandler_IncludesExecutionEnv(t *testing.T) {
+	logger := zerolog.Nop()
+	handlers := NewHandlers(new(MockOrderManager), logger, nil, nil)
+	handlers.SetExecutionEnv("testnet")
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rr := httptest.NewRecorder()
+	handlers.HealthzHandler(rr, req)
+
+	var body map[string]string
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	assert.Equal(t, map[string]string{
+		"status":        "healthy",
+		"service":       "order-router",
+		"execution_env": "testnet",
+	}, body)
+}

--- a/app/router/internal/config/config.go
+++ b/app/router/internal/config/config.go
@@ -111,6 +111,9 @@ func Load() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := validateLiveTradingAck(testnet, getEnv("I_UNDERSTAND_LIVE_TRADING", "")); err != nil {
+		return nil, err
+	}
 
 	config := &Config{
 		Server: ServerConfig{
@@ -197,6 +200,16 @@ func parseExecutionEnv(raw string) (bool, error) {
 	default:
 		return false, fmt.Errorf("ROUTER_EXECUTION_ENV must be 'mainnet' or 'testnet'")
 	}
+}
+
+func validateLiveTradingAck(testnet bool, ack string) error {
+	if testnet {
+		return nil
+	}
+	if strings.TrimSpace(ack) == "1" {
+		return nil
+	}
+	return fmt.Errorf("ROUTER_EXECUTION_ENV=mainnet requires I_UNDERSTAND_LIVE_TRADING=1")
 }
 
 // Validate validates the configuration

--- a/app/router/internal/config/config_test.go
+++ b/app/router/internal/config/config_test.go
@@ -108,6 +108,7 @@ func TestBinanceConfig_ExecutionEnv(t *testing.T) {
 
 	t.Run("mainnet execution env disables testnet URLs", func(t *testing.T) {
 		t.Setenv("ROUTER_EXECUTION_ENV", "mainnet")
+		t.Setenv("I_UNDERSTAND_LIVE_TRADING", "1")
 		t.Setenv("BINANCE_SPOT_API_KEY", "test-spot-key")
 		t.Setenv("BINANCE_SPOT_SECRET_KEY", "test-spot-secret")
 		t.Setenv("TRADING_MODE", "spot")
@@ -126,5 +127,47 @@ func TestBinanceConfig_ExecutionEnv(t *testing.T) {
 		_, err := Load()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "ROUTER_EXECUTION_ENV")
+	})
+}
+
+func TestLoad_LiveTradingAck(t *testing.T) {
+	setSpotCredentials := func(t *testing.T) {
+		t.Helper()
+		t.Setenv("BINANCE_SPOT_API_KEY", "test-spot-key")
+		t.Setenv("BINANCE_SPOT_SECRET_KEY", "test-spot-secret")
+		t.Setenv("TRADING_MODE", "spot")
+	}
+
+	t.Run("mainnet without ack fails load", func(t *testing.T) {
+		setSpotCredentials(t)
+		t.Setenv("ROUTER_EXECUTION_ENV", "mainnet")
+		t.Setenv("I_UNDERSTAND_LIVE_TRADING", "")
+
+		_, err := Load()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "I_UNDERSTAND_LIVE_TRADING")
+	})
+
+	t.Run("mainnet with ack loads", func(t *testing.T) {
+		setSpotCredentials(t)
+		t.Setenv("ROUTER_EXECUTION_ENV", "mainnet")
+		t.Setenv("I_UNDERSTAND_LIVE_TRADING", "1")
+
+		config, err := Load()
+
+		require.NoError(t, err)
+		assert.False(t, config.Binance.Testnet)
+	})
+
+	t.Run("testnet loads without ack", func(t *testing.T) {
+		setSpotCredentials(t)
+		t.Setenv("ROUTER_EXECUTION_ENV", "testnet")
+		t.Setenv("I_UNDERSTAND_LIVE_TRADING", "")
+
+		config, err := Load()
+
+		require.NoError(t, err)
+		assert.True(t, config.Binance.Testnet)
 	})
 }


### PR DESCRIPTION
## Summary

W0-6 of the five-gap campaign (gap 4). The three venue knobs (`BINANCE_DATA_SOURCE`, `EXECUTION_MODE`, `ROUTER_EXECUTION_ENV`) were already independent — what was missing was validation between them and a router-side safety gate:

- **Router live gate**: `ROUTER_EXECUTION_ENV=mainnet` without `I_UNDERSTAND_LIVE_TRADING=1` now fails `config.Load()`. Until now one env var alone flipped the router to real-money URLs; the engine had this ack, the router didn't.
- **Health exposes the venue**: `/health` + `/healthz` now include `execution_env`, wired from the loaded config (single choke point verified — no other path reads `ROUTER_EXECUTION_ENV`).
- **Engine cross-check at startup**: `RouterExecutionSubscriber.start()` probes the router and hard-fails on a confirmed testnet↔mainnet mismatch with `EXECUTION_MODE`; unreachable/older routers warn and proceed. QCHECK caught that compose starts the router *after* the engine, so a single probe would deterministically miss it — probes now retry (5×3s in the wiring; injectable, existing tests unaffected). Router env string is normalized (`" MAINNET "` still hard-fails a testnet engine).
- **Thin-data warning** when `BINANCE_DATA_SOURCE=testnet` — testnet market data is unrealistic for signals; the honest rehearsal is mainnet data + testnet orders.

Not in this diff (file-protection hook): `.env.example` comment noting the new router ack, and `app/router/.env.example` still documents a legacy `TESTNET` var the code no longer reads — two one-liners if you approve editing those files.

## Test plan

- Go: 3 new gate tests + health execution_env test; one pre-existing mainnet test updated to set the ack; `go build`, `go vet`, full `go test ./...` green
- Python: 9 verification tests (mismatch both directions, match both venues, uppercase normalization, retry-until-boot with probe counting, lacks-field/unreachable/no-method fallthroughs) + 2 thin-data warning tests; full engine suite 1447 passed ×1, affected files ×3
- QCHECK verdict PASS-WITH-NITS; HIGH (compose-ordering inertness) + MEDIUMs (case normalization, warn diagnostics) all taken

CI billing-locked — local gates; admin squash-merge to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)