### PR TITLE
fix(backtest): honest trade bookkeeping + live-parity risk caps

### DIFF
--- a/app/engine/backtest/simulator.py
+++ b/app/engine/backtest/simulator.py
@@ -111,16 +111,19 @@ class BacktestSimulator:
             cooldown_seconds=config.cooldown_seconds,
             clock=self._clock,
         )
+        # Notional/symbol-exposure/open-position caps mirror the live engine
+        # defaults (main.py risk_parameters); daily-loss/drawdown gates and
+        # max_position_size deliberately stay disabled here.
         self._risk = RiskParameters(
             max_position_size=Decimal(1_000_000_000),
             max_daily_loss=Decimal(1),
             max_drawdown=Decimal(1),
             risk_per_trade=config.risk_per_trade,
             max_correlation=Decimal(1),
-            max_open_positions=10,
+            max_open_positions=5,
             max_total_exposure_leverage=Decimal(3),
-            max_symbol_exposure_pct=Decimal(1),
-            max_position_notional_pct=Decimal(1),
+            max_symbol_exposure_pct=Decimal("0.25"),
+            max_position_notional_pct=Decimal("0.10"),
             risk_data_max_age_seconds=86400,
             drawdown_lookback_days=30,
         )
@@ -374,7 +377,8 @@ class BacktestSimulator:
         fee = self.cost_calculator.calculate_fill_fee(fill)
         fill.fee = fee
         self.total_fees += fee
-        self.total_slippage += fill.slippage
+        # fill.slippage is a per-unit price delta; cost is per-unit × quantity
+        self.total_slippage += fill.slippage * fill.quantity
         self.current_balance -= fee
 
         order.filled_quantity += fill.quantity
@@ -422,6 +426,7 @@ class BacktestSimulator:
                 symbol=fill.symbol,
                 side=side,
                 quantity=fill.quantity,
+                entry_quantity=fill.quantity,
                 entry_price=fill.price,
                 opened_at=fill.fill_time,
             )
@@ -431,6 +436,7 @@ class BacktestSimulator:
             new_quantity = position.quantity + fill.quantity
             position.entry_price = (old_value + fill.quantity * fill.price) / new_quantity
             position.quantity = new_quantity
+            position.entry_quantity += fill.quantity
         else:
             logger.warning(
                 f"Opposite-side entry fill ignored for {fill.symbol}; netting unsupported",
@@ -439,6 +445,8 @@ class BacktestSimulator:
 
         position.mark_price = candle.close_price
         position.total_fees += fill.fee
+        position.total_slippage += fill.slippage * fill.quantity
+        position.risked_amount += fill.quantity * abs(fill.price - bracket.stop_loss)
         position.stop_loss = bracket.stop_loss
         position.take_profit = bracket.take_profit
 
@@ -473,6 +481,7 @@ class BacktestSimulator:
             return
 
         position.total_fees += fill.fee
+        position.total_slippage += fill.slippage * fill.quantity
         close_quantity = min(fill.quantity, position.quantity)
 
         if close_quantity >= position.quantity:
@@ -520,8 +529,9 @@ class BacktestSimulator:
             exit_time=self.current_time,
             entry_price=position.entry_price,
             exit_price=exit_price,
-            size=position.quantity,
+            size=position.entry_quantity,
             fees=position.total_fees,
+            slippage=position.total_slippage,
             funding=position.total_funding,
             stop_loss=position.stop_loss,
             exit_reason=exit_reason,
@@ -530,12 +540,10 @@ class BacktestSimulator:
         trade.gross_pnl = position.realized_pnl
         trade.net_pnl = trade.gross_pnl - trade.fees - trade.funding
 
-        stop_distance = abs(
-            trade.entry_price - (position.stop_loss or trade.entry_price),
-        )
-        if stop_distance > 0:
-            trade.gross_pnl_r = trade.gross_pnl / (stop_distance * trade.size)
-            trade.net_pnl_r = trade.net_pnl / (stop_distance * trade.size)
+        # Initial risk summed per entry fill against its own bracket's stop
+        if position.risked_amount > 0:
+            trade.gross_pnl_r = trade.gross_pnl / position.risked_amount
+            trade.net_pnl_r = trade.net_pnl / position.risked_amount
 
         self.completed_trades.append(trade)
 

--- a/app/engine/backtest/types.py
+++ b/app/engine/backtest/types.py
@@ -105,12 +105,15 @@ class BacktestPosition:
     symbol: str = ""
     side: str | None = None  # "LONG" or "SHORT"
     quantity: Decimal = Decimal(0)
+    entry_quantity: Decimal = Decimal(0)
     entry_price: Decimal = Decimal(0)
     mark_price: Decimal = Decimal(0)
     unrealized_pnl: Decimal = Decimal(0)
     realized_pnl: Decimal = Decimal(0)
     total_fees: Decimal = Decimal(0)
     total_funding: Decimal = Decimal(0)
+    total_slippage: Decimal = Decimal(0)
+    risked_amount: Decimal = Decimal(0)
     stop_loss: Decimal | None = None
     take_profit: Decimal | None = None
     breakeven_moved: bool = False
@@ -121,7 +124,12 @@ class BacktestPosition:
 
 @dataclass
 class BacktestTrade:
-    """Completed trade for reporting."""
+    """Completed trade for reporting.
+
+    For merged/partially-exited positions this is an aggregate row: size is the
+    total entered quantity, entry_price the final average, exit_price the last
+    fill — so (exit-entry)*size need not equal gross_pnl.
+    """
 
     id: UUID = field(default_factory=uuid4)
     symbol: str = ""

--- a/app/engine/tests/unit/backtest/test_simulator_lifecycle.py
+++ b/app/engine/tests/unit/backtest/test_simulator_lifecycle.py
@@ -49,7 +49,7 @@ async def test_entry_fills_next_bar_open_plus_slippage_and_places_oco(
     position = simulator.positions["BTCUSDT"]
     assert (position.side, position.quantity, position.entry_price) == (
         "LONG",
-        Decimal(25),
+        Decimal(10),
         Decimal("100.03"),
     )
     assert (position.stop_loss, position.take_profit) == (Decimal(98), Decimal(103))
@@ -71,9 +71,9 @@ async def test_tp_limit_exit_records_tp_cancels_stop_and_deducts_fees(
 
     assert len(simulator.completed_trades) == 1
     trade = simulator.completed_trades[0]
-    entry_fee = Decimal("100.03") * Decimal(25) * Decimal("0.001")
-    exit_fee = Decimal(103) * Decimal(25) * Decimal("0.001")
-    gross_pnl = (Decimal(103) - Decimal("100.03")) * Decimal(25)
+    entry_fee = Decimal("100.03") * Decimal(10) * Decimal("0.001")
+    exit_fee = Decimal(103) * Decimal(10) * Decimal("0.001")
+    gross_pnl = (Decimal(103) - Decimal("100.03")) * Decimal(10)
     stop_distance = Decimal("100.03") - Decimal(98)
     assert (
         trade.exit_reason,
@@ -89,12 +89,12 @@ async def test_tp_limit_exit_records_tp_cancels_stop_and_deducts_fees(
         ExitReason.TP,
         Decimal(103),
         Decimal("100.03"),
-        Decimal(25),
+        Decimal(10),
         gross_pnl,
         entry_fee + exit_fee,
         gross_pnl - entry_fee - exit_fee,
-        gross_pnl / (stop_distance * Decimal(25)),
-        (gross_pnl - entry_fee - exit_fee) / (stop_distance * Decimal(25)),
+        gross_pnl / (stop_distance * Decimal(10)),
+        (gross_pnl - entry_fee - exit_fee) / (stop_distance * Decimal(10)),
     )
     assert stop_order.status == OrderStatus.CANCELLED
     assert simulator.active_orders == []

--- a/app/engine/tests/unit/backtest/test_simulator_signal_gates.py
+++ b/app/engine/tests/unit/backtest/test_simulator_signal_gates.py
@@ -45,7 +45,7 @@ def _install_fake_analyze(
 
 
 @pytest.mark.asyncio
-async def test_signal_places_market_order_sized_fixed_fractional(
+async def test_signal_quantity_clamped_by_live_notional_cap(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     candles = flat_candles(51)
@@ -58,13 +58,40 @@ async def test_signal_places_market_order_sized_fixed_fractional(
     market_orders = [order for order in simulator.active_orders if order.type == OrderType.MARKET]
     assert len(market_orders) == 1
     order = market_orders[0]
-    assert (order.symbol, order.side, order.quantity) == ("BTCUSDT", OrderSide.BUY, Decimal(25))
+    # risk-based qty would be 25 (0.5% of 10k over a 2-point stop), but the
+    # 10% notional cap (live parity) clamps to 1000/100 = 10
+    assert (order.symbol, order.side, order.quantity) == ("BTCUSDT", OrderSide.BUY, Decimal(10))
     bracket = simulator._pending_brackets[order.id]
     assert (bracket.stop_loss, bracket.take_profit, bracket.direction) == (
         Decimal(98),
         Decimal(103),
         "LONG",
     )
+
+
+@pytest.mark.asyncio
+async def test_signal_sized_fixed_fractional_when_below_notional_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    candles = flat_candles(51)
+    fire_at = candles[-1].open_time
+
+    async def fake_analyze(**kwargs: Any) -> dict[str, Any] | None:
+        if kwargs["candles"][-1]["open_time"] == fire_at:
+            signal = make_signal(fire_at)
+            signal["stop_loss"] = Decimal(90)
+            return signal
+        return None
+
+    monkeypatch.setattr(simulator_module, "analyze_retest", fake_analyze)
+    simulator = BacktestSimulator(BacktestConfig())
+
+    for candle in candles:
+        await simulator.process_candle(candle)
+
+    market_orders = [order for order in simulator.active_orders if order.type == OrderType.MARKET]
+    # 0.5% of 10k over a 10-point stop → 5 units, notional 5% stays below the cap
+    assert [order.quantity for order in market_orders] == [Decimal(5)]
 
 
 @pytest.mark.asyncio
@@ -83,7 +110,7 @@ async def test_cooldown_blocks_identical_second_signal(
         OrderType.LIMIT,
     ]
     assert simulator._pending_brackets == {}
-    assert simulator.positions["BTCUSDT"].quantity == Decimal(25)
+    assert simulator.positions["BTCUSDT"].quantity == Decimal(10)
 
 
 @pytest.mark.asyncio

--- a/app/engine/tests/unit/backtest/test_trade_bookkeeping.py
+++ b/app/engine/tests/unit/backtest/test_trade_bookkeeping.py
@@ -1,0 +1,129 @@
+"""
+Unit tests for honest trade bookkeeping in the simulator.
+
+Regression coverage for the 2026-07 baseline findings: recorded trade size was
+the residual position quantity (Decimal dust after partial exits) while PnL and
+fees covered the whole aggregate, poisoning R metrics; fill slippage was never
+attributed to trades; and the backtest risk caps did not mirror the live ones.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from app.engine.backtest.simulator import BacktestSimulator, _BracketSpec
+from app.engine.backtest.types import BacktestConfig, BacktestFill, ExitReason, OrderSide
+from app.engine.models import Candle, TimeFrame
+
+# Driving simulator internals directly is intentional in these unit tests.
+# ruff: noqa: SLF001
+
+FILL_TIME = datetime(2024, 1, 2, tzinfo=UTC)
+INITIAL_BALANCE = Decimal(10000)
+
+
+def _candle(close: str) -> Candle:
+    return Candle(
+        venue="SPOT",
+        symbol="BTCUSDT",
+        timeframe=TimeFrame.M15,
+        open_time=FILL_TIME,
+        close_time=FILL_TIME,
+        open_price=Decimal(close),
+        high_price=Decimal(close),
+        low_price=Decimal(close),
+        close_price=Decimal(close),
+        volume=Decimal(10),
+        quote_volume=Decimal(1000),
+        trades=10,
+        taker_buy_base_volume=Decimal(5),
+        taker_buy_quote_volume=Decimal(500),
+    )
+
+
+def _fill(
+    quantity: str, price: str, side: OrderSide = OrderSide.BUY, slippage: str = "0"
+) -> BacktestFill:
+    return BacktestFill(
+        symbol="BTCUSDT",
+        side=side,
+        quantity=Decimal(quantity),
+        price=Decimal(price),
+        slippage=Decimal(slippage),
+        fill_time=FILL_TIME,
+    )
+
+
+def _simulator() -> BacktestSimulator:
+    return BacktestSimulator(BacktestConfig(), INITIAL_BALANCE)
+
+
+def test_recorded_size_is_total_entry_quantity_after_partial_exits() -> None:
+    simulator = _simulator()
+    bracket = _BracketSpec(stop_loss=Decimal(95), take_profit=Decimal(110), direction="LONG")
+    simulator._open_position(_fill("1", "100"), _candle("100"), bracket)
+    simulator._open_position(_fill("1", "100"), _candle("100"), bracket)
+
+    simulator._close_position(_fill("1", "110", OrderSide.SELL), ExitReason.TP)
+    simulator._close_position(_fill("1", "95", OrderSide.SELL), ExitReason.SL)
+
+    assert len(simulator.completed_trades) == 1
+    trade = simulator.completed_trades[0]
+    # partial TP: +10 on 1 unit; final SL: -5 on remaining 1 unit
+    assert (trade.size, trade.gross_pnl) == (Decimal(2), Decimal(5))
+
+
+def test_r_multiple_uses_entry_quantity_not_residual_dust() -> None:
+    simulator = _simulator()
+    bracket = _BracketSpec(stop_loss=Decimal(95), take_profit=Decimal(110), direction="LONG")
+    simulator._open_position(_fill("1", "100"), _candle("100"), bracket)
+    simulator._open_position(_fill("1E-28", "100"), _candle("100"), bracket)
+
+    simulator._close_position(_fill("1", "110", OrderSide.SELL), ExitReason.TP)
+    simulator._close_position(_fill("1E-28", "95", OrderSide.SELL), ExitReason.SL)
+
+    trade = simulator.completed_trades[0]
+    # risk basis = per-bracket risk (5*1 + 5*1e-28 ≈ 5), not the 1e-28 residual
+    assert trade.gross_pnl_r == Decimal(2)
+
+
+def test_r_multiple_sums_risk_per_bracket_stop() -> None:
+    simulator = _simulator()
+    simulator._open_position(
+        _fill("1", "100"),
+        _candle("100"),
+        _BracketSpec(stop_loss=Decimal(95), take_profit=Decimal(110), direction="LONG"),
+    )
+    simulator._open_position(
+        _fill("1", "100"),
+        _candle("100"),
+        _BracketSpec(stop_loss=Decimal(90), take_profit=Decimal(110), direction="LONG"),
+    )
+
+    simulator._close_position(_fill("2", "110", OrderSide.SELL), ExitReason.TP)
+
+    trade = simulator.completed_trades[0]
+    # gross 20 over summed risk 1*5 + 1*10 = 15
+    assert trade.gross_pnl_r == Decimal(20) / Decimal(15)
+
+
+def test_trade_slippage_is_dollar_cost_per_unit_times_quantity() -> None:
+    simulator = _simulator()
+    bracket = _BracketSpec(stop_loss=Decimal(95), take_profit=Decimal(110), direction="LONG")
+    simulator._open_position(_fill("2", "100", slippage="1.5"), _candle("100"), bracket)
+
+    simulator._close_position(_fill("2", "110", OrderSide.SELL, slippage="2.5"), ExitReason.TP)
+
+    # (1.5 + 2.5 per unit) × 2 units
+    assert simulator.completed_trades[0].slippage == Decimal("8.0")
+
+
+def test_simulator_risk_caps_mirror_live_defaults() -> None:
+    simulator = _simulator()
+
+    assert (
+        simulator._risk.max_position_notional_pct,
+        simulator._risk.max_symbol_exposure_pct,
+        simulator._risk.max_open_positions,
+    ) == (Decimal("0.10"), Decimal("0.25"), 5)


### PR DESCRIPTION
## Summary

Closes the three simulator defects filed by the first real baseline (#187), plus the risk-cap parity gap found while investigating:

- **size/PnL mismatch**: merged same-symbol positions recorded the residual quantity (Decimal dust) as trade size against whole-aggregate PnL/fees → `entry_quantity` tracking; aggregate rows documented on `BacktestTrade`.
- **R poison (±1e27)**: risk basis now summed per entry fill against its own bracket's stop (`risked_amount`), guarded — QCHECK's suggestion, strictly better than last-bracket stop × size for merged positions.
- **slippage reporting**: QCHECK caught that `fill.slippage` is a per-unit price delta — naive accumulation would have reported price-units in a dollar column (up to 100× off at BTC scale). Accumulated as per-unit × quantity everywhere (trade, position, simulator aggregate), pinned by a 2-unit test that distinguishes the units.
- **caps**: notional 10%/symbol 25%/5 open positions mirror live `main.py` defaults (was 100%/100%/10). Daily-loss/drawdown gates + `max_position_size` deliberately not mirrored (documented); live's `max_position_size=0.1` absolute-quantity default looks like a latent live bug — follow-up.

**Results-changing modeling change**: config hash will NOT change (caps live in code) — the baseline re-run and report update will cite the code SHA explicitly.

Follow-ups filed from review: stale sibling bracket exits can survive an aggregate close (pre-existing OCO-per-bracket linkage; pollutes attribution on rare merged closes); shared default constants so the parity test can't drift.

## Test plan

- 57 backtest tests ×3 stable (4 new bookkeeping tests incl. dust-R regression `== 2` exact, summed-risk 20/15, dollar-slippage 8.0; cap-clamp pinned; below-cap fixed-fractional pinned)
- Full engine suite 1453 passed
- ruff check/format clean; QCHECK BLOCK (slippage units) resolved + MEDIUMs taken

🤖 Generated with [Claude Code](https://claude.com/claude-code)