### PR TITLE
fix(router): resolve ambiguous and duplicate order submits via client-id query (C1)

### DIFF
--- a/app/router/internal/binance/client.go
+++ b/app/router/internal/binance/client.go
@@ -653,6 +653,43 @@ func (c *Client) GetSymbolInfo(ctx context.Context, symbol string) (*SymbolInfo,
 	return c.exchangeInfoCache.GetSymbolInfo(ctx, symbol, c.isFutures)
 }
 
+// GetOrderByClientID queries an order by its client order id, used to resolve
+// ambiguous or duplicate submits without re-POSTing.
+func (c *Client) GetOrderByClientID(
+	ctx context.Context,
+	symbol, clientOrderID string,
+) (*OrderResponse, error) {
+	if c.restClient == nil {
+		return nil, fmt.Errorf("rest client not available")
+	}
+	restResp, err := c.restClient.GetOrderByClientID(ctx, symbol, clientOrderID, c.isFutures)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query order by client id: %w", err)
+	}
+
+	// The order-query response carries no fills and, for market orders, a
+	// zero price; derive the average fill price so adopters don't record 0.
+	price := restResp.Price
+	if price.IsZero() && restResp.ExecutedQty.IsPositive() && restResp.CummulativeQuoteQty.IsPositive() {
+		price = restResp.CummulativeQuoteQty.Div(restResp.ExecutedQty)
+	}
+
+	return &OrderResponse{
+		Symbol:        restResp.Symbol,
+		OrderID:       restResp.OrderID,
+		ClientOrderID: restResp.ClientOrderID,
+		TransactTime:  restResp.TransactTime,
+		Price:         price,
+		OrigQty:       restResp.OrigQty,
+		ExecutedQty:   restResp.ExecutedQty,
+		Status:        restResp.Status,
+		TimeInForce:   restResp.TimeInForce,
+		Type:          restResp.Type,
+		Side:          restResp.Side,
+		Fills:         convertFills(restResp.Fills),
+	}, nil
+}
+
 // GetTickerLastPrice returns the last traded price for a spot symbol (e.g. BTCUSDT).
 func (c *Client) GetTickerLastPrice(ctx context.Context, symbol string) (decimal.Decimal, error) {
 	if c.restClient == nil {

--- a/app/router/internal/orders/bracket.go
+++ b/app/router/internal/orders/bracket.go
@@ -42,7 +42,11 @@ func (m *Manager) placeSpotBracket(ctx context.Context, client *binance.Client, 
 		NewClientOrderID: mainOrderID,
 	}
 
-	mainResp, err := client.PlaceSpotOrder(ctx, mainOrder)
+	mainResp, err := submitResolvingAmbiguity(
+		ctx, m.logger, client, req.Symbol, mainOrderID, mainOrder.Type != "MARKET",
+		func(ctx context.Context) (*binance.OrderResponse, error) {
+			return client.PlaceSpotOrder(ctx, mainOrder)
+		})
 	if err != nil {
 		bracketErr.Add("MAIN", err)
 		// Return immediately if main order fails as it's critical
@@ -72,7 +76,11 @@ func (m *Manager) placeSpotBracket(ctx context.Context, client *binance.Client, 
 			NewClientOrderID: tpID,
 		}
 
-		tpResp, err := client.PlaceSpotOrder(ctx, tpOrder)
+		tpResp, err := submitResolvingAmbiguity(
+			ctx, m.logger, client, req.Symbol, tpID, true,
+			func(ctx context.Context) (*binance.OrderResponse, error) {
+				return client.PlaceSpotOrder(ctx, tpOrder)
+			})
 		if err != nil {
 			bracketErr.Add(fmt.Sprintf("TP%d", i+1), err)
 			m.logger.Error().
@@ -111,7 +119,11 @@ func (m *Manager) placeSpotBracket(ctx context.Context, client *binance.Client, 
 		NewClientOrderID: slID,
 	}
 
-	slResp, err := client.PlaceSpotOrder(ctx, slOrder)
+	slResp, err := submitResolvingAmbiguity(
+		ctx, m.logger, client, req.Symbol, slID, true,
+		func(ctx context.Context) (*binance.OrderResponse, error) {
+			return client.PlaceSpotOrder(ctx, slOrder)
+		})
 	if err != nil {
 		bracketErr.Add("SL", err)
 		m.logger.Error().
@@ -171,7 +183,11 @@ func (m *Manager) placeFuturesBracket(ctx context.Context, client *binance.Clien
 		ReduceOnly:       false, // Opening position
 	}
 
-	mainResp, err := client.PlaceFuturesOrder(ctx, mainOrder)
+	mainResp, err := submitResolvingAmbiguity(
+		ctx, m.logger, client, req.Symbol, mainOrderID, mainOrder.Type != "MARKET",
+		func(ctx context.Context) (*binance.OrderResponse, error) {
+			return client.PlaceFuturesOrder(ctx, mainOrder)
+		})
 	if err != nil {
 		bracketErr.Add("MAIN", err)
 		// Return immediately if main order fails as it's critical
@@ -201,7 +217,11 @@ func (m *Manager) placeFuturesBracket(ctx context.Context, client *binance.Clien
 			ReduceOnly:       true, // TP orders reduce position
 		}
 
-		tpResp, err := client.PlaceFuturesOrder(ctx, tpOrder)
+		tpResp, err := submitResolvingAmbiguity(
+			ctx, m.logger, client, req.Symbol, tpID, true,
+			func(ctx context.Context) (*binance.OrderResponse, error) {
+				return client.PlaceFuturesOrder(ctx, tpOrder)
+			})
 		if err != nil {
 			bracketErr.Add(fmt.Sprintf("TP%d", i+1), err)
 			m.logger.Error().
@@ -231,7 +251,11 @@ func (m *Manager) placeFuturesBracket(ctx context.Context, client *binance.Clien
 		ClosePosition: true, // Close entire position on stop
 	}
 
-	slResp, err := client.PlaceFuturesOrder(ctx, slOrder)
+	slResp, err := submitResolvingAmbiguity(
+		ctx, m.logger, client, req.Symbol, slID, true,
+		func(ctx context.Context) (*binance.OrderResponse, error) {
+			return client.PlaceFuturesOrder(ctx, slOrder)
+		})
 	if err != nil {
 		bracketErr.Add("SL", err)
 		m.logger.Error().

--- a/app/router/internal/orders/spot_execution_test.go
+++ b/app/router/internal/orders/spot_execution_test.go
@@ -30,6 +30,9 @@ func (f *fakeSpotExecutionLedger) callCount() int {
 func (f *fakeSpotExecutionLedger) latestSnapshot() SpotExecutionSnapshot {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if len(f.snapshots) == 0 {
+		return SpotExecutionSnapshot{}
+	}
 	return f.snapshots[len(f.snapshots)-1]
 }
 

--- a/app/router/internal/orders/spot_reconciler_test.go
+++ b/app/router/internal/orders/spot_reconciler_test.go
@@ -588,10 +588,13 @@ func TestSpotReconciler_RetriesWhenTradesLagTerminalStatus(t *testing.T) {
 	})
 
 	waitForEmitterStatus(t, emitter, "FILLED")
+	// FILLED is emitted before the trades-lag persist retry completes;
+	// wait on the ledger instead of racing it.
+	require.Eventually(t, func() bool { return ledger.callCount() == 1 },
+		time.Second, 5*time.Millisecond)
 
 	assert.GreaterOrEqual(t, getCalls.Load(), int64(2))
 	assert.Equal(t, int64(2), tradeCalls.Load())
-	assert.Equal(t, 1, ledger.callCount())
 	require.Len(t, ledger.latestSnapshot().Trades, 1)
 	assert.True(t, decimal.RequireFromString("50010").Equal(emitter.update.Price))
 }

--- a/app/router/internal/orders/submit.go
+++ b/app/router/internal/orders/submit.go
@@ -1,0 +1,143 @@
+package orders
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"router/internal/binance"
+	"router/internal/rest"
+)
+
+// Repoll settings for orders that are not yet visible after an ambiguous
+// submit; overridable in tests.
+var (
+	ambiguityRepollDelay         = 500 * time.Millisecond
+	ambiguityRepollAttempts      = 2
+	errAdoptedOrderDead          = errors.New("adopted order is terminal with no fills")
+	errRetryDisallowedForInstant = errors.New("retry disallowed for instantly-executable order")
+)
+
+// submitResolvingAmbiguity wraps an order POST so ambiguous or duplicate
+// outcomes are resolved against the exchange instead of guessed at.
+//
+// A -2013 not-found after an ambiguous submit is NOT proof the POST never
+// landed (degraded exchanges can execute after our timeout, and freshly
+// accepted orders can lag the query path), so the order is re-polled before
+// any retry, and orders that can execute instantly (allowRetry=false, e.g.
+// MARKET) are never re-POSTed. Anything unresolved fails closed with the
+// original error.
+func submitResolvingAmbiguity(
+	ctx context.Context,
+	logger zerolog.Logger,
+	client *binance.Client,
+	symbol string,
+	clientOrderID string,
+	allowRetry bool,
+	post func(context.Context) (*binance.OrderResponse, error),
+) (*binance.OrderResponse, error) {
+	resp, err := post(ctx)
+	if err == nil {
+		return resp, nil
+	}
+
+	ambiguous := errors.Is(err, rest.ErrAmbiguousSubmit)
+	duplicate := rest.IsDuplicateClientOrderID(err)
+	if !ambiguous && !duplicate {
+		return nil, err
+	}
+
+	adopted, queryErr := queryWithRepoll(ctx, client, symbol, clientOrderID)
+	if queryErr == nil {
+		return adoptExisting(logger, symbol, clientOrderID, duplicate, adopted, err)
+	}
+	if !rest.IsOrderNotFound(queryErr) {
+		return nil, fmt.Errorf(
+			"unresolved submit for %s (query failed: %v): %w",
+			clientOrderID, queryErr, err,
+		)
+	}
+	if duplicate {
+		// The exchange claims the id is a duplicate yet the order is not
+		// visible: unresolved, fail closed.
+		return nil, fmt.Errorf(
+			"duplicate submit for %s but order not found: %w",
+			clientOrderID, err,
+		)
+	}
+	if !allowRetry {
+		return nil, fmt.Errorf(
+			"%v for %s: %w",
+			errRetryDisallowedForInstant, clientOrderID, err,
+		)
+	}
+
+	logger.Warn().
+		Str("symbol", symbol).
+		Str("client_order_id", clientOrderID).
+		Msg("Ambiguous submit not visible on exchange; re-POSTing once")
+	retryResp, retryErr := post(ctx)
+	if retryErr == nil {
+		return retryResp, nil
+	}
+	if rest.IsDuplicateClientOrderID(retryErr) {
+		readopted, adoptErr := client.GetOrderByClientID(ctx, symbol, clientOrderID)
+		if adoptErr == nil {
+			return adoptExisting(logger, symbol, clientOrderID, true, readopted, retryErr)
+		}
+		return nil, fmt.Errorf(
+			"unresolved submit retry for %s (query failed: %v): %w",
+			clientOrderID, adoptErr, retryErr,
+		)
+	}
+	return nil, retryErr
+}
+
+// queryWithRepoll looks the order up by client id, re-polling on -2013 to
+// bridge the exchange's post-accept visibility lag.
+func queryWithRepoll(
+	ctx context.Context,
+	client *binance.Client,
+	symbol, clientOrderID string,
+) (*binance.OrderResponse, error) {
+	adopted, queryErr := client.GetOrderByClientID(ctx, symbol, clientOrderID)
+	for attempt := 0; attempt < ambiguityRepollAttempts && queryErr != nil; attempt++ {
+		if !rest.IsOrderNotFound(queryErr) || ctx.Err() != nil {
+			break
+		}
+		time.Sleep(ambiguityRepollDelay)
+		adopted, queryErr = client.GetOrderByClientID(ctx, symbol, clientOrderID)
+	}
+	return adopted, queryErr
+}
+
+// adoptExisting accepts the exchange's state for an order we could not
+// confirm submitting, refusing terminal orders that never traded.
+func adoptExisting(
+	logger zerolog.Logger,
+	symbol, clientOrderID string,
+	wasDuplicate bool,
+	existing *binance.OrderResponse,
+	originalErr error,
+) (*binance.OrderResponse, error) {
+	switch existing.Status {
+	case "CANCELED", "EXPIRED", "REJECTED", "EXPIRED_IN_MATCH":
+		if !existing.ExecutedQty.IsPositive() {
+			return nil, fmt.Errorf(
+				"%v (status=%s) for %s: %w",
+				errAdoptedOrderDead, existing.Status, clientOrderID, originalErr,
+			)
+		}
+	}
+
+	logger.Warn().
+		Str("symbol", symbol).
+		Str("client_order_id", clientOrderID).
+		Str("status", existing.Status).
+		Bool("was_duplicate", wasDuplicate).
+		Msg("Adopted exchange state for unresolved order submit")
+	return existing, nil
+}

--- a/app/router/internal/orders/submit_test.go
+++ b/app/router/internal/orders/submit_test.go
@@ -1,0 +1,331 @@
+package orders
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"router/internal/auth"
+	"router/internal/binance"
+	"router/internal/rest"
+)
+
+func init() {
+	// The repoll bridge is timing behavior; tests only assert call counts.
+	ambiguityRepollDelay = 0
+}
+
+type getScript struct {
+	status      int    // 200 serves an order; 400 serves -2013 not found
+	orderStatus string // order status served on 200 (default FILLED)
+	executedQty string // executed quantity served on 200 (default "1")
+}
+
+type fakeExchange struct {
+	orderPath    string // "/api/v3/order" or "/fapi/v1/order"
+	postStatuses []int  // per-POST: 200 NEW | 400 duplicate | 500 ambiguous
+	dupCode      int    // duplicate error code for 400 POSTs (default -2010)
+	getScripts   []getScript
+	postCount    atomic.Int64
+	getCount     atomic.Int64
+}
+
+func (f *fakeExchange) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != f.orderPath {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"code":-1121,"msg":"Invalid symbol."}`))
+			return
+		}
+		clientOrderID := r.URL.Query().Get("newClientOrderId")
+		if clientOrderID == "" {
+			clientOrderID = r.URL.Query().Get("origClientOrderId")
+		}
+
+		switch r.Method {
+		case http.MethodPost:
+			call := int(f.postCount.Add(1)) - 1
+			status := http.StatusOK
+			if call < len(f.postStatuses) {
+				status = f.postStatuses[call]
+			}
+			switch status {
+			case http.StatusOK:
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"symbol": "BTCUSDT", "orderId": 100 + call, "clientOrderId": clientOrderID,
+					"transactTime": 1, "price": "100", "origQty": "1", "executedQty": "0",
+					"status": "NEW", "timeInForce": "GTC", "type": "LIMIT", "side": "BUY",
+				})
+			case http.StatusBadRequest:
+				dupCode := f.dupCode
+				if dupCode == 0 {
+					dupCode = -2010
+				}
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = fmt.Fprintf(w, `{"code":%d,"msg":"Duplicate order sent."}`, dupCode)
+			default:
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte(`upstream exploded`))
+			}
+		case http.MethodGet:
+			call := int(f.getCount.Add(1)) - 1
+			script := getScript{status: http.StatusBadRequest}
+			if call < len(f.getScripts) {
+				script = f.getScripts[call]
+			}
+			if script.status != http.StatusOK {
+				w.WriteHeader(script.status)
+				_, _ = w.Write([]byte(`{"code":-2013,"msg":"Order does not exist."}`))
+				return
+			}
+			orderStatus := script.orderStatus
+			if orderStatus == "" {
+				orderStatus = "FILLED"
+			}
+			executedQty := script.executedQty
+			if executedQty == "" {
+				executedQty = "1"
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"symbol": "BTCUSDT", "orderId": 555, "clientOrderId": clientOrderID,
+				"price": "100", "origQty": "1", "executedQty": executedQty,
+				"status": orderStatus, "timeInForce": "GTC", "type": "LIMIT", "side": "BUY",
+			})
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}
+}
+
+func newSubmitFixture(
+	t *testing.T,
+	fake *fakeExchange,
+) (*binance.Client, func(context.Context) (*binance.OrderResponse, error)) {
+	t.Helper()
+	if fake.orderPath == "" {
+		fake.orderPath = "/api/v3/order"
+	}
+	server := httptest.NewServer(fake.handler())
+	t.Cleanup(server.Close)
+
+	signer := auth.NewSignerWithRecvWindow("key", "secret", 5000)
+	restClient := rest.NewClient(server.URL, signer)
+
+	var client *binance.Client
+	var err error
+	if fake.orderPath == "/fapi/v1/order" {
+		client, err = binance.NewFuturesClient(server.URL, signer, restClient, zerolog.Nop())
+	} else {
+		client, err = binance.NewSpotClient(server.URL, signer, restClient, zerolog.Nop())
+	}
+	require.NoError(t, err)
+
+	order := binance.SpotOrderRequest{
+		Symbol:           "BTCUSDT",
+		Side:             "BUY",
+		Type:             "LIMIT",
+		Quantity:         decimal.NewFromInt(1),
+		Price:            decimal.NewFromInt(100),
+		TimeInForce:      "GTC",
+		NewClientOrderID: "cid-1",
+	}
+	futuresOrder := binance.FuturesOrderRequest{
+		Symbol:           order.Symbol,
+		Side:             order.Side,
+		Type:             order.Type,
+		Quantity:         order.Quantity,
+		Price:            order.Price,
+		TimeInForce:      order.TimeInForce,
+		NewClientOrderID: order.NewClientOrderID,
+	}
+	post := func(ctx context.Context) (*binance.OrderResponse, error) {
+		if fake.orderPath == "/fapi/v1/order" {
+			return client.PlaceFuturesOrder(ctx, futuresOrder)
+		}
+		return client.PlaceSpotOrder(ctx, order)
+	}
+	return client, post
+}
+
+func resolve(
+	t *testing.T,
+	client *binance.Client,
+	allowRetry bool,
+	post func(context.Context) (*binance.OrderResponse, error),
+) (*binance.OrderResponse, error) {
+	t.Helper()
+	return submitResolvingAmbiguity(
+		context.Background(), zerolog.Nop(), client, "BTCUSDT", "cid-1", allowRetry, post)
+}
+
+func TestSubmitResolvingAmbiguity_CleanSubmitPassesThrough(t *testing.T) {
+	fake := &fakeExchange{postStatuses: []int{http.StatusOK}}
+	client, post := newSubmitFixture(t, fake)
+
+	resp, err := resolve(t, client, true, post)
+
+	require.NoError(t, err)
+	assert.Equal(t, "NEW", resp.Status)
+	assert.Equal(t, [2]int64{1, 0}, [2]int64{fake.postCount.Load(), fake.getCount.Load()})
+}
+
+func TestSubmitResolvingAmbiguity_AmbiguousResolvesViaQuery(t *testing.T) {
+	fake := &fakeExchange{
+		postStatuses: []int{http.StatusInternalServerError},
+		getScripts:   []getScript{{status: http.StatusOK}},
+	}
+	client, post := newSubmitFixture(t, fake)
+
+	resp, err := resolve(t, client, true, post)
+
+	require.NoError(t, err)
+	assert.Equal(t, "FILLED", resp.Status)
+	assert.Equal(t, int64(555), resp.OrderID)
+	assert.Equal(t, [2]int64{1, 1}, [2]int64{fake.postCount.Load(), fake.getCount.Load()})
+}
+
+func TestSubmitResolvingAmbiguity_DuplicateAdoptsExistingOrder(t *testing.T) {
+	fake := &fakeExchange{
+		postStatuses: []int{http.StatusBadRequest},
+		getScripts:   []getScript{{status: http.StatusOK}},
+	}
+	client, post := newSubmitFixture(t, fake)
+
+	resp, err := resolve(t, client, true, post)
+
+	require.NoError(t, err)
+	assert.Equal(t, "FILLED", resp.Status)
+	assert.Equal(t, [2]int64{1, 1}, [2]int64{fake.postCount.Load(), fake.getCount.Load()})
+}
+
+func TestSubmitResolvingAmbiguity_VisibilityLagBridgedByRepoll(t *testing.T) {
+	fake := &fakeExchange{
+		postStatuses: []int{http.StatusInternalServerError},
+		getScripts:   []getScript{{status: http.StatusBadRequest}, {status: http.StatusOK}},
+	}
+	client, post := newSubmitFixture(t, fake)
+
+	resp, err := resolve(t, client, true, post)
+
+	require.NoError(t, err)
+	assert.Equal(t, "FILLED", resp.Status)
+	assert.Equal(t, [2]int64{1, 2}, [2]int64{fake.postCount.Load(), fake.getCount.Load()})
+}
+
+func TestSubmitResolvingAmbiguity_NotFoundAfterRepollsRetriesOnce(t *testing.T) {
+	fake := &fakeExchange{
+		postStatuses: []int{http.StatusInternalServerError, http.StatusOK},
+	}
+	client, post := newSubmitFixture(t, fake)
+
+	resp, err := resolve(t, client, true, post)
+
+	require.NoError(t, err)
+	assert.Equal(t, "NEW", resp.Status)
+	// initial query + 2 repolls, all -2013, then exactly one retry POST
+	assert.Equal(t, [2]int64{2, 3}, [2]int64{fake.postCount.Load(), fake.getCount.Load()})
+}
+
+func TestSubmitResolvingAmbiguity_RetryAmbiguousAgainFailsClosed(t *testing.T) {
+	fake := &fakeExchange{
+		postStatuses: []int{http.StatusInternalServerError, http.StatusInternalServerError},
+	}
+	client, post := newSubmitFixture(t, fake)
+
+	_, err := resolve(t, client, true, post)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, rest.ErrAmbiguousSubmit)
+	assert.Equal(t, int64(2), fake.postCount.Load())
+}
+
+func TestSubmitResolvingAmbiguity_RetryDuplicateAdoptsExchangeState(t *testing.T) {
+	fake := &fakeExchange{
+		postStatuses: []int{http.StatusInternalServerError, http.StatusBadRequest},
+		getScripts: []getScript{
+			{status: http.StatusBadRequest},
+			{status: http.StatusBadRequest},
+			{status: http.StatusBadRequest},
+			{status: http.StatusOK},
+		},
+	}
+	client, post := newSubmitFixture(t, fake)
+
+	resp, err := resolve(t, client, true, post)
+
+	require.NoError(t, err)
+	assert.Equal(t, "FILLED", resp.Status)
+	assert.Equal(t, [2]int64{2, 4}, [2]int64{fake.postCount.Load(), fake.getCount.Load()})
+}
+
+func TestSubmitResolvingAmbiguity_MarketOrderNeverRetries(t *testing.T) {
+	fake := &fakeExchange{postStatuses: []int{http.StatusInternalServerError}}
+	client, post := newSubmitFixture(t, fake)
+
+	_, err := resolve(t, client, false, post)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, rest.ErrAmbiguousSubmit)
+	assert.Equal(t, [2]int64{1, 3}, [2]int64{fake.postCount.Load(), fake.getCount.Load()})
+}
+
+func TestSubmitResolvingAmbiguity_DuplicateButInvisibleFailsClosed(t *testing.T) {
+	fake := &fakeExchange{postStatuses: []int{http.StatusBadRequest}}
+	client, post := newSubmitFixture(t, fake)
+
+	_, err := resolve(t, client, true, post)
+
+	require.Error(t, err)
+	assert.True(t, rest.IsDuplicateClientOrderID(err),
+		"original duplicate error must survive the wrap")
+	assert.Equal(t, int64(1), fake.postCount.Load())
+}
+
+func TestSubmitResolvingAmbiguity_DeadAdoptedOrderFailsClosed(t *testing.T) {
+	fake := &fakeExchange{
+		postStatuses: []int{http.StatusInternalServerError},
+		getScripts:   []getScript{{status: http.StatusOK, orderStatus: "CANCELED", executedQty: "0"}},
+	}
+	client, post := newSubmitFixture(t, fake)
+
+	_, err := resolve(t, client, true, post)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, rest.ErrAmbiguousSubmit)
+	assert.Equal(t, [2]int64{1, 1}, [2]int64{fake.postCount.Load(), fake.getCount.Load()})
+}
+
+func TestSubmitResolvingAmbiguity_UnrelatedErrorFailsClosedWithoutQuery(t *testing.T) {
+	fake := &fakeExchange{postStatuses: []int{http.StatusTeapot}}
+	client, post := newSubmitFixture(t, fake)
+
+	_, err := resolve(t, client, true, post)
+
+	require.Error(t, err)
+	assert.Equal(t, [2]int64{1, 0}, [2]int64{fake.postCount.Load(), fake.getCount.Load()})
+}
+
+func TestSubmitResolvingAmbiguity_FuturesDuplicateAdoptsViaFapiPath(t *testing.T) {
+	fake := &fakeExchange{
+		orderPath:    "/fapi/v1/order",
+		postStatuses: []int{http.StatusBadRequest},
+		dupCode:      -4116,
+		getScripts:   []getScript{{status: http.StatusOK}},
+	}
+	client, post := newSubmitFixture(t, fake)
+
+	resp, err := resolve(t, client, true, post)
+
+	require.NoError(t, err)
+	assert.Equal(t, "FILLED", resp.Status)
+	assert.Equal(t, [2]int64{1, 1}, [2]int64{fake.postCount.Load(), fake.getCount.Load()})
+}

--- a/app/router/internal/rest/client.go
+++ b/app/router/internal/rest/client.go
@@ -754,11 +754,15 @@ func (c *Client) doRequest(ctx context.Context, method, path string, params url.
 			return nil, err
 		}
 
-		// Read response body
+		// Read response body. A read/close failure after Do succeeded is the
+		// strongest signal a POST executed — never blind re-POST from here.
 		respBody, readErr := io.ReadAll(resp.Body)
 		closeErr := resp.Body.Close()
 		if readErr != nil {
 			lastErr = readErr
+			if method == http.MethodPost {
+				return nil, fmt.Errorf("%w: %s %s: %v", ErrAmbiguousSubmit, method, path, readErr)
+			}
 			if attempt < c.maxRetries {
 				c.waitForRetry(attempt)
 				continue
@@ -767,6 +771,9 @@ func (c *Client) doRequest(ctx context.Context, method, path string, params url.
 		}
 		if closeErr != nil {
 			lastErr = closeErr
+			if method == http.MethodPost {
+				return nil, fmt.Errorf("%w: %s %s: %v", ErrAmbiguousSubmit, method, path, closeErr)
+			}
 			if attempt < c.maxRetries {
 				c.waitForRetry(attempt)
 				continue

--- a/app/router/internal/rest/errors.go
+++ b/app/router/internal/rest/errors.go
@@ -110,6 +110,17 @@ func IsDuplicateClientOrderID(err error) bool {
 	return binanceErr.Code == -4116
 }
 
+// IsOrderNotFound reports whether the error is Binance saying the queried
+// order is not visible. NOT proof a submit never landed: freshly accepted
+// orders can lag the query path, so callers must re-poll before acting.
+func IsOrderNotFound(err error) bool {
+	var binanceErr *BinanceError
+	if !errors.As(err, &binanceErr) {
+		return false
+	}
+	return binanceErr.Code == -2013
+}
+
 func IsRetryableError(err error) bool {
 	if err == nil {
 		return false


### PR DESCRIPTION
## Summary

First PR of the router order-lifecycle hardening series (C1 of C1–C7). The recovery primitives built in #183 (`ErrAmbiguousSubmit`, `GetOrderByClientID`, `IsDuplicateClientOrderID`) were never consumed — a POST that timed out or 5xx'd was reported as a hard leg failure even when the order had actually landed. Now every bracket leg POST resolves against the exchange:

- **Adopt, don't guess**: ambiguous/duplicate outcomes query by client id (venue-aware) and adopt the exchange's state. Adopted market fills derive average price from `cummulativeQuoteQty/executedQty` so downstream persistence doesn't record 0.
- **-2013 is visibility lag, not proof** (review finding): the query re-polls (initial + 2 × 500ms) before acting; only order types that rest on the book may re-POST (exactly once, logged). **MARKET legs never retry** — once filled-and-closed, Binance's duplicate-id guard evaporates and a retry would silently double-execute.
- **Dead adoptions refused**: CANCELED/EXPIRED/REJECTED with zero fills fail closed rather than building a bracket around a nonexistent entry.
- **Transport hole closed** (review finding): rest-client body read/close failures after a successful POST — the strongest signal the order executed — now surface `ErrAmbiguousSubmit` instead of blindly re-POSTing up to maxRetries times.
- **Deflaked** `TestSpotReconciler_RetriesWhenTradesLagTerminalStatus` (9/10 failures under load at HEAD, bisected as pre-existing): the FILLED emit races the persist retry; now waits on the ledger, and the fake's `latestSnapshot` is empty-safe.

**Disclosed residuals** (accepted in review, tracked for the series): a *marketable* LIMIT (stale price after a fast move) can still fill instantly and retry — the window requires the exchange to process the original >~1s late AND the retry to fill first; a `canRestOnBook(type, tif)` predicate is the future-proofing if IOC/FOK ever appear. Futures adopted-fill avg price still falls back (futures GET uses `cumQuote`/`avgPrice` field names) — will ride with the GetMyTrades backfill in a later series PR.

## Test plan

- 12 resolution tests through the real rest→binance stack against a scripted fake exchange: clean pass-through, adopt-via-query (ambiguous + duplicate), visibility-lag repoll recovery, retry-once-after-confirmed-invisible, retry-ambiguous fail-closed, retry-duplicate adopt, MARKET-no-retry, duplicate-but-invisible fail-closed (original error preserved through the wrap), dead-order refusal, unrelated-error fast-fail, futures /fapi + -4116
- Full router suite, `go vet`, `-race` on orders/rest/binance, 3× flake-stable; deflaked test verified `-count=5`
- QCHECK: initial BLOCK (MARKET retry race + transport re-POST hole) — both fixed; re-verify verdict PASS

CI billing-locked — local gates; admin squash-merge to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)