### PR TITLE
feat(router): durable bracket reservations with replay repair (C2)

### DIFF
--- a/app/router/cmd/router/main.go
+++ b/app/router/cmd/router/main.go
@@ -178,6 +178,10 @@ func main() {
 
 	// Create order manager
 	orderManager := orders.NewManager(spotClient, futuresClient, eventEmitter, logger)
+	if dbPool != nil {
+		orderManager.SetBracketStore(storage.NewBracketRepo(dbPool))
+		logger.Info().Msg("Durable bracket reservations enabled")
+	}
 	var spotReconciler *orders.SpotReconciler
 	if spotClient != nil {
 		if enabled, err := strconv.ParseBool(os.Getenv("SPOT_RECONCILIATION_ENABLED")); err == nil && enabled {

--- a/app/router/internal/orders/bracket.go
+++ b/app/router/internal/orders/bracket.go
@@ -17,8 +17,10 @@ type bracketPlacementResult struct {
 	StopLossLimitPrice decimal.Decimal
 }
 
-// placeSpotBracket places a bracket order for spot trading
-func (m *Manager) placeSpotBracket(ctx context.Context, client *binance.Client, req *PlaceBracketRequest, bracketID string) (*bracketPlacementResult, error) {
+// placeSpotBracket places a bracket order for spot trading. A non-nil
+// adoptedEntry is a replayed entry already live on the exchange: it is used
+// as the main order instead of POSTing, and exit legs place idempotently.
+func (m *Manager) placeSpotBracket(ctx context.Context, client *binance.Client, req *PlaceBracketRequest, bracketID string, adoptedEntry *binance.OrderResponse) (*bracketPlacementResult, error) {
 	result := &bracketPlacementResult{
 		IDs: ClientOrderIDs{
 			TakeProfits: make([]string, len(req.TakeProfitPrices)),
@@ -42,15 +44,19 @@ func (m *Manager) placeSpotBracket(ctx context.Context, client *binance.Client, 
 		NewClientOrderID: mainOrderID,
 	}
 
-	mainResp, err := submitResolvingAmbiguity(
-		ctx, m.logger, client, req.Symbol, mainOrderID, mainOrder.Type != "MARKET",
-		func(ctx context.Context) (*binance.OrderResponse, error) {
-			return client.PlaceSpotOrder(ctx, mainOrder)
-		})
-	if err != nil {
-		bracketErr.Add("MAIN", err)
-		// Return immediately if main order fails as it's critical
-		return result, bracketErr
+	mainResp := adoptedEntry
+	if mainResp == nil {
+		var err error
+		mainResp, err = submitResolvingAmbiguity(
+			ctx, m.logger, client, req.Symbol, mainOrderID, mainOrder.Type != "MARKET",
+			func(ctx context.Context) (*binance.OrderResponse, error) {
+				return client.PlaceSpotOrder(ctx, mainOrder)
+			})
+		if err != nil {
+			bracketErr.Add("MAIN", err)
+			// Return immediately if main order fails as it's critical
+			return result, bracketErr
+		}
 	}
 	result.IDs.Main = mainOrderID
 	result.Main = mainResp
@@ -157,8 +163,10 @@ func (m *Manager) placeSpotBracket(ctx context.Context, client *binance.Client, 
 	return result, nil
 }
 
-// placeFuturesBracket places a bracket order for futures trading
-func (m *Manager) placeFuturesBracket(ctx context.Context, client *binance.Client, req *PlaceBracketRequest, bracketID string) (*bracketPlacementResult, error) {
+// placeFuturesBracket places a bracket order for futures trading. A non-nil
+// adoptedEntry is a replayed entry already live on the exchange: it is used
+// as the main order instead of POSTing, and exit legs place idempotently.
+func (m *Manager) placeFuturesBracket(ctx context.Context, client *binance.Client, req *PlaceBracketRequest, bracketID string, adoptedEntry *binance.OrderResponse) (*bracketPlacementResult, error) {
 	result := &bracketPlacementResult{
 		IDs: ClientOrderIDs{
 			TakeProfits: make([]string, len(req.TakeProfitPrices)),
@@ -183,15 +191,19 @@ func (m *Manager) placeFuturesBracket(ctx context.Context, client *binance.Clien
 		ReduceOnly:       false, // Opening position
 	}
 
-	mainResp, err := submitResolvingAmbiguity(
-		ctx, m.logger, client, req.Symbol, mainOrderID, mainOrder.Type != "MARKET",
-		func(ctx context.Context) (*binance.OrderResponse, error) {
-			return client.PlaceFuturesOrder(ctx, mainOrder)
-		})
-	if err != nil {
-		bracketErr.Add("MAIN", err)
-		// Return immediately if main order fails as it's critical
-		return result, bracketErr
+	mainResp := adoptedEntry
+	if mainResp == nil {
+		var err error
+		mainResp, err = submitResolvingAmbiguity(
+			ctx, m.logger, client, req.Symbol, mainOrderID, mainOrder.Type != "MARKET",
+			func(ctx context.Context) (*binance.OrderResponse, error) {
+				return client.PlaceFuturesOrder(ctx, mainOrder)
+			})
+		if err != nil {
+			bracketErr.Add("MAIN", err)
+			// Return immediately if main order fails as it's critical
+			return result, bracketErr
+		}
 	}
 	result.IDs.Main = mainOrderID
 	result.Main = mainResp

--- a/app/router/internal/orders/bracket_store_test.go
+++ b/app/router/internal/orders/bracket_store_test.go
@@ -1,0 +1,333 @@
+package orders
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"router/internal/auth"
+	"router/internal/binance"
+	"router/internal/rest"
+	"router/internal/storage"
+)
+
+type fakeBracketStore struct {
+	mu             sync.Mutex
+	reserveErr     error
+	existingRecord *storage.BracketRecord // nil => this store wins the insert
+
+	reserved       []storage.BracketRecord
+	bracketUpdates []string
+	legUpdates     map[string]string
+}
+
+func newFakeBracketStore() *fakeBracketStore {
+	return &fakeBracketStore{legUpdates: make(map[string]string)}
+}
+
+func (f *fakeBracketStore) Reserve(_ context.Context, rec storage.BracketRecord) (*storage.BracketRecord, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.reserveErr != nil {
+		return nil, false, f.reserveErr
+	}
+	f.reserved = append(f.reserved, rec)
+	if f.existingRecord != nil {
+		return f.existingRecord, false, nil
+	}
+	stored := rec
+	if stored.BracketID == uuid.Nil {
+		stored.BracketID = uuid.New()
+	}
+	return &stored, true, nil
+}
+
+func (f *fakeBracketStore) UpdateBracketStatus(_ context.Context, _ uuid.UUID, status string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.bracketUpdates = append(f.bracketUpdates, status)
+	return nil
+}
+
+func (f *fakeBracketStore) UpdateLegStatus(_ context.Context, _ uuid.UUID, clientOrderID, status string, _ int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.legUpdates[clientOrderID] = status
+	return nil
+}
+
+// bracketExchange serves the futures order endpoints, recording POSTed ids.
+type bracketExchange struct {
+	mu         sync.Mutex
+	postedIDs  []string
+	getStatus  int             // GET /fapi/v1/order: 200 live NEW order, else -2013
+	postDupIDs map[string]bool // POSTs of these ids are rejected as -4116 duplicates
+	failPosts  bool            // all POSTs fail with a non-retryable -1102
+}
+
+func (f *bracketExchange) posted() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.postedIDs...)
+}
+
+func (f *bracketExchange) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/fapi/v1/order" {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"not found"}`))
+			return
+		}
+		q := r.URL.Query()
+		switch r.Method {
+		case http.MethodPost:
+			clientOrderID := q.Get("newClientOrderId")
+			if f.failPosts {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"code":-1102,"msg":"Mandatory parameter was not sent."}`))
+				return
+			}
+			if f.postDupIDs[clientOrderID] {
+				f.mu.Lock()
+				f.postedIDs = append(f.postedIDs, clientOrderID)
+				f.mu.Unlock()
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"code":-4116,"msg":"Duplicate order sent."}`))
+				return
+			}
+			orDefault := func(v string) string {
+				if v == "" {
+					return "0"
+				}
+				return v
+			}
+			f.mu.Lock()
+			f.postedIDs = append(f.postedIDs, clientOrderID)
+			count := len(f.postedIDs)
+			f.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"orderId": 1000 + count, "symbol": q.Get("symbol"), "status": "NEW",
+				"clientOrderId": clientOrderID, "price": orDefault(q.Get("price")), "avgPrice": "0",
+				"origQty": orDefault(q.Get("quantity")), "executedQty": "0", "cumQty": "0", "cumQuote": "0",
+				"timeInForce": "GTC", "type": q.Get("type"), "reduceOnly": false,
+				"closePosition": q.Get("closePosition") == "true", "side": q.Get("side"),
+				"positionSide": "BOTH", "stopPrice": orDefault(q.Get("stopPrice")), "workingType": "CONTRACT_PRICE",
+				"priceProtect": false, "origType": q.Get("type"), "updateTime": 1,
+			})
+		case http.MethodGet:
+			if f.getStatus == http.StatusOK {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"orderId": 777, "symbol": q.Get("symbol"), "status": "NEW",
+					"clientOrderId": q.Get("origClientOrderId"), "price": "50000", "avgPrice": "0",
+					"origQty": "0.02", "executedQty": "0", "cumQuote": "0",
+					"timeInForce": "GTC", "type": "LIMIT", "side": "BUY",
+					"stopPrice": "0", "updateTime": 1,
+				})
+				return
+			}
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"code":-2013,"msg":"Order does not exist."}`))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}
+}
+
+func newStoreFixture(t *testing.T, fake *bracketExchange, store *fakeBracketStore) *Manager {
+	t.Helper()
+	server := httptest.NewServer(fake.handler())
+	t.Cleanup(server.Close)
+
+	signer := auth.NewSignerWithRecvWindow("key", "secret", 5000)
+	logger := zerolog.Nop()
+	futuresRest := rest.NewClient(server.URL, signer)
+	futuresClient, err := binance.NewFuturesClient(server.URL, signer, futuresRest, logger)
+	require.NoError(t, err)
+
+	manager := NewManager(nil, futuresClient, nil, logger)
+	manager.SetBracketStore(store)
+	return manager
+}
+
+func storeBracketRequest() *PlaceBracketRequest {
+	return &PlaceBracketRequest{
+		Symbol:           "BTCUSDT",
+		Side:             "BUY",
+		Quantity:         decimal.RequireFromString("0.02"),
+		EntryPrice:       decimal.RequireFromString("50000"),
+		TakeProfitPrices: []decimal.Decimal{decimal.RequireFromString("51000")},
+		StopLossPrice:    decimal.RequireFromString("49000"),
+		IsFutures:        true,
+		ClientOrderIDs: &ClientOrderIDs{
+			Main:        "engine-main-9",
+			TakeProfits: []string{"engine-tp-9"},
+			StopLoss:    "engine-sl-9",
+		},
+	}
+}
+
+func TestPlaceBracketOrder_ReservesAndPersistsOutcome(t *testing.T) {
+	store := newFakeBracketStore()
+	manager := newStoreFixture(t, &bracketExchange{}, store)
+
+	resp, err := manager.PlaceBracketOrder(context.Background(), storeBracketRequest())
+
+	require.NoError(t, err)
+	require.Len(t, store.reserved, 1)
+	reserved := store.reserved[0]
+	assert.Equal(t, storage.BracketStatusReserved, reserved.Status)
+	roles := map[string]string{}
+	for _, leg := range reserved.Legs {
+		roles[leg.ClientOrderID] = leg.Role + ":" + leg.Status
+	}
+	assert.Equal(t, map[string]string{
+		"engine-main-9": "ENTRY:PLANNED",
+		"engine-tp-9":   "TP:PLANNED",
+		"engine-sl-9":   "SL:PLANNED",
+	}, roles)
+
+	assert.Equal(t, []string{storage.BracketStatusLegsPlaced}, store.bracketUpdates)
+	assert.Equal(t, map[string]string{
+		"engine-main-9": storage.LegStatusPlaced,
+		"engine-tp-9":   storage.LegStatusPlaced,
+		"engine-sl-9":   storage.LegStatusPlaced,
+	}, store.legUpdates)
+	assert.Equal(t, "engine-main-9", resp.ClientOrderIDs.Main)
+}
+
+func TestPlaceBracketOrder_ReplayAdoptsLiveEntryWithoutRePosting(t *testing.T) {
+	existingID := uuid.New()
+	store := newFakeBracketStore()
+	store.existingRecord = &storage.BracketRecord{
+		BracketID:          existingID,
+		Venue:              "USD_M",
+		Symbol:             "BTCUSDT",
+		Side:               "BUY",
+		EntryClientOrderID: "engine-main-9",
+		Status:             storage.BracketStatusEntryPlaced,
+	}
+	fake := &bracketExchange{getStatus: http.StatusOK}
+	manager := newStoreFixture(t, fake, store)
+
+	resp, err := manager.PlaceBracketOrder(context.Background(), storeBracketRequest())
+
+	require.NoError(t, err)
+	assert.NotContains(t, fake.posted(), "engine-main-9",
+		"replay must adopt the live entry, never re-POST it")
+	assert.ElementsMatch(t, []string{"engine-tp-9", "engine-sl-9"}, fake.posted())
+	assert.Equal(t, existingID.String(), resp.BracketOrderID)
+	assert.Equal(t, []string{storage.BracketStatusLegsPlaced}, store.bracketUpdates)
+}
+
+func TestPlaceBracketOrder_ReplayPlacesFreshWhenEntryInvisible(t *testing.T) {
+	store := newFakeBracketStore()
+	store.existingRecord = &storage.BracketRecord{
+		BracketID:          uuid.New(),
+		Venue:              "USD_M",
+		Symbol:             "BTCUSDT",
+		Side:               "BUY",
+		EntryClientOrderID: "engine-main-9",
+		Status:             storage.BracketStatusReserved,
+	}
+	fake := &bracketExchange{getStatus: http.StatusBadRequest}
+	manager := newStoreFixture(t, fake, store)
+
+	resp, err := manager.PlaceBracketOrder(context.Background(), storeBracketRequest())
+
+	require.NoError(t, err)
+	assert.ElementsMatch(t,
+		[]string{"engine-main-9", "engine-tp-9", "engine-sl-9"}, fake.posted())
+	assert.Equal(t, "engine-main-9", resp.ClientOrderIDs.Main)
+}
+
+func TestPlaceBracketOrder_CriticalFailurePersistsFailedStatus(t *testing.T) {
+	store := newFakeBracketStore()
+	manager := newStoreFixture(t, &bracketExchange{failPosts: true}, store)
+
+	_, err := manager.PlaceBracketOrder(context.Background(), storeBracketRequest())
+
+	require.Error(t, err)
+	assert.Equal(t, []string{storage.BracketStatusFailed}, store.bracketUpdates)
+}
+
+func TestPlaceBracketOrder_ReplayWithAllLegsLiveAdoptsEverything(t *testing.T) {
+	existingID := uuid.New()
+	store := newFakeBracketStore()
+	store.existingRecord = &storage.BracketRecord{
+		BracketID:          existingID,
+		Venue:              "USD_M",
+		Symbol:             "BTCUSDT",
+		Side:               "BUY",
+		EntryClientOrderID: "engine-main-9",
+		Status:             storage.BracketStatusLegsPlaced,
+		Legs: []storage.BracketLegRecord{
+			{Role: "ENTRY", ClientOrderID: "engine-main-9", Status: storage.LegStatusPlaced},
+			{Role: "TP", TPIndex: 1, ClientOrderID: "engine-tp-9", Status: storage.LegStatusPlaced},
+			{Role: "SL", ClientOrderID: "engine-sl-9", Status: storage.LegStatusPlaced},
+		},
+	}
+	fake := &bracketExchange{
+		getStatus:  http.StatusOK,
+		postDupIDs: map[string]bool{"engine-tp-9": true, "engine-sl-9": true},
+	}
+	manager := newStoreFixture(t, fake, store)
+
+	resp, err := manager.PlaceBracketOrder(context.Background(), storeBracketRequest())
+
+	require.NoError(t, err)
+	assert.False(t, resp.PartialFailure)
+	assert.NotContains(t, fake.posted(), "engine-main-9")
+	assert.Equal(t, map[string]string{
+		"engine-main-9": storage.LegStatusPlaced,
+		"engine-tp-9":   storage.LegStatusPlaced,
+		"engine-sl-9":   storage.LegStatusPlaced,
+	}, store.legUpdates)
+}
+
+func TestPlaceBracketOrder_ReplayDivergentLegIDsFailsClosed(t *testing.T) {
+	store := newFakeBracketStore()
+	store.existingRecord = &storage.BracketRecord{
+		BracketID:          uuid.New(),
+		Venue:              "USD_M",
+		Symbol:             "BTCUSDT",
+		Side:               "BUY",
+		EntryClientOrderID: "engine-main-9",
+		Status:             storage.BracketStatusEntryPlaced,
+		Legs: []storage.BracketLegRecord{
+			{Role: "ENTRY", ClientOrderID: "engine-main-9"},
+			{Role: "TP", TPIndex: 1, ClientOrderID: "old-tp-id"},
+			{Role: "SL", ClientOrderID: "old-sl-id"},
+		},
+	}
+	fake := &bracketExchange{getStatus: http.StatusOK}
+	manager := newStoreFixture(t, fake, store)
+
+	_, err := manager.PlaceBracketOrder(context.Background(), storeBracketRequest())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "diverges from reservation")
+	assert.Empty(t, fake.posted(), "divergent replay must not touch the exchange")
+}
+
+func TestPlaceBracketOrder_StoreErrorDegradesToInMemory(t *testing.T) {
+	store := newFakeBracketStore()
+	store.reserveErr = assert.AnError
+	fake := &bracketExchange{}
+	manager := newStoreFixture(t, fake, store)
+
+	resp, err := manager.PlaceBracketOrder(context.Background(), storeBracketRequest())
+
+	require.NoError(t, err)
+	assert.Len(t, fake.posted(), 3)
+	assert.Empty(t, store.bracketUpdates, "no reservation id, so no status writes")
+	assert.Equal(t, "engine-main-9", resp.ClientOrderIDs.Main)
+}

--- a/app/router/internal/orders/manager.go
+++ b/app/router/internal/orders/manager.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/shopspring/decimal"
 	"router/internal/binance"
+	"router/internal/storage"
 )
 
 // clientOrderIDSeq provides a monotonically increasing counter to guarantee
@@ -32,6 +33,9 @@ type Manager struct {
 
 	spotReconciler spotOrderTracker
 
+	// Durable reservation store; nil keeps in-memory-only idempotency
+	bracketStore BracketStore
+
 	// Logger
 	logger zerolog.Logger
 }
@@ -39,6 +43,19 @@ type Manager struct {
 // EventEmitter defines interface for emitting order events
 type EventEmitter interface {
 	EmitOrderUpdate(ctx context.Context, update *OrderUpdate) error
+}
+
+// BracketStore persists bracket reservations and leg state so idempotency
+// and replay repair survive router restarts.
+type BracketStore interface {
+	Reserve(ctx context.Context, rec storage.BracketRecord) (*storage.BracketRecord, bool, error)
+	UpdateBracketStatus(ctx context.Context, bracketID uuid.UUID, status string) error
+	UpdateLegStatus(ctx context.Context, bracketID uuid.UUID, clientOrderID, status string, exchangeOrderID int64) error
+}
+
+// SetBracketStore installs the durable reservation store.
+func (m *Manager) SetBracketStore(store BracketStore) {
+	m.bracketStore = store
 }
 
 // NewManager creates a new order manager
@@ -264,6 +281,32 @@ func (m *Manager) PlaceBracketOrder(ctx context.Context, req *PlaceBracketReques
 		orderType = OrderTypeFutures
 	}
 
+	// Durable check-and-reserve: survives restarts, and on replay the entry
+	// is verified against the exchange so it is adopted, never re-POSTed.
+	var reservedBracketID uuid.UUID
+	var adoptedEntry *binance.OrderResponse
+	if m.bracketStore != nil && req.ClientOrderIDs != nil && req.ClientOrderIDs.Main != "" {
+		record, inserted, reserveErr := m.bracketStore.Reserve(ctx, bracketRecordFromRequest(req))
+		switch {
+		case reserveErr != nil:
+			m.logger.Warn().Err(reserveErr).
+				Str("client_order_id", req.ClientOrderIDs.Main).
+				Msg("Bracket store reserve failed; continuing with in-memory idempotency only")
+		case inserted:
+			reservedBracketID = record.BracketID
+		default:
+			if divergeErr := validateReplayMatchesReservation(record, req); divergeErr != nil {
+				return nil, divergeErr
+			}
+			reservedBracketID = record.BracketID
+			entry, replayErr := m.replayEntryState(ctx, client, req.Symbol, record.EntryClientOrderID)
+			if replayErr != nil {
+				return nil, replayErr
+			}
+			adoptedEntry = entry
+		}
+	}
+
 	// Round prices and quantities
 	roundedQty, err := client.RoundQuantity(ctx, req.Symbol, req.Quantity)
 	if err != nil {
@@ -304,8 +347,12 @@ func (m *Manager) PlaceBracketOrder(ctx context.Context, req *PlaceBracketReques
 		return nil, fmt.Errorf("notional validation failed: %w", err)
 	}
 
-	// Generate bracket order ID
+	// Generate bracket order ID (reuse the durable reservation's id so the
+	// in-memory bracket and the brackets row stay correlated)
 	bracketID := uuid.New().String()
+	if reservedBracketID != uuid.Nil {
+		bracketID = reservedBracketID.String()
+	}
 
 	// Create bracket order
 	bracket := &BracketOrder{
@@ -342,9 +389,9 @@ func (m *Manager) PlaceBracketOrder(ctx context.Context, req *PlaceBracketReques
 
 	var placement *bracketPlacementResult
 	if req.IsFutures {
-		placement, err = m.placeFuturesBracket(ctx, client, req, bracketID)
+		placement, err = m.placeFuturesBracket(ctx, client, req, bracketID, adoptedEntry)
 	} else {
-		placement, err = m.placeSpotBracket(ctx, client, req, bracketID)
+		placement, err = m.placeSpotBracket(ctx, client, req, bracketID, adoptedEntry)
 	}
 	if placement != nil {
 		bracket.ClientOrderIDs = placement.IDs
@@ -372,6 +419,8 @@ func (m *Manager) PlaceBracketOrder(ctx context.Context, req *PlaceBracketReques
 			return nil, fmt.Errorf("failed to place bracket order: %w", err)
 		}
 	}
+
+	m.persistPlacementOutcome(ctx, reservedBracketID, placement, criticalPlacementErr != nil)
 
 	// Store order (only store successfully placed order IDs)
 	m.mu.Lock()

--- a/app/router/internal/orders/replay.go
+++ b/app/router/internal/orders/replay.go
@@ -1,0 +1,196 @@
+package orders
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+
+	"router/internal/binance"
+	"router/internal/rest"
+	"router/internal/storage"
+)
+
+// bracketRecordFromRequest builds the durable reservation for a request that
+// carries caller-supplied client order ids (the engine contract).
+func bracketRecordFromRequest(req *PlaceBracketRequest) storage.BracketRecord {
+	venue := "SPOT"
+	if req.IsFutures {
+		venue = "USD_M"
+	}
+
+	legs := make([]storage.BracketLegRecord, 0, len(req.ClientOrderIDs.TakeProfits)+2)
+	legs = append(legs, storage.BracketLegRecord{
+		Role:          "ENTRY",
+		ClientOrderID: req.ClientOrderIDs.Main,
+		Price:         req.EntryPrice,
+		Quantity:      req.Quantity,
+		Status:        storage.LegStatusPlanned,
+	})
+	for i, tpID := range req.ClientOrderIDs.TakeProfits {
+		price := tpPriceAt(req.TakeProfitPrices, i)
+		legs = append(legs, storage.BracketLegRecord{
+			Role:          "TP",
+			TPIndex:       i + 1,
+			ClientOrderID: tpID,
+			Price:         price,
+			Quantity:      req.Quantity,
+			Status:        storage.LegStatusPlanned,
+		})
+	}
+	legs = append(legs, storage.BracketLegRecord{
+		Role:          "SL",
+		ClientOrderID: req.ClientOrderIDs.StopLoss,
+		StopPrice:     req.StopLossPrice,
+		Quantity:      req.Quantity,
+		Status:        storage.LegStatusPlanned,
+	})
+
+	return storage.BracketRecord{
+		Venue:              venue,
+		Symbol:             req.Symbol,
+		Side:               req.Side,
+		Quantity:           req.Quantity,
+		EntryPrice:         req.EntryPrice,
+		StopLossPrice:      req.StopLossPrice,
+		EntryClientOrderID: req.ClientOrderIDs.Main,
+		Status:             storage.BracketStatusReserved,
+		Legs:               legs,
+	}
+}
+
+func tpPriceAt(prices []decimal.Decimal, i int) decimal.Decimal {
+	if i < len(prices) {
+		return prices[i]
+	}
+	return decimal.Zero
+}
+
+// validateReplayMatchesReservation fails closed when a retried request
+// diverges from its durable reservation: with regenerated exit-leg ids the
+// pre-crash legs would stay live while new-id legs place cleanly beside them.
+func validateReplayMatchesReservation(rec *storage.BracketRecord, req *PlaceBracketRequest) error {
+	if rec.Symbol != req.Symbol || rec.Side != req.Side {
+		return fmt.Errorf(
+			"replayed request diverges from reservation %s: got %s/%s, reserved %s/%s",
+			rec.EntryClientOrderID, req.Symbol, req.Side, rec.Symbol, rec.Side,
+		)
+	}
+	if len(rec.Legs) == 0 {
+		return nil
+	}
+
+	want := map[string]bool{
+		req.ClientOrderIDs.Main:     true,
+		req.ClientOrderIDs.StopLoss: true,
+	}
+	for _, tpID := range req.ClientOrderIDs.TakeProfits {
+		want[tpID] = true
+	}
+	got := make(map[string]bool, len(rec.Legs))
+	for _, leg := range rec.Legs {
+		got[leg.ClientOrderID] = true
+	}
+	if !maps.Equal(want, got) {
+		return fmt.Errorf(
+			"replayed request diverges from reservation %s: leg client order ids differ",
+			rec.EntryClientOrderID,
+		)
+	}
+	return nil
+}
+
+// replayEntryState checks the exchange for the reserved entry before a
+// replayed placement: a live entry must be adopted, never re-POSTed (a
+// filled-and-closed entry frees its client id and a blind re-POST would
+// double-execute). Returns nil when the entry is confirmed not visible or
+// is terminal with zero fills — placement may proceed reusing the same ids.
+func (m *Manager) replayEntryState(
+	ctx context.Context,
+	client *binance.Client,
+	symbol, entryClientOrderID string,
+) (*binance.OrderResponse, error) {
+	existing, err := queryWithRepoll(ctx, client, symbol, entryClientOrderID)
+	if err != nil {
+		if rest.IsOrderNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("replay: cannot verify entry %s: %w", entryClientOrderID, err)
+	}
+
+	switch existing.Status {
+	case "CANCELED", "EXPIRED", "REJECTED", "EXPIRED_IN_MATCH":
+		if !existing.ExecutedQty.IsPositive() {
+			m.logger.Warn().
+				Str("symbol", symbol).
+				Str("client_order_id", entryClientOrderID).
+				Str("status", existing.Status).
+				Msg("Replayed bracket's prior entry is dead; placing fresh")
+			return nil, nil
+		}
+	}
+
+	m.logger.Warn().
+		Str("symbol", symbol).
+		Str("client_order_id", entryClientOrderID).
+		Str("status", existing.Status).
+		Msg("Replayed bracket adopted live entry from exchange")
+	return existing, nil
+}
+
+// persistPlacementOutcome records leg-level results after a placement pass;
+// best-effort — trading must not block on bookkeeping.
+func (m *Manager) persistPlacementOutcome(
+	ctx context.Context,
+	bracketID uuid.UUID,
+	placement *bracketPlacementResult,
+	critical bool,
+) {
+	if m.bracketStore == nil || bracketID == uuid.Nil {
+		return
+	}
+	// Bookkeeping must survive a caller cancel/disconnect after the POSTs.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+
+	status := storage.BracketStatusFailed
+	if !critical {
+		status = storage.BracketStatusLegsPlaced
+	}
+	if err := m.bracketStore.UpdateBracketStatus(ctx, bracketID, status); err != nil {
+		m.logger.Warn().Err(err).Str("bracket_id", bracketID.String()).
+			Msg("Failed to persist bracket status")
+	}
+	if placement == nil {
+		return
+	}
+
+	update := func(clientOrderID string, resp *binance.OrderResponse) {
+		if clientOrderID == "" {
+			return
+		}
+		legStatus := storage.LegStatusFailed
+		var exchangeID int64
+		if resp != nil {
+			legStatus = storage.LegStatusPlaced
+			exchangeID = resp.OrderID
+		}
+		if err := m.bracketStore.UpdateLegStatus(ctx, bracketID, clientOrderID, legStatus, exchangeID); err != nil {
+			m.logger.Warn().Err(err).Str("client_order_id", clientOrderID).
+				Msg("Failed to persist bracket leg status")
+		}
+	}
+
+	update(placement.IDs.Main, placement.Main)
+	for i, tpID := range placement.IDs.TakeProfits {
+		var resp *binance.OrderResponse
+		if i < len(placement.TakeProfits) {
+			resp = placement.TakeProfits[i]
+		}
+		update(tpID, resp)
+	}
+	update(placement.IDs.StopLoss, placement.StopLoss)
+}

--- a/app/router/internal/orders/spot_reconciler_test.go
+++ b/app/router/internal/orders/spot_reconciler_test.go
@@ -589,14 +589,17 @@ func TestSpotReconciler_RetriesWhenTradesLagTerminalStatus(t *testing.T) {
 
 	waitForEmitterStatus(t, emitter, "FILLED")
 	// FILLED is emitted before the trades-lag persist retry completes;
-	// wait on the ledger instead of racing it.
+	// wait on the ledger and the price-rewritten emission instead of racing.
 	require.Eventually(t, func() bool { return ledger.callCount() == 1 },
 		time.Second, 5*time.Millisecond)
+	require.Eventually(t, func() bool {
+		_, current := emitter.snapshot()
+		return current != nil && decimal.RequireFromString("50010").Equal(current.Price)
+	}, time.Second, 5*time.Millisecond)
 
 	assert.GreaterOrEqual(t, getCalls.Load(), int64(2))
 	assert.Equal(t, int64(2), tradeCalls.Load())
 	require.Len(t, ledger.latestSnapshot().Trades, 1)
-	assert.True(t, decimal.RequireFromString("50010").Equal(emitter.update.Price))
 }
 
 func TestSpotReconciler_RewritesFilledPriceToTradeWeightedAverage(t *testing.T) {

--- a/app/router/internal/storage/bracket_repo.go
+++ b/app/router/internal/storage/bracket_repo.go
@@ -1,0 +1,272 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+)
+
+// Bracket lifecycle statuses.
+const (
+	BracketStatusReserved    = "RESERVED"
+	BracketStatusEntryPlaced = "ENTRY_PLACED"
+	BracketStatusEntryFilled = "ENTRY_FILLED"
+	BracketStatusLegsPlaced  = "LEGS_PLACED"
+	BracketStatusClosed      = "CLOSED"
+	BracketStatusFailed      = "FAILED"
+)
+
+// Bracket leg statuses.
+const (
+	LegStatusPlanned  = "PLANNED"
+	LegStatusPlaced   = "PLACED"
+	LegStatusFilled   = "FILLED"
+	LegStatusCanceled = "CANCELED"
+	LegStatusExpired  = "EXPIRED"
+	LegStatusFailed   = "FAILED"
+)
+
+type BracketLegRecord struct {
+	LegID           uuid.UUID
+	BracketID       uuid.UUID
+	Role            string // ENTRY | TP | SL
+	TPIndex         int
+	ClientOrderID   string
+	ExchangeOrderID int64
+	Price           decimal.Decimal
+	StopPrice       decimal.Decimal
+	Quantity        decimal.Decimal
+	Status          string
+}
+
+type BracketRecord struct {
+	BracketID          uuid.UUID
+	Venue              string
+	Symbol             string
+	Side               string
+	Quantity           decimal.Decimal
+	EntryPrice         decimal.Decimal
+	StopLossPrice      decimal.Decimal
+	EntryClientOrderID string
+	Status             string
+	LegsOnFill         bool
+	CreatedAt          time.Time
+	Legs               []BracketLegRecord
+}
+
+type BracketRepo struct {
+	pool *pgxpool.Pool
+}
+
+func NewBracketRepo(pool *pgxpool.Pool) *BracketRepo {
+	return &BracketRepo{pool: pool}
+}
+
+// Reserve atomically claims (venue, entry_client_order_id). Exactly one
+// caller wins the insert; losers get the existing record (with legs) back.
+func (r *BracketRepo) Reserve(ctx context.Context, rec BracketRecord) (*BracketRecord, bool, error) {
+	if rec.Venue == "" || rec.EntryClientOrderID == "" {
+		return nil, false, fmt.Errorf("venue and entry client order id are required")
+	}
+	if rec.BracketID == uuid.Nil {
+		rec.BracketID = uuid.New()
+	}
+	if rec.Status == "" {
+		rec.Status = BracketStatusReserved
+	}
+
+	var inserted bool
+	err := RunInTx(ctx, r.pool, func(tx pgx.Tx) error {
+		var insertedID uuid.UUID
+		err := tx.QueryRow(ctx, `
+			INSERT INTO brackets (
+				bracket_id, venue, symbol, side, quantity, entry_price,
+				stop_loss_price, entry_client_order_id, status, legs_on_fill
+			) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+			ON CONFLICT (venue, entry_client_order_id) DO NOTHING
+			RETURNING bracket_id`,
+			rec.BracketID, rec.Venue, rec.Symbol, rec.Side, rec.Quantity,
+			rec.EntryPrice, rec.StopLossPrice, rec.EntryClientOrderID,
+			rec.Status, rec.LegsOnFill,
+		).Scan(&insertedID)
+		if errors.Is(err, pgx.ErrNoRows) {
+			inserted = false
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("insert bracket: %w", err)
+		}
+		inserted = true
+
+		for _, leg := range rec.Legs {
+			legID := leg.LegID
+			if legID == uuid.Nil {
+				legID = uuid.New()
+			}
+			status := leg.Status
+			if status == "" {
+				status = LegStatusPlanned
+			}
+			if _, err := tx.Exec(ctx, `
+				INSERT INTO bracket_legs (
+					leg_id, bracket_id, role, tp_index, client_order_id,
+					price, stop_price, quantity, status
+				) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`,
+				legID, rec.BracketID, leg.Role, leg.TPIndex, leg.ClientOrderID,
+				leg.Price, leg.StopPrice, leg.Quantity, status,
+			); err != nil {
+				return fmt.Errorf("insert bracket leg %s: %w", leg.ClientOrderID, err)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, false, err
+	}
+
+	if inserted {
+		stored := rec
+		return &stored, true, nil
+	}
+
+	existing, err := r.getByEntryClientOrderID(ctx, rec.Venue, rec.EntryClientOrderID)
+	if err != nil {
+		return nil, false, err
+	}
+	return existing, false, nil
+}
+
+func (r *BracketRepo) UpdateBracketStatus(ctx context.Context, bracketID uuid.UUID, status string) error {
+	tag, err := r.pool.Exec(ctx, `
+		UPDATE brackets SET status = $2, updated_at = CURRENT_TIMESTAMP
+		WHERE bracket_id = $1`, bracketID, status)
+	if err != nil {
+		return fmt.Errorf("update bracket status: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("update bracket status: no bracket %s", bracketID)
+	}
+	return nil
+}
+
+func (r *BracketRepo) UpdateLegStatus(
+	ctx context.Context,
+	bracketID uuid.UUID,
+	clientOrderID, status string,
+	exchangeOrderID int64,
+) error {
+	tag, err := r.pool.Exec(ctx, `
+		UPDATE bracket_legs
+		SET status = $3,
+		    exchange_order_id = NULLIF($4, 0),
+		    updated_at = CURRENT_TIMESTAMP
+		WHERE bracket_id = $1 AND client_order_id = $2`,
+		bracketID, clientOrderID, status, exchangeOrderID)
+	if err != nil {
+		return fmt.Errorf("update bracket leg status: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("update bracket leg status: no leg %s in bracket %s", clientOrderID, bracketID)
+	}
+	return nil
+}
+
+// LoadOpenBrackets returns non-terminal brackets created within lookback,
+// legs included — the work list for startup reconciliation.
+func (r *BracketRepo) LoadOpenBrackets(ctx context.Context, lookback time.Duration) ([]BracketRecord, error) {
+	rows, err := r.pool.Query(ctx, `
+		SELECT bracket_id, venue, symbol, side, quantity, entry_price,
+		       stop_loss_price, entry_client_order_id, status, legs_on_fill, created_at
+		FROM brackets
+		WHERE status NOT IN ('CLOSED', 'FAILED')
+		  AND created_at >= CURRENT_TIMESTAMP - $1::interval`,
+		fmt.Sprintf("%d seconds", int(lookback.Seconds())))
+	if err != nil {
+		return nil, fmt.Errorf("load open brackets: %w", err)
+	}
+	defer rows.Close()
+
+	var records []BracketRecord
+	for rows.Next() {
+		var rec BracketRecord
+		if err := rows.Scan(
+			&rec.BracketID, &rec.Venue, &rec.Symbol, &rec.Side, &rec.Quantity,
+			&rec.EntryPrice, &rec.StopLossPrice, &rec.EntryClientOrderID,
+			&rec.Status, &rec.LegsOnFill, &rec.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan bracket: %w", err)
+		}
+		records = append(records, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	for i := range records {
+		legs, err := r.loadLegs(ctx, records[i].BracketID)
+		if err != nil {
+			return nil, err
+		}
+		records[i].Legs = legs
+	}
+	return records, nil
+}
+
+func (r *BracketRepo) getByEntryClientOrderID(ctx context.Context, venue, entryClientOrderID string) (*BracketRecord, error) {
+	var rec BracketRecord
+	err := r.pool.QueryRow(ctx, `
+		SELECT bracket_id, venue, symbol, side, quantity, entry_price,
+		       stop_loss_price, entry_client_order_id, status, legs_on_fill, created_at
+		FROM brackets
+		WHERE venue = $1 AND entry_client_order_id = $2`,
+		venue, entryClientOrderID,
+	).Scan(
+		&rec.BracketID, &rec.Venue, &rec.Symbol, &rec.Side, &rec.Quantity,
+		&rec.EntryPrice, &rec.StopLossPrice, &rec.EntryClientOrderID,
+		&rec.Status, &rec.LegsOnFill, &rec.CreatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load bracket by entry client order id: %w", err)
+	}
+
+	legs, err := r.loadLegs(ctx, rec.BracketID)
+	if err != nil {
+		return nil, err
+	}
+	rec.Legs = legs
+	return &rec, nil
+}
+
+func (r *BracketRepo) loadLegs(ctx context.Context, bracketID uuid.UUID) ([]BracketLegRecord, error) {
+	rows, err := r.pool.Query(ctx, `
+		SELECT leg_id, bracket_id, role, tp_index, client_order_id,
+		       COALESCE(exchange_order_id, 0), COALESCE(price, 0),
+		       COALESCE(stop_price, 0), quantity, status
+		FROM bracket_legs
+		WHERE bracket_id = $1
+		ORDER BY role, tp_index`,
+		bracketID)
+	if err != nil {
+		return nil, fmt.Errorf("load bracket legs: %w", err)
+	}
+	defer rows.Close()
+
+	var legs []BracketLegRecord
+	for rows.Next() {
+		var leg BracketLegRecord
+		if err := rows.Scan(
+			&leg.LegID, &leg.BracketID, &leg.Role, &leg.TPIndex, &leg.ClientOrderID,
+			&leg.ExchangeOrderID, &leg.Price, &leg.StopPrice, &leg.Quantity, &leg.Status,
+		); err != nil {
+			return nil, fmt.Errorf("scan bracket leg: %w", err)
+		}
+		legs = append(legs, leg)
+	}
+	return legs, rows.Err()
+}

--- a/app/router/internal/storage/bracket_repo_integration_test.go
+++ b/app/router/internal/storage/bracket_repo_integration_test.go
@@ -1,0 +1,150 @@
+package storage
+
+import (
+	"context"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newBracketTestRepo(t *testing.T) (*BracketRepo, context.Context) {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	pool, err := NewPostgresPool(ctx, dsn)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+
+	// Temp tables would vanish per-connection under a pool; use real tables
+	// with a unique-suffix-free schema and clean up after ourselves.
+	_, err = pool.Exec(ctx, `CREATE EXTENSION IF NOT EXISTS pgcrypto`)
+	require.NoError(t, err)
+	migration, err := os.ReadFile("../../../../db/migrations/030_brackets.sql")
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, string(migration))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cleanupCancel()
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM bracket_legs`)
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM brackets`)
+	})
+
+	return NewBracketRepo(pool), ctx
+}
+
+func sampleBracket(entryID string) BracketRecord {
+	return BracketRecord{
+		Venue:              "SPOT",
+		Symbol:             "BTCUSDT",
+		Side:               "BUY",
+		Quantity:           decimal.RequireFromString("0.02"),
+		EntryPrice:         decimal.RequireFromString("50000"),
+		StopLossPrice:      decimal.RequireFromString("49000"),
+		EntryClientOrderID: entryID,
+		LegsOnFill:         false,
+		Legs: []BracketLegRecord{
+			{Role: "ENTRY", ClientOrderID: entryID, Price: decimal.RequireFromString("50000"), Quantity: decimal.RequireFromString("0.02")},
+			{Role: "TP", TPIndex: 1, ClientOrderID: entryID + "-tp1", Price: decimal.RequireFromString("51000"), Quantity: decimal.RequireFromString("0.02")},
+			{Role: "SL", ClientOrderID: entryID + "-sl", StopPrice: decimal.RequireFromString("49000"), Quantity: decimal.RequireFromString("0.02")},
+		},
+	}
+}
+
+func TestBracketRepo_ReserveInsertsOnceAndRoundTripsLegs(t *testing.T) {
+	repo, ctx := newBracketTestRepo(t)
+	entryID := "it-" + uuid.NewString()[:8]
+
+	first, inserted, err := repo.Reserve(ctx, sampleBracket(entryID))
+	require.NoError(t, err)
+	require.True(t, inserted)
+
+	second, insertedAgain, err := repo.Reserve(ctx, sampleBracket(entryID))
+	require.NoError(t, err)
+	assert.False(t, insertedAgain)
+	assert.Equal(t, first.BracketID, second.BracketID)
+	require.Len(t, second.Legs, 3)
+	assert.Equal(t, StatusRolesFromLegs(second.Legs), map[string]string{
+		"ENTRY": LegStatusPlanned, "TP": LegStatusPlanned, "SL": LegStatusPlanned,
+	})
+}
+
+// StatusRolesFromLegs maps role -> status for compact whole-structure asserts.
+func StatusRolesFromLegs(legs []BracketLegRecord) map[string]string {
+	out := make(map[string]string, len(legs))
+	for _, leg := range legs {
+		out[leg.Role] = leg.Status
+	}
+	return out
+}
+
+func TestBracketRepo_ConcurrentReservesElectSingleWinner(t *testing.T) {
+	repo, ctx := newBracketTestRepo(t)
+	entryID := "it-" + uuid.NewString()[:8]
+
+	const racers = 8
+	var wins atomic.Int64
+	var wg sync.WaitGroup
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, inserted, err := repo.Reserve(ctx, sampleBracket(entryID))
+			assert.NoError(t, err)
+			if inserted {
+				wins.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int64(1), wins.Load())
+}
+
+func TestBracketRepo_StatusTransitionsAndOpenBracketScan(t *testing.T) {
+	repo, ctx := newBracketTestRepo(t)
+	entryID := "it-" + uuid.NewString()[:8]
+
+	rec, inserted, err := repo.Reserve(ctx, sampleBracket(entryID))
+	require.NoError(t, err)
+	require.True(t, inserted)
+
+	require.NoError(t, repo.UpdateBracketStatus(ctx, rec.BracketID, BracketStatusEntryPlaced))
+	require.NoError(t, repo.UpdateLegStatus(ctx, rec.BracketID, entryID, LegStatusPlaced, 12345))
+
+	open, err := repo.LoadOpenBrackets(ctx, time.Hour)
+	require.NoError(t, err)
+	var found *BracketRecord
+	for i := range open {
+		if open[i].EntryClientOrderID == entryID {
+			found = &open[i]
+		}
+	}
+	require.NotNil(t, found)
+	assert.Equal(t, BracketStatusEntryPlaced, found.Status)
+	for _, leg := range found.Legs {
+		if leg.Role == "ENTRY" {
+			assert.Equal(t, [2]any{LegStatusPlaced, int64(12345)}, [2]any{leg.Status, leg.ExchangeOrderID})
+		}
+	}
+
+	require.NoError(t, repo.UpdateBracketStatus(ctx, rec.BracketID, BracketStatusClosed))
+	open, err = repo.LoadOpenBrackets(ctx, time.Hour)
+	require.NoError(t, err)
+	for i := range open {
+		assert.NotEqual(t, entryID, open[i].EntryClientOrderID, "closed bracket must leave the open scan")
+	}
+}

--- a/db/migrations/030_brackets.sql
+++ b/db/migrations/030_brackets.sql
@@ -1,0 +1,49 @@
+-- 030_brackets.sql: Durable bracket reservations and leg-level state.
+-- Owned by the Go router. The in-memory idempotency map dies with the
+-- process; these tables make check-and-reserve and replay repair survive
+-- restarts. `orders` stays exchange-acked-only; planned-but-unplaced legs
+-- live here.
+
+CREATE TABLE IF NOT EXISTS brackets (
+    bracket_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    venue TEXT NOT NULL CHECK (venue IN ('SPOT', 'USD_M')),
+    symbol TEXT NOT NULL,
+    side TEXT NOT NULL CHECK (side IN ('BUY', 'SELL')),
+    quantity NUMERIC(18,8) NOT NULL CHECK (quantity > 0),
+    entry_price NUMERIC(18,8) CHECK (entry_price IS NULL OR entry_price >= 0),
+    stop_loss_price NUMERIC(18,8) NOT NULL CHECK (stop_loss_price > 0),
+    entry_client_order_id TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (
+        status IN ('RESERVED', 'ENTRY_PLACED', 'ENTRY_FILLED', 'LEGS_PLACED', 'CLOSED', 'FAILED')
+    ),
+    legs_on_fill BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_brackets PRIMARY KEY (bracket_id),
+    CONSTRAINT uq_brackets_entry_client_order_id UNIQUE (venue, entry_client_order_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_brackets_status ON brackets (status);
+CREATE INDEX IF NOT EXISTS idx_brackets_symbol_status ON brackets (symbol, status);
+CREATE INDEX IF NOT EXISTS idx_brackets_created_at ON brackets (created_at);
+
+CREATE TABLE IF NOT EXISTS bracket_legs (
+    leg_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    bracket_id UUID NOT NULL REFERENCES brackets (bracket_id) ON DELETE CASCADE,
+    role TEXT NOT NULL CHECK (role IN ('ENTRY', 'TP', 'SL')),
+    tp_index INT NOT NULL DEFAULT 0 CHECK (tp_index >= 0),
+    client_order_id TEXT NOT NULL,
+    exchange_order_id BIGINT,
+    price NUMERIC(18,8) CHECK (price IS NULL OR price >= 0),
+    stop_price NUMERIC(18,8) CHECK (stop_price IS NULL OR stop_price >= 0),
+    quantity NUMERIC(18,8) NOT NULL CHECK (quantity >= 0),
+    status TEXT NOT NULL CHECK (
+        status IN ('PLANNED', 'PLACED', 'FILLED', 'CANCELED', 'EXPIRED', 'FAILED')
+    ),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_bracket_legs PRIMARY KEY (leg_id),
+    CONSTRAINT uq_bracket_legs_client_order_id UNIQUE (bracket_id, client_order_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_bracket_legs_bracket_id ON bracket_legs (bracket_id);
+CREATE INDEX IF NOT EXISTS idx_bracket_legs_status ON bracket_legs (status);


### PR DESCRIPTION
## Summary

C2 of the order-lifecycle series. Idempotency previously lived in a per-process map — a router restart forgot every in-flight bracket, and a retried request re-POSTed blind. This PR makes reservations durable and replays self-repairing:

- **Migration 030** (`brackets` + `bracket_legs`): reservation keyed `UNIQUE(venue, entry_client_order_id)`; leg-level status machine (`PLANNED→PLACED→FILLED/CANCELED/EXPIRED/FAILED`). `orders` stays exchange-acked-only. Additive — rollback = run the old binary; tables sit unused.
- **`BracketRepo.Reserve`**: single `INSERT ON CONFLICT DO NOTHING RETURNING` in a tx — exactly one winner; losers receive the existing record with legs. Verified by an 8-way concurrent integration test (TEST_DATABASE_URL-gated, applies the real migration).
- **Replay repair** (all three crash windows traced in review): crash-before-POST → fresh placement reusing the reserved ids; crash-after-entry → entry **adopted from the exchange, never re-POSTed** (a filled MARKET frees its id; re-POST = double-execution); crash-after-legs → #193's idempotent submission turns each leg re-POST into a duplicate-adopt (spot −2010 and futures −4116 both verified to cover LIMIT and STOP legs).
- **Divergence guard** (review HIGH, landed): a replayed request must match its reservation's symbol/side/leg-id set or fail closed — regenerated exit-leg ids would otherwise leave the pre-crash legs live alongside new ones.
- Bookkeeping is best-effort on an uncancellable ctx; zero-row updates error instead of masking id mismatches; store failure degrades to in-memory idempotency with a warning. Wired only when `DATABASE_URL` is set.

**Follow-ups noted from review** (deliberate, for C3/C6): replay is not yet leg-status-aware (CANCELED legs re-place — the startup reconciler owns richer state handling); a young-reservation safety window for instantly-executable entries on the fresh-replacement path; `LoadOpenBrackets`/`legs_on_fill`/`ENTRY_FILLED` are C3/C4 groundwork wired there.

## Test plan

- 8 manager-level tests (fake store + scripted futures fake): reserve shape (RESERVED + 3 PLANNED legs), outcome persistence (LEGS_PLACED + per-leg PLACED with exchange ids), replay-adopts-live-entry (zero entry POSTs), replay-fresh-when-invisible, all-legs-live full adoption via −4116 duplicate-adopt (zero double placements), critical-failure→FAILED, divergence fail-closed (zero exchange calls), store-error degradation
- 3 repo integration tests incl. the 8-way single-winner race
- Full router suite, `go vet`, `-race` (found and fixed a test data race), 3× flake-stable, gofmt clean
- QCHECK verdict PASS-WITH-NITS; the recommended HIGH (divergence guard) + ctx/rows-affected hardening landed in-PR

CI billing-locked — local gates; admin squash-merge to follow. **Deploy note: run `make db-migrate` (or apply 030) before rolling the router.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)