### PR TITLE
fix(router): serialized user-data dispatch + listen-key rotation on reconnect (C3)

### DIFF
--- a/app/router/cmd/router/main.go
+++ b/app/router/cmd/router/main.go
@@ -133,6 +133,7 @@ func main() {
 					return processor.HandleFuturesOrderTradeUpdate(context.Background(), event)
 				}),
 			)
+			wsClient.SetUserDataReconnectHandler(userDataIngestor.OnSocketReconnected)
 
 			if err := userDataIngestor.Start(context.Background()); err != nil {
 				logger.Fatal().Err(err).Msg("Failed to start user data ingestor")

--- a/app/router/internal/execution/ingestor.go
+++ b/app/router/internal/execution/ingestor.go
@@ -28,6 +28,7 @@ type Ingestor struct {
 	logger          zerolog.Logger
 
 	keepAliveInterval  time.Duration
+	restartBackoff     time.Duration
 	onOrderTradeUpdate func(*websocket.FuturesOrderTradeUpdateEvent) error
 
 	mu        sync.Mutex
@@ -56,6 +57,15 @@ func WithOrderTradeUpdateHandler(
 	}
 }
 
+// WithRestartBackoff sets the base delay between stream-restart retries.
+func WithRestartBackoff(backoff time.Duration) IngestorOption {
+	return func(i *Ingestor) {
+		if backoff > 0 {
+			i.restartBackoff = backoff
+		}
+	}
+}
+
 func NewIngestor(
 	listenKeyClient ListenKeyClient,
 	subscriber UserDataSubscriber,
@@ -67,6 +77,7 @@ func NewIngestor(
 		subscriber:        subscriber,
 		logger:            logger,
 		keepAliveInterval: 30 * time.Minute,
+		restartBackoff:    time.Second,
 		done:              make(chan struct{}),
 	}
 	for _, opt := range opts {
@@ -166,6 +177,30 @@ func (i *Ingestor) startWithNewListenKey(ctx context.Context) error {
 	return nil
 }
 
+// OnSocketReconnected rotates the listen key after a socket-level reconnect
+// (or reconnect exhaustion). Binance invalidates the session server-side, so
+// without this only a listenKeyExpired event (which the dead socket cannot
+// deliver) would recover the user-data stream. Events for keys we no longer
+// own are ignored so a raced zombie connection cannot kill a healthy one.
+func (i *Ingestor) OnSocketReconnected(listenKey string) {
+	i.mu.Lock()
+	current := i.listenKey
+	i.mu.Unlock()
+	if listenKey != "" && current != "" && listenKey != current {
+		i.logger.Debug().
+			Str("listen_key", listenKey).
+			Str("current", current).
+			Msg("ignoring reconnect signal for stale listen key")
+		return
+	}
+
+	i.logger.Warn().Str("listen_key", listenKey).
+		Msg("user data socket reconnected; rotating listen key")
+	if err := i.restartSerialized(context.Background()); err != nil {
+		i.logger.Error().Err(err).Msg("failed to restart user data stream after reconnect")
+	}
+}
+
 // restartSerialized ensures only one restart runs at a time.
 // If a restart is already in progress, additional calls return immediately.
 func (i *Ingestor) restartSerialized(ctx context.Context) error {
@@ -197,7 +232,29 @@ func (i *Ingestor) restart(ctx context.Context) error {
 		_ = i.listenKeyClient.DeleteFuturesListenKey(ctx, oldKey)
 	}
 
-	return i.startWithNewListenKey(ctx)
+	// The failure that forced a rotation (network trouble) is exactly when
+	// the new listen-key request will also fail; a single silent failure
+	// here would leave orders flowing with fills invisible. Retry with
+	// backoff until the stream is back or the ingestor stops.
+	backoff := i.restartBackoff
+	for {
+		err := i.startWithNewListenKey(ctx)
+		if err == nil {
+			return nil
+		}
+		i.logger.Error().Err(err).Dur("retry_in", backoff).
+			Msg("failed to restart user data stream; retrying")
+		select {
+		case <-i.done:
+			return err
+		case <-ctx.Done():
+			return err
+		case <-time.After(backoff):
+		}
+		if backoff < 30*time.Second {
+			backoff *= 2
+		}
+	}
 }
 
 func (i *Ingestor) keepAliveLoop(ctx context.Context) {

--- a/app/router/internal/execution/ingestor_test.go
+++ b/app/router/internal/execution/ingestor_test.go
@@ -20,6 +20,7 @@ type mockListenKeyClient struct {
 	deleted        []string
 	nextListenKeys []string
 	createDelay    time.Duration // Optional delay to simulate network latency
+	failCreates    int           // Fail this many CreateFuturesListenKey calls first
 }
 
 func (m *mockListenKeyClient) CreateFuturesListenKey(ctx context.Context) (string, error) {
@@ -33,6 +34,10 @@ func (m *mockListenKeyClient) CreateFuturesListenKey(ctx context.Context) (strin
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.failCreates > 0 {
+		m.failCreates--
+		return "", fmt.Errorf("simulated listen key failure")
+	}
 	if len(m.nextListenKeys) == 0 {
 		return "", fmt.Errorf("no more listen keys available in mock")
 	}
@@ -255,4 +260,71 @@ func TestIngestor_ForwardsOrderTradeUpdatesToCallback(t *testing.T) {
 		defer mu.Unlock()
 		return got != nil && got.OrderTradeUpdate.TradeID == 123
 	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func TestIngestor_OnSocketReconnectedRotatesListenKey(t *testing.T) {
+	lk := &mockListenKeyClient{nextListenKeys: []string{"lk-1", "lk-2"}}
+	sub := &mockSubscriber{}
+	logger := zerolog.Nop()
+
+	ing := NewIngestor(lk, sub, logger, WithKeepAliveInterval(0))
+	require.NoError(t, ing.Start(context.Background()))
+	t.Cleanup(func() { _ = ing.Stop(context.Background()) })
+
+	ing.OnSocketReconnected("lk-1")
+
+	require.Eventually(t, func() bool {
+		sub.mu.Lock()
+		defer sub.mu.Unlock()
+		_, ok := sub.handlers["lk-2"]
+		return ok
+	}, 2*time.Second, 10*time.Millisecond, "socket reconnect must rotate to a fresh listen key")
+
+	lk.mu.Lock()
+	defer lk.mu.Unlock()
+	require.Equal(t, []string{"lk-1"}, lk.deleted, "stale listen key must be deleted")
+}
+
+func TestIngestor_OnSocketReconnectedIgnoresStaleListenKey(t *testing.T) {
+	lk := &mockListenKeyClient{nextListenKeys: []string{"lk-1", "lk-2"}}
+	sub := &mockSubscriber{}
+	logger := zerolog.Nop()
+
+	ing := NewIngestor(lk, sub, logger, WithKeepAliveInterval(0))
+	require.NoError(t, ing.Start(context.Background()))
+	t.Cleanup(func() { _ = ing.Stop(context.Background()) })
+
+	ing.OnSocketReconnected("lk-zombie")
+
+	time.Sleep(50 * time.Millisecond)
+	lk.mu.Lock()
+	defer lk.mu.Unlock()
+	require.Equal(t, []string{"lk-1"}, lk.created, "stale key signal must not rotate a healthy stream")
+	require.Empty(t, lk.deleted)
+}
+
+func TestIngestor_RestartRetriesUntilListenKeyAvailable(t *testing.T) {
+	lk := &mockListenKeyClient{nextListenKeys: []string{"lk-1", "lk-2"}}
+	sub := &mockSubscriber{}
+	logger := zerolog.Nop()
+
+	ing := NewIngestor(lk, sub, logger,
+		WithKeepAliveInterval(0),
+		WithRestartBackoff(5*time.Millisecond),
+	)
+	require.NoError(t, ing.Start(context.Background()))
+	t.Cleanup(func() { _ = ing.Stop(context.Background()) })
+	lk.mu.Lock()
+	lk.failCreates = 2
+	lk.mu.Unlock()
+
+	ing.OnSocketReconnected("lk-1")
+
+	require.Eventually(t, func() bool {
+		sub.mu.Lock()
+		defer sub.mu.Unlock()
+		_, ok := sub.handlers["lk-2"]
+		return ok
+	}, 2*time.Second, 5*time.Millisecond,
+		"rotation must retry through listen-key creation failures")
 }

--- a/app/router/internal/websocket/client.go
+++ b/app/router/internal/websocket/client.go
@@ -26,6 +26,28 @@ type Client struct {
 	tickerHandlers map[string]func(*TickerEvent) error
 	userHandlers   map[string]*UserDataHandler
 	handlersMu     sync.RWMutex
+
+	userDataReconnectHandler func(listenKey string)
+	reconnectHandlerMu       sync.RWMutex
+}
+
+// SetUserDataReconnectHandler registers a callback invoked when a user-data
+// socket reconnects (or exhausts its reconnect attempts); the listen-key
+// owner must rotate and resubscribe. The key identifies which stream fired
+// so stale connections cannot disturb a healthy successor.
+func (c *Client) SetUserDataReconnectHandler(fn func(listenKey string)) {
+	c.reconnectHandlerMu.Lock()
+	defer c.reconnectHandlerMu.Unlock()
+	c.userDataReconnectHandler = fn
+}
+
+func (c *Client) notifyUserDataReconnect(listenKey string) {
+	c.reconnectHandlerMu.RLock()
+	fn := c.userDataReconnectHandler
+	c.reconnectHandlerMu.RUnlock()
+	if fn != nil {
+		fn(listenKey)
+	}
 }
 
 // ClientOption configures the client
@@ -271,6 +293,7 @@ func (c *Client) SubscribeToUserData(ctx context.Context, listenKey string, hand
 		client:    c,
 		listenKey: listenKey,
 	})
+	userMgr.SetReconnectHandler(func() { c.notifyUserDataReconnect(listenKey) })
 
 	// Connect if not already connected
 	if userMgr.State() != StateConnected {

--- a/app/router/internal/websocket/connection.go
+++ b/app/router/internal/websocket/connection.go
@@ -43,10 +43,31 @@ type Connection struct {
 	doneOnce  sync.Once
 	doneMutex sync.Mutex // Protects doneChan recreation
 
+	// Serialized dispatch: user-data ordering depends on one consumer.
+	// dispatchStop is never recreated (closeChan is, on reconnect).
+	dispatchChan     chan []byte
+	dispatchStop     chan struct{}
+	dispatchOnce     sync.Once
+	dispatchStopOnce sync.Once
+
+	reconnectHandler   func()
+	reconnectHandlerMu sync.RWMutex
+
 	// Reconnection state
 	reconnectAttempts int
 	reconnecting      bool
 	reconnectMu       sync.Mutex
+}
+
+const defaultDispatchBufferSize = 1024
+
+// WithDispatchBuffer sets the serialized-dispatch queue capacity.
+func WithDispatchBuffer(size int) ConnectionOption {
+	return func(c *Connection) {
+		if size > 0 {
+			c.dispatchChan = make(chan []byte, size)
+		}
+	}
 }
 
 // ConnectionOption configures connection behavior
@@ -115,13 +136,66 @@ func NewConnection(url string, opts ...ConnectionOption) *Connection {
 		reconnectInterval:    5 * time.Second,
 		closeChan:            make(chan struct{}),
 		doneChan:             make(chan struct{}),
+		dispatchStop:         make(chan struct{}),
 	}
 
 	for _, opt := range opts {
 		opt(conn)
 	}
 
+	if conn.dispatchChan == nil {
+		conn.dispatchChan = make(chan []byte, defaultDispatchBufferSize)
+	}
+
 	return conn
+}
+
+// SetReconnectHandler registers a callback invoked after a successful
+// automatic reconnection, and also when reconnection attempts are exhausted
+// (the listen-key owner must rotate and rebuild in both cases).
+func (c *Connection) SetReconnectHandler(fn func()) {
+	c.reconnectHandlerMu.Lock()
+	defer c.reconnectHandlerMu.Unlock()
+	c.reconnectHandler = fn
+}
+
+func (c *Connection) fireReconnectHandler() {
+	c.reconnectHandlerMu.RLock()
+	fn := c.reconnectHandler
+	c.reconnectHandlerMu.RUnlock()
+	if fn != nil {
+		go fn()
+	}
+}
+
+func (c *Connection) deliver(message []byte) {
+	c.handlerMu.RLock()
+	handler := c.messageHandler
+	c.handlerMu.RUnlock()
+	if handler != nil {
+		handler(message)
+	}
+}
+
+// dispatchLoop delivers messages to the handler one at a time, preserving
+// the exchange's per-connection ordering end to end. On stop it drains the
+// queue: already-read fill events must never be silently discarded.
+func (c *Connection) dispatchLoop() {
+	for {
+		select {
+		case message := <-c.dispatchChan:
+			c.deliver(message)
+		case <-c.dispatchStop:
+			for {
+				select {
+				case message := <-c.dispatchChan:
+					c.deliver(message)
+				default:
+					return
+				}
+			}
+		}
+	}
 }
 
 // URL returns the WebSocket URL
@@ -167,6 +241,19 @@ func (c *Connection) ReadTimeout() time.Duration {
 func (c *Connection) Connect(ctx context.Context) error {
 	if c.State() == StateConnected {
 		return fmt.Errorf("already connected")
+	}
+	if c.State() == StateClosed {
+		return fmt.Errorf("connection is closed")
+	}
+
+	// A prior socket may still be half-alive (pong timeout with data
+	// flowing); close it so only one read loop ever feeds the dispatcher.
+	c.connMu.Lock()
+	previous := c.conn
+	c.conn = nil
+	c.connMu.Unlock()
+	if previous != nil {
+		_ = previous.Close()
 	}
 
 	c.setState(StateConnecting)
@@ -223,9 +310,15 @@ func (c *Connection) Connect(ctx context.Context) error {
 		return err
 	}
 
+	if c.State() == StateClosed {
+		// Closed while dialing (e.g. a listen-key rotation raced us)
+		_ = conn.Close()
+		return fmt.Errorf("connection closed during connect")
+	}
 	c.setState(StateConnected)
 
-	// Start background goroutines
+	// Start background goroutines; one dispatch loop per Connection lifetime
+	c.dispatchOnce.Do(func() { go c.dispatchLoop() })
 	go c.startPingLoop()
 	go c.startReadLoop()
 
@@ -289,6 +382,7 @@ func (c *Connection) Close() error {
 	default:
 		close(c.closeChan)
 	}
+	c.dispatchStopOnce.Do(func() { close(c.dispatchStop) })
 
 	// Wait a moment for ongoing operations to complete
 	time.Sleep(10 * time.Millisecond)
@@ -453,13 +547,12 @@ func (c *Connection) startReadLoop() {
 			return
 		}
 
-		// Handle message
-		c.handlerMu.RLock()
-		handler := c.messageHandler
-		c.handlerMu.RUnlock()
-
-		if handler != nil {
-			go handler(message)
+		// Enqueue for serialized dispatch; a full queue backpressures the
+		// read loop (TCP flow control) rather than dropping or reordering.
+		select {
+		case c.dispatchChan <- message:
+		case <-c.dispatchStop:
+			return
 		}
 	}
 }
@@ -530,12 +623,15 @@ func (c *Connection) attemptReconnection() {
 		if err == nil {
 			// Connection established - but don't reset attempts yet
 			// Let the connection prove it's stable before declaring success
+			c.fireReconnectHandler()
 			return
 		}
 
 		// Continue loop to try again if we haven't exceeded max attempts
 	}
 
-	// All reconnection attempts failed
+	// All reconnection attempts failed: still fire the handler so the
+	// listen-key owner can rebuild from scratch instead of going deaf.
 	c.setState(StateDisconnected)
+	c.fireReconnectHandler()
 }

--- a/app/router/internal/websocket/dispatch_test.go
+++ b/app/router/internal/websocket/dispatch_test.go
@@ -1,0 +1,208 @@
+package websocket
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnection_DispatchPreservesArrivalOrder(t *testing.T) {
+	const messageCount = 50
+	server := newMockWebSocketServer(t, func(conn *websocket.Conn) {
+		for i := 0; i < messageCount; i++ {
+			if err := conn.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf("msg-%03d", i))); err != nil {
+				return
+			}
+		}
+		select {} // hold the connection open
+	})
+	defer server.Close()
+
+	var mu sync.Mutex
+	var received []string
+	var firstDelay sync.Once
+	done := make(chan struct{})
+
+	conn := NewConnection(getWebSocketURL(server.URL))
+	conn.SetMessageHandler(func(message []byte) {
+		// A slow first handler would let go-per-message dispatch reorder;
+		// serialized dispatch must still deliver in arrival order.
+		firstDelay.Do(func() { time.Sleep(100 * time.Millisecond) })
+		mu.Lock()
+		received = append(received, string(message))
+		if len(received) == messageCount {
+			close(done)
+		}
+		mu.Unlock()
+	})
+
+	require.NoError(t, conn.Connect(context.Background()))
+	defer func() { _ = conn.Close() }()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for messages")
+	}
+
+	expected := make([]string, messageCount)
+	for i := range expected {
+		expected[i] = fmt.Sprintf("msg-%03d", i)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, expected, received)
+}
+
+func TestConnection_FullDispatchQueueBackpressuresWithoutDropping(t *testing.T) {
+	const messageCount = 10
+	server := newMockWebSocketServer(t, func(conn *websocket.Conn) {
+		for i := 0; i < messageCount; i++ {
+			if err := conn.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf("m%d", i))); err != nil {
+				return
+			}
+		}
+		select {}
+	})
+	defer server.Close()
+
+	gate := make(chan struct{})
+	var handled atomic.Int64
+
+	conn := NewConnection(getWebSocketURL(server.URL), WithDispatchBuffer(1))
+	conn.SetMessageHandler(func([]byte) {
+		<-gate
+		handled.Add(1)
+	})
+
+	require.NoError(t, conn.Connect(context.Background()))
+	defer func() { _ = conn.Close() }()
+
+	// Handler blocked, buffer size 1: nothing may be dropped meanwhile.
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, int64(0), handled.Load())
+
+	close(gate)
+	require.Eventually(t, func() bool {
+		return handled.Load() == messageCount
+	}, 5*time.Second, 10*time.Millisecond, "all messages must survive backpressure")
+}
+
+func TestConnection_CloseTerminatesDispatch(t *testing.T) {
+	server := newMockWebSocketServer(t, func(conn *websocket.Conn) {
+		select {}
+	})
+	defer server.Close()
+
+	conn := NewConnection(getWebSocketURL(server.URL))
+	conn.SetMessageHandler(func([]byte) {})
+
+	require.NoError(t, conn.Connect(context.Background()))
+	require.NoError(t, conn.Close())
+
+	select {
+	case <-conn.dispatchStop:
+	default:
+		t.Fatal("dispatchStop must be closed after Close")
+	}
+}
+
+func TestConnection_ReconnectHandlerFiresAfterSocketReconnect(t *testing.T) {
+	var connCount atomic.Int64
+	server := newMockWebSocketServer(t, func(conn *websocket.Conn) {
+		n := connCount.Add(1)
+		if n == 1 {
+			_ = conn.Close() // kill the first connection to force a reconnect
+			return
+		}
+		select {}
+	})
+	defer server.Close()
+
+	var reconnects atomic.Int64
+	conn := NewConnection(getWebSocketURL(server.URL),
+		WithAutoReconnect(true),
+		WithMaxReconnectAttempts(5),
+		WithReconnectInterval(10*time.Millisecond),
+	)
+	conn.SetReconnectHandler(func() { reconnects.Add(1) })
+	conn.SetMessageHandler(func([]byte) {})
+
+	require.NoError(t, conn.Connect(context.Background()))
+	defer func() { _ = conn.Close() }()
+
+	require.Eventually(t, func() bool {
+		return reconnects.Load() >= 1
+	}, 5*time.Second, 10*time.Millisecond, "reconnect handler must fire after socket recovery")
+}
+
+func TestConnection_CloseDrainsQueuedMessages(t *testing.T) {
+	const messageCount = 5
+	server := newMockWebSocketServer(t, func(conn *websocket.Conn) {
+		for i := 0; i < messageCount; i++ {
+			if err := conn.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf("m%d", i))); err != nil {
+				return
+			}
+		}
+		select {}
+	})
+	defer server.Close()
+
+	gate := make(chan struct{})
+	var handled atomic.Int64
+
+	conn := NewConnection(getWebSocketURL(server.URL), WithDispatchBuffer(messageCount))
+	conn.SetMessageHandler(func([]byte) {
+		<-gate
+		handled.Add(1)
+	})
+
+	require.NoError(t, conn.Connect(context.Background()))
+	time.Sleep(200 * time.Millisecond) // let all messages enqueue behind the gate
+	require.NoError(t, conn.Close())
+	close(gate)
+
+	require.Eventually(t, func() bool {
+		return handled.Load() == messageCount
+	}, 5*time.Second, 10*time.Millisecond,
+		"already-received fill events must be drained on close, never dropped")
+}
+
+func TestConnection_ReconnectHandlerNotFiredOnFirstConnect(t *testing.T) {
+	server := newMockWebSocketServer(t, func(conn *websocket.Conn) {
+		select {}
+	})
+	defer server.Close()
+
+	var reconnects atomic.Int64
+	conn := NewConnection(getWebSocketURL(server.URL), WithAutoReconnect(true))
+	conn.SetReconnectHandler(func() { reconnects.Add(1) })
+	conn.SetMessageHandler(func([]byte) {})
+
+	require.NoError(t, conn.Connect(context.Background()))
+	defer func() { _ = conn.Close() }()
+
+	time.Sleep(150 * time.Millisecond)
+	assert.Equal(t, int64(0), reconnects.Load())
+}
+
+func TestConnection_ConnectAfterCloseFailsLoudly(t *testing.T) {
+	server := newMockWebSocketServer(t, func(conn *websocket.Conn) {
+		select {}
+	})
+	defer server.Close()
+
+	conn := NewConnection(getWebSocketURL(server.URL))
+	require.NoError(t, conn.Connect(context.Background()))
+	require.NoError(t, conn.Close())
+
+	err := conn.Connect(context.Background())
+	require.Error(t, err, "a closed connection has a dead dispatch loop; reuse must fail loudly")
+}

--- a/app/router/internal/websocket/streams.go
+++ b/app/router/internal/websocket/streams.go
@@ -320,6 +320,11 @@ func (sm *StreamManager) SetUserStreamHandler(handler UserStreamHandler) {
 	sm.userHandler = handler
 }
 
+// SetReconnectHandler forwards a socket-reconnect callback to the connection.
+func (sm *StreamManager) SetReconnectHandler(fn func()) {
+	sm.conn.SetReconnectHandler(fn)
+}
+
 // SetEventHandler sets the generic event handler
 func (sm *StreamManager) SetEventHandler(handler EventHandler) {
 	sm.handlersMu.Lock()


### PR DESCRIPTION
## Summary

C3 of the order-lifecycle series — the event-transport prerequisites for C4's fill-triggered protective legs.

- **Ordered dispatch**: `go handler(message)` per frame meant fills could process out of order. One dispatch loop per connection now drains a bounded queue (1024, test-injectable); a full queue backpressures the read loop via TCP flow control — never drops, never reorders. Review-verified airtight through `handleMessage → routeStreamMessage → OnOrderTradeUpdate → trade processor`.
- **Drain on close** (review BLOCK finding, fixed): closing a connection previously could discard up to a queue's worth of already-read fill events — Binance never replays user-data. The dispatch loop now drains before exiting, pinned by a gated-handler test.
- **Listen-key rotation on socket reconnect**: only a `listenKeyExpired` event rotated the key before — an event a dead socket cannot deliver. Reconnect success AND reconnect exhaustion now fire a handler → ingestor rotates (single-flight). **Rotation retries with backoff** (review BLOCK finding, fixed): the network incident that forced the rotation is exactly when the new listen-key request also fails; one silent failure must not leave orders flowing with fills invisible.
- **Single-producer hygiene** (review M1/M2): `Connect` closes any half-alive prior socket (pong-timeout reconnects) and refuses closed connections; reconnect signals carry the listen key so a raced zombie cannot rotate a healthy successor.

Cut per plan: per-symbol sharded dispatch (the router's WS use is the user-data stream only — global serialization is sufficient and simpler to reason about).

## Test plan

- 7 new connection tests: arrival-order under a slow first handler (discriminates against the old dispatch), backpressure-without-drops (buffer 1), drain-on-close, close-terminates-loop, reconnect-handler-fires, not-fired-on-first-connect, connect-after-close-fails-loudly
- 3 new ingestor tests: rotation on reconnect (fresh key + stale key deleted), stale-key signal ignored, retry-through-creation-failures
- Full router suite, `go vet`, `-race` on websocket+execution, 3× flake-stable, gofmt clean
- QCHECK: BLOCK (drop-on-close + silent rotation death) → all HIGHs and MEDIUMs fixed → gates re-run green

CI billing-locked — local gates; admin squash-merge to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)