### PR TITLE
feat(router): fill-triggered futures protective legs — BRACKET_LEGS_ON_FILL (C4)

### DIFF
--- a/app/router/cmd/router/main.go
+++ b/app/router/cmd/router/main.go
@@ -73,6 +73,20 @@ func main() {
 	var userDataIngestor *execution.Ingestor
 	var spotTradeProcessor *execution.SpotTradeProcessor
 	var fundingCancel context.CancelFunc
+	var legArmer *orders.LegArmer
+
+	// Create event emitter (needed by the leg armer inside the DB block)
+	var eventEmitter orders.EventEmitter
+	orderUpdateURL := os.Getenv("ORDER_UPDATE_URL")
+	if orderUpdateURL != "" {
+		eventEmitter = orders.NewHTTPEventEmitter(orderUpdateURL)
+		logger.Info().Str("url", orderUpdateURL).Msg("Order updates will be sent via HTTP")
+	} else {
+		eventEmitter = orders.NewLogEventEmitter(logger)
+		logger.Info().Msg("Order updates will be logged to console")
+	}
+
+	legsOnFill, _ := strconv.ParseBool(os.Getenv("BRACKET_LEGS_ON_FILL"))
 
 	if databaseURL := os.Getenv("DATABASE_URL"); databaseURL != "" {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -125,12 +139,26 @@ func main() {
 				logger.Fatal().Err(err).Msg("Failed to initialize trade processor")
 			}
 
+			if legsOnFill && futuresClient != nil {
+				legArmer = orders.NewLegArmer(
+					storage.NewBracketRepo(dbPool),
+					futuresClient,
+					eventEmitter,
+					logger.With().Str("component", "leg_armer").Logger(),
+				)
+				logger.Info().Msg("BRACKET_LEGS_ON_FILL enabled: futures exit legs placed on entry fill")
+			}
+
 			userDataIngestor = execution.NewIngestor(
 				futuresRestClient,
 				wsClient,
 				logger.With().Str("component", "user_stream").Logger(),
 				execution.WithOrderTradeUpdateHandler(func(event *websocket.FuturesOrderTradeUpdateEvent) error {
-					return processor.HandleFuturesOrderTradeUpdate(context.Background(), event)
+					err := processor.HandleFuturesOrderTradeUpdate(context.Background(), event)
+					if legArmer != nil {
+						legArmer.OnOrderTradeUpdate(context.Background(), event)
+					}
+					return err
 				}),
 			)
 			wsClient.SetUserDataReconnectHandler(userDataIngestor.OnSocketReconnected)
@@ -166,22 +194,18 @@ func main() {
 		logger.Warn().Msg("DATABASE_URL not set; router persistence disabled")
 	}
 
-	// Create event emitter
-	var eventEmitter orders.EventEmitter
-	orderUpdateURL := os.Getenv("ORDER_UPDATE_URL")
-	if orderUpdateURL != "" {
-		eventEmitter = orders.NewHTTPEventEmitter(orderUpdateURL)
-		logger.Info().Str("url", orderUpdateURL).Msg("Order updates will be sent via HTTP")
-	} else {
-		eventEmitter = orders.NewLogEventEmitter(logger)
-		logger.Info().Msg("Order updates will be logged to console")
-	}
-
 	// Create order manager
 	orderManager := orders.NewManager(spotClient, futuresClient, eventEmitter, logger)
 	if dbPool != nil {
 		orderManager.SetBracketStore(storage.NewBracketRepo(dbPool))
 		logger.Info().Msg("Durable bracket reservations enabled")
+	}
+	if legArmer != nil {
+		// Deferring legs is only safe when an armer exists to place them
+		orderManager.SetLegsOnFill(true)
+	} else if legsOnFill {
+		logger.Warn().Msg("BRACKET_LEGS_ON_FILL set but DATABASE_URL or futures trading " +
+			"is missing; exit legs will place synchronously")
 	}
 	var spotReconciler *orders.SpotReconciler
 	if spotClient != nil {

--- a/app/router/internal/orders/bracket.go
+++ b/app/router/internal/orders/bracket.go
@@ -166,7 +166,10 @@ func (m *Manager) placeSpotBracket(ctx context.Context, client *binance.Client, 
 // placeFuturesBracket places a bracket order for futures trading. A non-nil
 // adoptedEntry is a replayed entry already live on the exchange: it is used
 // as the main order instead of POSTing, and exit legs place idempotently.
-func (m *Manager) placeFuturesBracket(ctx context.Context, client *binance.Client, req *PlaceBracketRequest, bracketID string, adoptedEntry *binance.OrderResponse) (*bracketPlacementResult, error) {
+// With legsDeferred the exit legs stay PLANNED for the leg armer to place on
+// entry fill — a ReduceOnly TP POSTed before any position exists is rejected
+// with -2022, which is the bug this mode fixes.
+func (m *Manager) placeFuturesBracket(ctx context.Context, client *binance.Client, req *PlaceBracketRequest, bracketID string, adoptedEntry *binance.OrderResponse, legsDeferred bool) (*bracketPlacementResult, error) {
 	result := &bracketPlacementResult{
 		IDs: ClientOrderIDs{
 			TakeProfits: make([]string, len(req.TakeProfitPrices)),
@@ -207,6 +210,17 @@ func (m *Manager) placeFuturesBracket(ctx context.Context, client *binance.Clien
 	}
 	result.IDs.Main = mainOrderID
 	result.Main = mainResp
+
+	if legsDeferred {
+		// Report the reserved exit-leg ids; the leg armer places them on fill
+		copy(result.IDs.TakeProfits, plannedIDs.TakeProfits)
+		result.IDs.StopLoss = plannedIDs.StopLoss
+		m.logger.Info().
+			Str("symbol", req.Symbol).
+			Str("bracket_id", bracketID).
+			Msg("Exit legs deferred until entry fill")
+		return result, nil
+	}
 
 	// 2. Place take profit orders with ReduceOnly
 	tpStep, err := client.StepSize(ctx, req.Symbol)

--- a/app/router/internal/orders/bracket_store_test.go
+++ b/app/router/internal/orders/bracket_store_test.go
@@ -58,6 +58,13 @@ func (f *fakeBracketStore) UpdateBracketStatus(_ context.Context, _ uuid.UUID, s
 	return nil
 }
 
+func (f *fakeBracketStore) UpdateBracketStatusIf(_ context.Context, _ uuid.UUID, _, status string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.bracketUpdates = append(f.bracketUpdates, status)
+	return true, nil
+}
+
 func (f *fakeBracketStore) UpdateLegStatus(_ context.Context, _ uuid.UUID, clientOrderID, status string, _ int64) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -67,11 +74,13 @@ func (f *fakeBracketStore) UpdateLegStatus(_ context.Context, _ uuid.UUID, clien
 
 // bracketExchange serves the futures order endpoints, recording POSTed ids.
 type bracketExchange struct {
-	mu         sync.Mutex
-	postedIDs  []string
-	getStatus  int             // GET /fapi/v1/order: 200 live NEW order, else -2013
-	postDupIDs map[string]bool // POSTs of these ids are rejected as -4116 duplicates
-	failPosts  bool            // all POSTs fail with a non-retryable -1102
+	mu             sync.Mutex
+	postedIDs      []string
+	getStatus      int             // GET /fapi/v1/order: 200 live order, else -2013
+	getOrderStatus string          // order status served on GET 200 (default NEW)
+	getExecutedQty string          // executed qty served on GET 200 (default "0")
+	postDupIDs     map[string]bool // POSTs of these ids are rejected as -4116 duplicates
+	failPosts      bool            // all POSTs fail with a non-retryable -1102
 }
 
 func (f *bracketExchange) posted() []string {
@@ -125,10 +134,18 @@ func (f *bracketExchange) handler() http.HandlerFunc {
 			})
 		case http.MethodGet:
 			if f.getStatus == http.StatusOK {
+				orderStatus := f.getOrderStatus
+				if orderStatus == "" {
+					orderStatus = "NEW"
+				}
+				executedQty := f.getExecutedQty
+				if executedQty == "" {
+					executedQty = "0"
+				}
 				_ = json.NewEncoder(w).Encode(map[string]any{
-					"orderId": 777, "symbol": q.Get("symbol"), "status": "NEW",
+					"orderId": 777, "symbol": q.Get("symbol"), "status": orderStatus,
 					"clientOrderId": q.Get("origClientOrderId"), "price": "50000", "avgPrice": "0",
-					"origQty": "0.02", "executedQty": "0", "cumQuote": "0",
+					"origQty": "0.02", "executedQty": executedQty, "cumQuote": "0",
 					"timeInForce": "GTC", "type": "LIMIT", "side": "BUY",
 					"stopPrice": "0", "updateTime": 1,
 				})
@@ -330,4 +347,73 @@ func TestPlaceBracketOrder_StoreErrorDegradesToInMemory(t *testing.T) {
 	assert.Len(t, fake.posted(), 3)
 	assert.Empty(t, store.bracketUpdates, "no reservation id, so no status writes")
 	assert.Equal(t, "engine-main-9", resp.ClientOrderIDs.Main)
+}
+
+func TestPlaceBracketOrder_LegsOnFillDefersExitLegs(t *testing.T) {
+	store := newFakeBracketStore()
+	fake := &bracketExchange{}
+	manager := newStoreFixture(t, fake, store)
+	manager.SetLegsOnFill(true)
+
+	resp, err := manager.PlaceBracketOrder(context.Background(), storeBracketRequest())
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"engine-main-9"}, fake.posted(),
+		"only the entry may be POSTed before it fills")
+	assert.True(t, resp.LegsPendingTrigger)
+	assert.Equal(t, ClientOrderIDs{
+		Main:        "engine-main-9",
+		TakeProfits: []string{"engine-tp-9"},
+		StopLoss:    "engine-sl-9",
+	}, resp.ClientOrderIDs, "reserved exit-leg ids must still be reported")
+	require.Len(t, store.reserved, 1)
+	assert.True(t, store.reserved[0].LegsOnFill)
+	assert.Equal(t, []string{storage.BracketStatusEntryPlaced}, store.bracketUpdates)
+	assert.Equal(t, map[string]string{"engine-main-9": storage.LegStatusPlaced}, store.legUpdates,
+		"exit legs must stay PLANNED for the armer")
+}
+
+func TestPlaceBracketOrder_LegsOnFillWithoutStoreStaysSynchronous(t *testing.T) {
+	fake := &bracketExchange{}
+	server := httptest.NewServer(fake.handler())
+	t.Cleanup(server.Close)
+	signer := auth.NewSignerWithRecvWindow("key", "secret", 5000)
+	futuresRest := rest.NewClient(server.URL, signer)
+	futuresClient, err := binance.NewFuturesClient(server.URL, signer, futuresRest, zerolog.Nop())
+	require.NoError(t, err)
+	manager := NewManager(nil, futuresClient, nil, zerolog.Nop())
+	manager.SetLegsOnFill(true) // no bracket store installed
+
+	resp, err := manager.PlaceBracketOrder(context.Background(), storeBracketRequest())
+
+	require.NoError(t, err)
+	assert.Len(t, fake.posted(), 3, "without durable legs, deferral would lose them on crash")
+	assert.False(t, resp.LegsPendingTrigger)
+}
+
+func TestPlaceBracketOrder_ReplayAdoptedFilledEntryPlacesLegsSynchronously(t *testing.T) {
+	store := newFakeBracketStore()
+	store.existingRecord = &storage.BracketRecord{
+		BracketID:          uuid.New(),
+		Venue:              "USD_M",
+		Symbol:             "BTCUSDT",
+		Side:               "BUY",
+		EntryClientOrderID: "engine-main-9",
+		Status:             storage.BracketStatusEntryPlaced,
+		LegsOnFill:         true,
+	}
+	fake := &bracketExchange{
+		getStatus:      http.StatusOK,
+		getOrderStatus: "FILLED",
+		getExecutedQty: "0.02",
+	}
+	manager := newStoreFixture(t, fake, store)
+	manager.SetLegsOnFill(true)
+
+	resp, err := manager.PlaceBracketOrder(context.Background(), storeBracketRequest())
+
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"engine-tp-9", "engine-sl-9"}, fake.posted(),
+		"the fill event is gone forever; legs must place now, not wait for it")
+	assert.False(t, resp.LegsPendingTrigger)
 }

--- a/app/router/internal/orders/leg_armer.go
+++ b/app/router/internal/orders/leg_armer.go
@@ -1,0 +1,367 @@
+package orders
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/shopspring/decimal"
+
+	"router/internal/binance"
+	"router/internal/storage"
+	"router/internal/websocket"
+)
+
+// armerStore is the slice of the bracket store the leg armer needs.
+type armerStore interface {
+	GetByEntryClientOrderID(ctx context.Context, venue, entryClientOrderID string) (*storage.BracketRecord, error)
+	GetByLegClientOrderID(ctx context.Context, venue, clientOrderID string) (*storage.BracketRecord, error)
+	TryMarkLegPlacing(ctx context.Context, bracketID uuid.UUID, clientOrderID string) (bool, error)
+	UpdateLegStatus(ctx context.Context, bracketID uuid.UUID, clientOrderID, status string, exchangeOrderID int64) error
+	UpdateBracketStatus(ctx context.Context, bracketID uuid.UUID, status string) error
+}
+
+// LegArmer places protective TP/SL legs when a deferred bracket's entry
+// fills, and enforces OCO semantics across the placed legs. It consumes the
+// serialized futures user-data stream, so events arrive in exchange order.
+type LegArmer struct {
+	store   armerStore
+	client  *binance.Client
+	emitter EventEmitter
+	logger  zerolog.Logger
+}
+
+func NewLegArmer(
+	store armerStore,
+	futuresClient *binance.Client,
+	emitter EventEmitter,
+	logger zerolog.Logger,
+) *LegArmer {
+	return &LegArmer{
+		store:   store,
+		client:  futuresClient,
+		emitter: emitter,
+		logger:  logger,
+	}
+}
+
+// OnOrderTradeUpdate routes a futures user-data event to entry arming or
+// exit-leg OCO handling. Errors are logged, never propagated: the stream
+// consumer must not stall, and the startup reconciler is the backstop.
+func (a *LegArmer) OnOrderTradeUpdate(ctx context.Context, event *websocket.FuturesOrderTradeUpdateEvent) {
+	if event == nil {
+		return
+	}
+	data := event.OrderTradeUpdate
+
+	record, err := a.store.GetByEntryClientOrderID(ctx, "USD_M", data.ClientOrderID)
+	if err != nil {
+		a.logger.Error().Err(err).Str("client_order_id", data.ClientOrderID).
+			Msg("leg armer: entry lookup failed")
+		return
+	}
+	if record != nil {
+		if record.LegsOnFill {
+			a.handleEntryUpdate(ctx, record, data)
+		}
+		return
+	}
+
+	record, err = a.store.GetByLegClientOrderID(ctx, "USD_M", data.ClientOrderID)
+	if err != nil {
+		a.logger.Error().Err(err).Str("client_order_id", data.ClientOrderID).
+			Msg("leg armer: exit leg lookup failed")
+		return
+	}
+	if record != nil && record.LegsOnFill {
+		a.handleExitUpdate(ctx, record, data)
+	}
+}
+
+func (a *LegArmer) handleEntryUpdate(
+	ctx context.Context,
+	record *storage.BracketRecord,
+	data websocket.FuturesOrderTradeData,
+) {
+	if record.Status == storage.BracketStatusClosed || record.Status == storage.BracketStatusFailed {
+		// A late duplicate must not resurrect a settled bracket
+		return
+	}
+	switch data.OrderStatus {
+	case "FILLED":
+		a.armLegs(ctx, record, data.CumulativeFilledQty)
+	case "CANCELED", "EXPIRED":
+		if data.CumulativeFilledQty.IsPositive() {
+			// A partial position exists and must still be protected.
+			a.armLegs(ctx, record, data.CumulativeFilledQty)
+			return
+		}
+		a.markLegsForDeadEntry(ctx, record)
+	}
+}
+
+// armLegs places all still-PLANNED protective legs for the executed
+// quantity. The PLANNED→PLACING claim makes duplicate events harmless, and
+// #193's submit resolution makes any raced POST adopt instead of double.
+func (a *LegArmer) armLegs(ctx context.Context, record *storage.BracketRecord, executedQty decimal.Decimal) {
+	if !executedQty.IsPositive() {
+		return
+	}
+
+	exitSide := getOppositeSide(record.Side)
+	tpLegs := legsByRole(record, "TP")
+	tpQuantities := a.takeProfitQuantities(ctx, record.Symbol, executedQty, len(tpLegs))
+	allPlaced := true
+
+	// Defensive re-rounding: records written before rounding preceded the
+	// reservation hold raw prices, and Binance rejects off-tick legs with
+	// -4014 at the exact moment the position opens.
+	tpDir, slDir := binance.RoundUp, binance.RoundDown
+	if record.Side == "SELL" {
+		tpDir, slDir = binance.RoundDown, binance.RoundUp
+	}
+
+	for i, leg := range tpLegs {
+		price := leg.Price
+		if rounded, err := a.client.RoundPriceDirection(ctx, record.Symbol, price, tpDir); err == nil {
+			price = rounded
+		}
+		if !a.armSingleLeg(ctx, record, leg, binance.FuturesOrderRequest{
+			Symbol:           record.Symbol,
+			Side:             exitSide,
+			Type:             "LIMIT",
+			Quantity:         tpQuantities[i],
+			Price:            price,
+			TimeInForce:      "GTC",
+			NewClientOrderID: leg.ClientOrderID,
+			ReduceOnly:       true,
+		}) {
+			allPlaced = false
+		}
+	}
+
+	for _, leg := range legsByRole(record, "SL") {
+		stopPrice := record.StopLossPrice
+		if rounded, err := a.client.RoundPriceDirection(ctx, record.Symbol, stopPrice, slDir); err == nil {
+			stopPrice = rounded
+		}
+		if !a.armSingleLeg(ctx, record, leg, binance.FuturesOrderRequest{
+			Symbol:           record.Symbol,
+			Side:             exitSide,
+			Type:             "STOP_MARKET",
+			Quantity:         decimal.Zero,
+			StopPrice:        stopPrice,
+			TimeInForce:      "GTC",
+			NewClientOrderID: leg.ClientOrderID,
+			// closePosition and reduceOnly are mutually exclusive on USD-M
+			ClosePosition: true,
+		}) {
+			allPlaced = false
+		}
+	}
+
+	status := storage.BracketStatusEntryFilled
+	if allPlaced {
+		status = storage.BracketStatusLegsPlaced
+	}
+	if err := a.store.UpdateBracketStatus(ctx, record.BracketID, status); err != nil {
+		a.logger.Warn().Err(err).Str("bracket_id", record.BracketID.String()).
+			Msg("leg armer: failed to persist bracket status")
+	}
+}
+
+// armSingleLeg claims and places one leg; returns true when the leg is
+// known-placed (including already placed by a prior event).
+func (a *LegArmer) armSingleLeg(
+	ctx context.Context,
+	record *storage.BracketRecord,
+	leg storage.BracketLegRecord,
+	order binance.FuturesOrderRequest,
+) bool {
+	if leg.Status != storage.LegStatusPlanned && leg.Status != storage.LegStatusFailed {
+		return leg.Status == storage.LegStatusPlaced || leg.Status == storage.LegStatusFilled
+	}
+
+	claimed, err := a.store.TryMarkLegPlacing(ctx, record.BracketID, leg.ClientOrderID)
+	if err != nil {
+		a.logger.Error().Err(err).Str("client_order_id", leg.ClientOrderID).
+			Msg("leg armer: failed to claim leg")
+		return false
+	}
+	if !claimed {
+		return true // another event placed (or is placing) it
+	}
+
+	resp, err := submitResolvingAmbiguity(
+		ctx, a.logger, a.client, record.Symbol, leg.ClientOrderID, true,
+		func(ctx context.Context) (*binance.OrderResponse, error) {
+			return a.client.PlaceFuturesOrder(ctx, order)
+		})
+	if err != nil {
+		a.logger.Error().Err(err).
+			Str("client_order_id", leg.ClientOrderID).
+			Str("symbol", record.Symbol).
+			Msg("leg armer: protective leg placement FAILED — position may be unprotected")
+		a.updateLegStatus(ctx, record.BracketID, leg.ClientOrderID, storage.LegStatusFailed, 0)
+		return false
+	}
+
+	a.updateLegStatus(ctx, record.BracketID, leg.ClientOrderID, storage.LegStatusPlaced, resp.OrderID)
+	a.emitLegUpdate(ctx, record, order, resp)
+	return true
+}
+
+func (a *LegArmer) handleExitUpdate(
+	ctx context.Context,
+	record *storage.BracketRecord,
+	data websocket.FuturesOrderTradeData,
+) {
+	leg := legByClientOrderID(record, data.ClientOrderID)
+	if leg == nil {
+		return
+	}
+
+	switch data.OrderStatus {
+	case "FILLED":
+		a.updateLegStatus(ctx, record.BracketID, leg.ClientOrderID, storage.LegStatusFilled, data.OrderID)
+		leg.Status = storage.LegStatusFilled
+		if leg.Role == "SL" {
+			a.cancelLegs(ctx, record, "TP")
+			a.closeBracket(ctx, record)
+			return
+		}
+		if allLegsFilled(record, "TP") {
+			a.cancelLegs(ctx, record, "SL")
+			a.closeBracket(ctx, record)
+		}
+	case "CANCELED", "EXPIRED":
+		status := storage.LegStatusCanceled
+		if data.OrderStatus == "EXPIRED" {
+			status = storage.LegStatusExpired
+		}
+		a.updateLegStatus(ctx, record.BracketID, leg.ClientOrderID, status, data.OrderID)
+	}
+}
+
+// cancelLegs explicitly cancels placed legs of a role — belt-and-braces
+// rather than trusting exchange-side auto-cancel behavior.
+func (a *LegArmer) cancelLegs(ctx context.Context, record *storage.BracketRecord, role string) {
+	for _, leg := range legsByRole(record, role) {
+		if leg.Status != storage.LegStatusPlaced || leg.ExchangeOrderID == 0 {
+			continue
+		}
+		if _, err := a.client.CancelOrder(ctx, record.Symbol, leg.ExchangeOrderID); err != nil {
+			a.logger.Warn().Err(err).
+				Str("client_order_id", leg.ClientOrderID).
+				Msg("leg armer: sibling cancel failed; reconciler will retry")
+			continue
+		}
+		a.updateLegStatus(ctx, record.BracketID, leg.ClientOrderID, storage.LegStatusCanceled, leg.ExchangeOrderID)
+	}
+}
+
+func (a *LegArmer) closeBracket(ctx context.Context, record *storage.BracketRecord) {
+	if err := a.store.UpdateBracketStatus(ctx, record.BracketID, storage.BracketStatusClosed); err != nil {
+		a.logger.Warn().Err(err).Str("bracket_id", record.BracketID.String()).
+			Msg("leg armer: failed to close bracket")
+	}
+}
+
+// markLegsForDeadEntry releases the legs when the entry died unfilled.
+func (a *LegArmer) markLegsForDeadEntry(ctx context.Context, record *storage.BracketRecord) {
+	for _, leg := range record.Legs {
+		if leg.Role == "ENTRY" || leg.Status == storage.LegStatusPlanned {
+			a.updateLegStatus(ctx, record.BracketID, leg.ClientOrderID, storage.LegStatusCanceled, 0)
+		}
+	}
+	a.closeBracket(ctx, record)
+}
+
+func (a *LegArmer) takeProfitQuantities(
+	ctx context.Context,
+	symbol string,
+	executedQty decimal.Decimal,
+	count int,
+) []decimal.Decimal {
+	// Unlike the synchronous path (which aborts on StepSize errors before
+	// any order exists), a position is already open here: attempting
+	// protection with an unstepped split beats aborting.
+	step := decimal.Zero
+	if s, err := a.client.StepSize(ctx, symbol); err == nil {
+		step = s
+	}
+	return splitTakeProfitQuantities(executedQty, count, step)
+}
+
+func (a *LegArmer) updateLegStatus(
+	ctx context.Context,
+	bracketID uuid.UUID,
+	clientOrderID, status string,
+	exchangeOrderID int64,
+) {
+	if err := a.store.UpdateLegStatus(ctx, bracketID, clientOrderID, status, exchangeOrderID); err != nil {
+		a.logger.Warn().Err(err).
+			Str("client_order_id", clientOrderID).
+			Str("status", status).
+			Msg("leg armer: failed to persist leg status")
+	}
+}
+
+func (a *LegArmer) emitLegUpdate(
+	ctx context.Context,
+	record *storage.BracketRecord,
+	order binance.FuturesOrderRequest,
+	resp *binance.OrderResponse,
+) {
+	if a.emitter == nil {
+		return
+	}
+	update := &OrderUpdate{
+		EventType:     "order_update.v1",
+		Venue:         "USD_M",
+		Symbol:        record.Symbol,
+		OrderID:       resp.OrderID,
+		ClientOrderID: order.NewClientOrderID,
+		Status:        normalizeOrderStatus(resp.Status),
+		Side:          order.Side,
+		OrderType:     order.Type,
+		Price:         order.Price,
+		Quantity:      order.Quantity,
+		ExecutedQty:   resp.ExecutedQty,
+		UpdateTime:    time.Now().UTC(),
+	}
+	if err := a.emitter.EmitOrderUpdate(ctx, update); err != nil {
+		a.logger.Warn().Err(err).
+			Str("client_order_id", order.NewClientOrderID).
+			Msg("leg armer: failed to emit order update")
+	}
+}
+
+func legsByRole(record *storage.BracketRecord, role string) []storage.BracketLegRecord {
+	var legs []storage.BracketLegRecord
+	for _, leg := range record.Legs {
+		if leg.Role == role {
+			legs = append(legs, leg)
+		}
+	}
+	return legs
+}
+
+func legByClientOrderID(record *storage.BracketRecord, clientOrderID string) *storage.BracketLegRecord {
+	for i := range record.Legs {
+		if record.Legs[i].ClientOrderID == clientOrderID {
+			return &record.Legs[i]
+		}
+	}
+	return nil
+}
+
+func allLegsFilled(record *storage.BracketRecord, role string) bool {
+	for _, leg := range record.Legs {
+		if leg.Role == role && leg.Status != storage.LegStatusFilled {
+			return false
+		}
+	}
+	return true
+}

--- a/app/router/internal/orders/leg_armer_test.go
+++ b/app/router/internal/orders/leg_armer_test.go
@@ -1,0 +1,390 @@
+package orders
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"router/internal/auth"
+	"router/internal/binance"
+	"router/internal/rest"
+	"router/internal/storage"
+	"router/internal/websocket"
+)
+
+// fakeArmerStore implements armerStore over a single mutable record.
+type fakeArmerStore struct {
+	mu             sync.Mutex
+	record         *storage.BracketRecord
+	bracketUpdates []string
+	legUpdates     []string // "clientOrderID:status"
+}
+
+func (f *fakeArmerStore) get(clientOrderID string, entryOnly bool) *storage.BracketRecord {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.record == nil {
+		return nil
+	}
+	if entryOnly {
+		if f.record.EntryClientOrderID == clientOrderID {
+			rec := *f.record
+			rec.Legs = append([]storage.BracketLegRecord(nil), f.record.Legs...)
+			return &rec
+		}
+		return nil
+	}
+	for _, leg := range f.record.Legs {
+		if leg.ClientOrderID == clientOrderID && leg.Role != "ENTRY" {
+			rec := *f.record
+			rec.Legs = append([]storage.BracketLegRecord(nil), f.record.Legs...)
+			return &rec
+		}
+	}
+	return nil
+}
+
+func (f *fakeArmerStore) GetByEntryClientOrderID(_ context.Context, _, entryClientOrderID string) (*storage.BracketRecord, error) {
+	return f.get(entryClientOrderID, true), nil
+}
+
+func (f *fakeArmerStore) GetByLegClientOrderID(_ context.Context, _, clientOrderID string) (*storage.BracketRecord, error) {
+	return f.get(clientOrderID, false), nil
+}
+
+func (f *fakeArmerStore) TryMarkLegPlacing(_ context.Context, _ uuid.UUID, clientOrderID string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for i := range f.record.Legs {
+		if f.record.Legs[i].ClientOrderID == clientOrderID &&
+			(f.record.Legs[i].Status == storage.LegStatusPlanned ||
+				f.record.Legs[i].Status == storage.LegStatusFailed) {
+			f.record.Legs[i].Status = storage.LegStatusPlacing
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (f *fakeArmerStore) UpdateLegStatus(_ context.Context, _ uuid.UUID, clientOrderID, status string, exchangeOrderID int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.legUpdates = append(f.legUpdates, clientOrderID+":"+status)
+	for i := range f.record.Legs {
+		if f.record.Legs[i].ClientOrderID == clientOrderID {
+			f.record.Legs[i].Status = status
+			if exchangeOrderID != 0 {
+				f.record.Legs[i].ExchangeOrderID = exchangeOrderID
+			}
+		}
+	}
+	return nil
+}
+
+func (f *fakeArmerStore) UpdateBracketStatus(_ context.Context, _ uuid.UUID, status string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.bracketUpdates = append(f.bracketUpdates, status)
+	f.record.Status = status
+	return nil
+}
+
+// armerExchange records POSTed and canceled orders on the futures paths.
+type armerExchange struct {
+	mu          sync.Mutex
+	postedIDs   []string
+	postedQtys  map[string]string
+	canceledIDs []int64
+	failPosts   bool // all POSTs fail with a non-retryable -1102
+}
+
+func (f *armerExchange) posted() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.postedIDs...)
+}
+
+func (f *armerExchange) canceled() []int64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]int64(nil), f.canceledIDs...)
+}
+
+func (f *armerExchange) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/fapi/v1/order" {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"not found"}`))
+			return
+		}
+		q := r.URL.Query()
+		orDefault := func(v string) string {
+			if v == "" {
+				return "0"
+			}
+			return v
+		}
+		switch r.Method {
+		case http.MethodPost:
+			clientOrderID := q.Get("newClientOrderId")
+			if f.failPosts {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"code":-1102,"msg":"Mandatory parameter was not sent."}`))
+				return
+			}
+			f.mu.Lock()
+			f.postedIDs = append(f.postedIDs, clientOrderID)
+			if f.postedQtys == nil {
+				f.postedQtys = make(map[string]string)
+			}
+			f.postedQtys[clientOrderID] = orDefault(q.Get("quantity"))
+			count := len(f.postedIDs)
+			f.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"orderId": 5000 + count, "symbol": q.Get("symbol"), "status": "NEW",
+				"clientOrderId": clientOrderID, "price": orDefault(q.Get("price")), "avgPrice": "0",
+				"origQty": orDefault(q.Get("quantity")), "executedQty": "0", "cumQty": "0", "cumQuote": "0",
+				"timeInForce": "GTC", "type": q.Get("type"), "reduceOnly": q.Get("reduceOnly") == "true",
+				"closePosition": q.Get("closePosition") == "true", "side": q.Get("side"),
+				"positionSide": "BOTH", "stopPrice": orDefault(q.Get("stopPrice")),
+				"workingType": "CONTRACT_PRICE", "priceProtect": false,
+				"origType": q.Get("type"), "updateTime": 1,
+			})
+		case http.MethodDelete:
+			orderID, _ := json.Number(orDefault(q.Get("orderId"))).Int64()
+			f.mu.Lock()
+			f.canceledIDs = append(f.canceledIDs, orderID)
+			f.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{"orderId": orderID, "status": "CANCELED"})
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}
+}
+
+func newArmerFixture(t *testing.T, store *fakeArmerStore) (*LegArmer, *armerExchange) {
+	t.Helper()
+	fake := &armerExchange{}
+	server := httptest.NewServer(fake.handler())
+	t.Cleanup(server.Close)
+
+	signer := auth.NewSignerWithRecvWindow("key", "secret", 5000)
+	logger := zerolog.Nop()
+	futuresRest := rest.NewClient(server.URL, signer)
+	futuresClient, err := binance.NewFuturesClient(server.URL, signer, futuresRest, logger)
+	require.NoError(t, err)
+
+	return NewLegArmer(store, futuresClient, nil, logger), fake
+}
+
+func armerRecord() *storage.BracketRecord {
+	return &storage.BracketRecord{
+		BracketID:          uuid.New(),
+		Venue:              "USD_M",
+		Symbol:             "BTCUSDT",
+		Side:               "BUY",
+		Quantity:           decimal.RequireFromString("0.02"),
+		StopLossPrice:      decimal.RequireFromString("49000"),
+		EntryClientOrderID: "arm-main",
+		Status:             storage.BracketStatusEntryPlaced,
+		LegsOnFill:         true,
+		Legs: []storage.BracketLegRecord{
+			{Role: "ENTRY", ClientOrderID: "arm-main", Status: storage.LegStatusPlaced, Quantity: decimal.RequireFromString("0.02")},
+			{Role: "TP", TPIndex: 1, ClientOrderID: "arm-tp1", Status: storage.LegStatusPlanned, Price: decimal.RequireFromString("51000"), Quantity: decimal.RequireFromString("0.02")},
+			{Role: "SL", ClientOrderID: "arm-sl", Status: storage.LegStatusPlanned, StopPrice: decimal.RequireFromString("49000")},
+		},
+	}
+}
+
+func entryFillEvent(clientOrderID, status, cumQty string) *websocket.FuturesOrderTradeUpdateEvent {
+	return &websocket.FuturesOrderTradeUpdateEvent{
+		OrderTradeUpdate: websocket.FuturesOrderTradeData{
+			Symbol:              "BTCUSDT",
+			ClientOrderID:       clientOrderID,
+			OrderStatus:         status,
+			CumulativeFilledQty: decimal.RequireFromString(cumQty),
+			OrderID:             42,
+		},
+	}
+}
+
+func TestLegArmer_EntryFillArmsProtectiveLegs(t *testing.T) {
+	store := &fakeArmerStore{record: armerRecord()}
+	armer, fake := newArmerFixture(t, store)
+
+	armer.OnOrderTradeUpdate(context.Background(), entryFillEvent("arm-main", "FILLED", "0.02"))
+
+	assert.Equal(t, []string{"arm-tp1", "arm-sl"}, fake.posted())
+	assert.Equal(t, "0.02", fake.postedQtys["arm-tp1"], "TP sized by executed quantity")
+	assert.Contains(t, store.legUpdates, "arm-tp1:PLACED")
+	assert.Contains(t, store.legUpdates, "arm-sl:PLACED")
+	assert.Equal(t, []string{storage.BracketStatusLegsPlaced}, store.bracketUpdates)
+}
+
+func TestLegArmer_DuplicateFillEventIsIdempotent(t *testing.T) {
+	store := &fakeArmerStore{record: armerRecord()}
+	armer, fake := newArmerFixture(t, store)
+
+	armer.OnOrderTradeUpdate(context.Background(), entryFillEvent("arm-main", "FILLED", "0.02"))
+	armer.OnOrderTradeUpdate(context.Background(), entryFillEvent("arm-main", "FILLED", "0.02"))
+
+	assert.Equal(t, []string{"arm-tp1", "arm-sl"}, fake.posted(),
+		"duplicate events must never double-place protective legs")
+}
+
+func TestLegArmer_PreFillStatusesPlaceNothing(t *testing.T) {
+	store := &fakeArmerStore{record: armerRecord()}
+	armer, fake := newArmerFixture(t, store)
+
+	armer.OnOrderTradeUpdate(context.Background(), entryFillEvent("arm-main", "NEW", "0"))
+	armer.OnOrderTradeUpdate(context.Background(), entryFillEvent("arm-main", "PARTIALLY_FILLED", "0.01"))
+
+	assert.Empty(t, fake.posted())
+}
+
+func TestLegArmer_CanceledEntryWithPartialFillStillArms(t *testing.T) {
+	store := &fakeArmerStore{record: armerRecord()}
+	armer, fake := newArmerFixture(t, store)
+
+	armer.OnOrderTradeUpdate(context.Background(), entryFillEvent("arm-main", "CANCELED", "0.01"))
+
+	assert.Equal(t, []string{"arm-tp1", "arm-sl"}, fake.posted())
+	assert.Equal(t, "0.01", fake.postedQtys["arm-tp1"],
+		"partial position must be protected with the executed quantity")
+}
+
+func TestLegArmer_CanceledEntryWithZeroFillClosesBracket(t *testing.T) {
+	store := &fakeArmerStore{record: armerRecord()}
+	armer, fake := newArmerFixture(t, store)
+
+	armer.OnOrderTradeUpdate(context.Background(), entryFillEvent("arm-main", "CANCELED", "0"))
+
+	assert.Empty(t, fake.posted())
+	assert.Contains(t, store.legUpdates, "arm-tp1:CANCELED")
+	assert.Contains(t, store.legUpdates, "arm-sl:CANCELED")
+	assert.Equal(t, []string{storage.BracketStatusClosed}, store.bracketUpdates)
+}
+
+func TestLegArmer_StopLossFillCancelsTakeProfits(t *testing.T) {
+	record := armerRecord()
+	record.Legs[1].Status = storage.LegStatusPlaced
+	record.Legs[1].ExchangeOrderID = 7101
+	record.Legs[2].Status = storage.LegStatusPlaced
+	record.Legs[2].ExchangeOrderID = 7102
+	store := &fakeArmerStore{record: record}
+	armer, fake := newArmerFixture(t, store)
+
+	armer.OnOrderTradeUpdate(context.Background(), entryFillEvent("arm-sl", "FILLED", "0.02"))
+
+	assert.Equal(t, []int64{7101}, fake.canceled(), "SL fill must cancel resting TPs")
+	assert.Contains(t, store.legUpdates, "arm-sl:FILLED")
+	assert.Contains(t, store.legUpdates, "arm-tp1:CANCELED")
+	assert.Contains(t, store.bracketUpdates, storage.BracketStatusClosed)
+}
+
+func TestLegArmer_FinalTakeProfitFillCancelsStopLoss(t *testing.T) {
+	record := armerRecord()
+	record.Legs[1].Status = storage.LegStatusPlaced
+	record.Legs[1].ExchangeOrderID = 7101
+	record.Legs[2].Status = storage.LegStatusPlaced
+	record.Legs[2].ExchangeOrderID = 7102
+	store := &fakeArmerStore{record: record}
+	armer, fake := newArmerFixture(t, store)
+
+	armer.OnOrderTradeUpdate(context.Background(), entryFillEvent("arm-tp1", "FILLED", "0.02"))
+
+	assert.Equal(t, []int64{7102}, fake.canceled(), "final TP fill must cancel the SL")
+	assert.Contains(t, store.bracketUpdates, storage.BracketStatusClosed)
+}
+
+func TestLegArmer_UnknownClientOrderIDIsIgnored(t *testing.T) {
+	store := &fakeArmerStore{record: armerRecord()}
+	armer, fake := newArmerFixture(t, store)
+
+	armer.OnOrderTradeUpdate(context.Background(), entryFillEvent("someone-else", "FILLED", "1"))
+
+	assert.Empty(t, fake.posted())
+	assert.Empty(t, store.bracketUpdates)
+}
+
+func TestLegArmer_SynchronousBracketsAreIgnored(t *testing.T) {
+	record := armerRecord()
+	record.LegsOnFill = false
+	store := &fakeArmerStore{record: record}
+	armer, fake := newArmerFixture(t, store)
+
+	armer.OnOrderTradeUpdate(context.Background(), entryFillEvent("arm-main", "FILLED", "0.02"))
+
+	assert.Empty(t, fake.posted())
+}
+
+func TestLegArmer_PlacementFailureMarksLegFailedAndBracketEntryFilled(t *testing.T) {
+	store := &fakeArmerStore{record: armerRecord()}
+	armer, fake := newArmerFixture(t, store)
+	fake.failPosts = true
+
+	armer.OnOrderTradeUpdate(context.Background(), entryFillEvent("arm-main", "FILLED", "0.02"))
+
+	assert.Contains(t, store.legUpdates, "arm-tp1:FAILED")
+	assert.Contains(t, store.legUpdates, "arm-sl:FAILED")
+	assert.Equal(t, []string{storage.BracketStatusEntryFilled}, store.bracketUpdates,
+		"unarmed bracket must stay visible as reconciler work")
+}
+
+func TestLegArmer_FailedLegsAreReclaimedOnNextEvent(t *testing.T) {
+	record := armerRecord()
+	record.Legs[1].Status = storage.LegStatusFailed
+	record.Legs[2].Status = storage.LegStatusFailed
+	store := &fakeArmerStore{record: record}
+	armer, fake := newArmerFixture(t, store)
+
+	armer.OnOrderTradeUpdate(context.Background(), entryFillEvent("arm-main", "FILLED", "0.02"))
+
+	assert.Equal(t, []string{"arm-tp1", "arm-sl"}, fake.posted(),
+		"a transient failure must not permanently strand the position unprotected")
+	assert.Contains(t, store.legUpdates, "arm-tp1:PLACED")
+	assert.Contains(t, store.legUpdates, "arm-sl:PLACED")
+}
+
+func TestLegArmer_ClosedBracketIgnoresLateDuplicateEntryEvent(t *testing.T) {
+	record := armerRecord()
+	record.Status = storage.BracketStatusClosed
+	store := &fakeArmerStore{record: record}
+	armer, fake := newArmerFixture(t, store)
+
+	armer.OnOrderTradeUpdate(context.Background(), entryFillEvent("arm-main", "FILLED", "0.02"))
+
+	assert.Empty(t, fake.posted())
+	assert.Empty(t, store.bracketUpdates, "a settled bracket must never be resurrected")
+}
+
+func TestLegArmer_MultiTPOnlyFinalFillCancelsStopLoss(t *testing.T) {
+	record := armerRecord()
+	record.Legs = []storage.BracketLegRecord{
+		{Role: "ENTRY", ClientOrderID: "arm-main", Status: storage.LegStatusPlaced, Quantity: decimal.RequireFromString("0.02")},
+		{Role: "TP", TPIndex: 1, ClientOrderID: "arm-tp1", Status: storage.LegStatusPlaced, ExchangeOrderID: 7101, Price: decimal.RequireFromString("51000")},
+		{Role: "TP", TPIndex: 2, ClientOrderID: "arm-tp2", Status: storage.LegStatusPlaced, ExchangeOrderID: 7102, Price: decimal.RequireFromString("52000")},
+		{Role: "SL", ClientOrderID: "arm-sl", Status: storage.LegStatusPlaced, ExchangeOrderID: 7103, StopPrice: decimal.RequireFromString("49000")},
+	}
+	store := &fakeArmerStore{record: record}
+	armer, fake := newArmerFixture(t, store)
+
+	armer.OnOrderTradeUpdate(context.Background(), entryFillEvent("arm-tp1", "FILLED", "0.01"))
+
+	assert.Empty(t, fake.canceled(), "SL must survive while TP2 still rests")
+	assert.Empty(t, store.bracketUpdates)
+
+	armer.OnOrderTradeUpdate(context.Background(), entryFillEvent("arm-tp2", "FILLED", "0.01"))
+
+	assert.Equal(t, []int64{7103}, fake.canceled())
+	assert.Contains(t, store.bracketUpdates, storage.BracketStatusClosed)
+}

--- a/app/router/internal/orders/manager.go
+++ b/app/router/internal/orders/manager.go
@@ -36,6 +36,10 @@ type Manager struct {
 	// Durable reservation store; nil keeps in-memory-only idempotency
 	bracketStore BracketStore
 
+	// Defer futures TP/SL placement until the entry fills (requires the
+	// bracket store: planned legs must survive a crash)
+	legsOnFill bool
+
 	// Logger
 	logger zerolog.Logger
 }
@@ -50,12 +54,28 @@ type EventEmitter interface {
 type BracketStore interface {
 	Reserve(ctx context.Context, rec storage.BracketRecord) (*storage.BracketRecord, bool, error)
 	UpdateBracketStatus(ctx context.Context, bracketID uuid.UUID, status string) error
+	UpdateBracketStatusIf(ctx context.Context, bracketID uuid.UUID, expected, status string) (bool, error)
 	UpdateLegStatus(ctx context.Context, bracketID uuid.UUID, clientOrderID, status string, exchangeOrderID int64) error
 }
 
 // SetBracketStore installs the durable reservation store.
 func (m *Manager) SetBracketStore(store BracketStore) {
 	m.bracketStore = store
+}
+
+// SetLegsOnFill defers futures protective legs until the entry fills.
+func (m *Manager) SetLegsOnFill(enabled bool) {
+	m.legsOnFill = enabled
+}
+
+// futuresLegsDeferred reports whether this request's exit legs are placed by
+// the leg armer on entry fill instead of synchronously.
+func (m *Manager) futuresLegsDeferred(req *PlaceBracketRequest) bool {
+	return m.legsOnFill &&
+		m.bracketStore != nil &&
+		req.IsFutures &&
+		req.ClientOrderIDs != nil &&
+		req.ClientOrderIDs.Main != ""
 }
 
 // NewManager creates a new order manager
@@ -281,33 +301,10 @@ func (m *Manager) PlaceBracketOrder(ctx context.Context, req *PlaceBracketReques
 		orderType = OrderTypeFutures
 	}
 
-	// Durable check-and-reserve: survives restarts, and on replay the entry
-	// is verified against the exchange so it is adopted, never re-POSTed.
-	var reservedBracketID uuid.UUID
-	var adoptedEntry *binance.OrderResponse
-	if m.bracketStore != nil && req.ClientOrderIDs != nil && req.ClientOrderIDs.Main != "" {
-		record, inserted, reserveErr := m.bracketStore.Reserve(ctx, bracketRecordFromRequest(req))
-		switch {
-		case reserveErr != nil:
-			m.logger.Warn().Err(reserveErr).
-				Str("client_order_id", req.ClientOrderIDs.Main).
-				Msg("Bracket store reserve failed; continuing with in-memory idempotency only")
-		case inserted:
-			reservedBracketID = record.BracketID
-		default:
-			if divergeErr := validateReplayMatchesReservation(record, req); divergeErr != nil {
-				return nil, divergeErr
-			}
-			reservedBracketID = record.BracketID
-			entry, replayErr := m.replayEntryState(ctx, client, req.Symbol, record.EntryClientOrderID)
-			if replayErr != nil {
-				return nil, replayErr
-			}
-			adoptedEntry = entry
-		}
-	}
-
-	// Round prices and quantities
+	// Round prices and quantities BEFORE reserving: the durable record is
+	// what the leg armer later POSTs from, so it must hold exchange-valid
+	// (tick-aligned) values or deferred legs get PRICE_FILTER-rejected at
+	// the exact moment a position opens.
 	roundedQty, err := client.RoundQuantity(ctx, req.Symbol, req.Quantity)
 	if err != nil {
 		return nil, fmt.Errorf("failed to round quantity: %w", err)
@@ -345,6 +342,43 @@ func (m *Manager) PlaceBracketOrder(ctx context.Context, req *PlaceBracketReques
 	// Validate notional
 	if err := client.ValidateNotional(ctx, req.Symbol, req.EntryPrice, req.Quantity); err != nil {
 		return nil, fmt.Errorf("notional validation failed: %w", err)
+	}
+
+	// Durable check-and-reserve: survives restarts, and on replay the entry
+	// is verified against the exchange so it is adopted, never re-POSTed.
+	var reservedBracketID uuid.UUID
+	var adoptedEntry *binance.OrderResponse
+	legsDeferred := m.futuresLegsDeferred(req)
+	if m.bracketStore != nil && req.ClientOrderIDs != nil && req.ClientOrderIDs.Main != "" {
+		record, inserted, reserveErr := m.bracketStore.Reserve(ctx, bracketRecordFromRequest(req, legsDeferred))
+		switch {
+		case reserveErr != nil:
+			m.logger.Warn().Err(reserveErr).
+				Str("client_order_id", req.ClientOrderIDs.Main).
+				Msg("Bracket store reserve failed; continuing with in-memory idempotency only")
+			// Without a durable record the armer could never find the legs
+			legsDeferred = false
+		case inserted:
+			reservedBracketID = record.BracketID
+		default:
+			if divergeErr := validateReplayMatchesReservation(record, req); divergeErr != nil {
+				return nil, divergeErr
+			}
+			reservedBracketID = record.BracketID
+			entry, replayErr := m.replayEntryState(ctx, client, req.Symbol, record.EntryClientOrderID)
+			if replayErr != nil {
+				return nil, replayErr
+			}
+			adoptedEntry = entry
+			if adoptedEntry != nil &&
+				(isTerminalOrderStatus(normalizeOrderStatus(adoptedEntry.Status)) ||
+					adoptedEntry.ExecutedQty.IsPositive()) {
+				// The fill event was consumed (or lost) in a previous process
+				// life and will never arrive again — place exit legs now.
+				// A position exists, so ReduceOnly cannot -2022.
+				legsDeferred = false
+			}
+		}
 	}
 
 	// Generate bracket order ID (reuse the durable reservation's id so the
@@ -389,10 +423,11 @@ func (m *Manager) PlaceBracketOrder(ctx context.Context, req *PlaceBracketReques
 
 	var placement *bracketPlacementResult
 	if req.IsFutures {
-		placement, err = m.placeFuturesBracket(ctx, client, req, bracketID, adoptedEntry)
+		placement, err = m.placeFuturesBracket(ctx, client, req, bracketID, adoptedEntry, legsDeferred)
 	} else {
 		placement, err = m.placeSpotBracket(ctx, client, req, bracketID, adoptedEntry)
 	}
+	response.LegsPendingTrigger = legsDeferred && err == nil
 	if placement != nil {
 		bracket.ClientOrderIDs = placement.IDs
 		bracket.StopLossLimitPrice = placement.StopLossLimitPrice
@@ -420,7 +455,7 @@ func (m *Manager) PlaceBracketOrder(ctx context.Context, req *PlaceBracketReques
 		}
 	}
 
-	m.persistPlacementOutcome(ctx, reservedBracketID, placement, criticalPlacementErr != nil)
+	m.persistPlacementOutcome(ctx, reservedBracketID, placement, criticalPlacementErr != nil, legsDeferred)
 
 	// Store order (only store successfully placed order IDs)
 	m.mu.Lock()

--- a/app/router/internal/orders/replay.go
+++ b/app/router/internal/orders/replay.go
@@ -16,7 +16,7 @@ import (
 
 // bracketRecordFromRequest builds the durable reservation for a request that
 // carries caller-supplied client order ids (the engine contract).
-func bracketRecordFromRequest(req *PlaceBracketRequest) storage.BracketRecord {
+func bracketRecordFromRequest(req *PlaceBracketRequest, legsOnFill bool) storage.BracketRecord {
 	venue := "SPOT"
 	if req.IsFutures {
 		venue = "USD_M"
@@ -58,6 +58,7 @@ func bracketRecordFromRequest(req *PlaceBracketRequest) storage.BracketRecord {
 		StopLossPrice:      req.StopLossPrice,
 		EntryClientOrderID: req.ClientOrderIDs.Main,
 		Status:             storage.BracketStatusReserved,
+		LegsOnFill:         legsOnFill,
 		Legs:               legs,
 	}
 }
@@ -148,6 +149,7 @@ func (m *Manager) persistPlacementOutcome(
 	bracketID uuid.UUID,
 	placement *bracketPlacementResult,
 	critical bool,
+	legsDeferred bool,
 ) {
 	if m.bracketStore == nil || bracketID == uuid.Nil {
 		return
@@ -160,7 +162,17 @@ func (m *Manager) persistPlacementOutcome(
 	if !critical {
 		status = storage.BracketStatusLegsPlaced
 	}
-	if err := m.bracketStore.UpdateBracketStatus(ctx, bracketID, status); err != nil {
+	if !critical && legsDeferred {
+		// Exit legs stay PLANNED; the armer places them on fill. A MARKET
+		// entry can fill — and the armer can advance the bracket — before
+		// this bookkeeping runs, so never downgrade past RESERVED.
+		if _, err := m.bracketStore.UpdateBracketStatusIf(
+			ctx, bracketID, storage.BracketStatusReserved, storage.BracketStatusEntryPlaced,
+		); err != nil {
+			m.logger.Warn().Err(err).Str("bracket_id", bracketID.String()).
+				Msg("Failed to persist bracket status")
+		}
+	} else if err := m.bracketStore.UpdateBracketStatus(ctx, bracketID, status); err != nil {
 		m.logger.Warn().Err(err).Str("bracket_id", bracketID.String()).
 			Msg("Failed to persist bracket status")
 	}
@@ -185,6 +197,9 @@ func (m *Manager) persistPlacementOutcome(
 	}
 
 	update(placement.IDs.Main, placement.Main)
+	if legsDeferred {
+		return
+	}
 	for i, tpID := range placement.IDs.TakeProfits {
 		var resp *binance.OrderResponse
 		if i < len(placement.TakeProfits) {

--- a/app/router/internal/orders/types.go
+++ b/app/router/internal/orders/types.go
@@ -79,6 +79,7 @@ type PlaceBracketResponse struct {
 	CreatedAt              time.Time               `json:"created_at"`
 	PartialFailure         bool                    `json:"partial_failure,omitempty"`
 	Errors                 []string                `json:"errors,omitempty"`
+	LegsPendingTrigger     bool                    `json:"legs_pending_trigger,omitempty"`
 	SpotExecutionSnapshots []SpotExecutionSnapshot `json:"-"`
 }
 

--- a/app/router/internal/storage/bracket_repo.go
+++ b/app/router/internal/storage/bracket_repo.go
@@ -25,6 +25,7 @@ const (
 // Bracket leg statuses.
 const (
 	LegStatusPlanned  = "PLANNED"
+	LegStatusPlacing  = "PLACING"
 	LegStatusPlaced   = "PLACED"
 	LegStatusFilled   = "FILLED"
 	LegStatusCanceled = "CANCELED"
@@ -175,6 +176,88 @@ func (r *BracketRepo) UpdateLegStatus(
 		return fmt.Errorf("update bracket leg status: no leg %s in bracket %s", clientOrderID, bracketID)
 	}
 	return nil
+}
+
+// TryMarkLegPlacing claims a leg for placement (compare-and-set to PLACING).
+// Exactly one caller wins per leg, making duplicate fill events unable to
+// double-place protective legs. FAILED legs are re-claimable: a transient
+// POST failure must not permanently strand a position unprotected, and
+// #193's submit resolution dedupes any raced re-POST against the exchange.
+func (r *BracketRepo) TryMarkLegPlacing(ctx context.Context, bracketID uuid.UUID, clientOrderID string) (bool, error) {
+	tag, err := r.pool.Exec(ctx, `
+		UPDATE bracket_legs
+		SET status = $3, updated_at = CURRENT_TIMESTAMP
+		WHERE bracket_id = $1 AND client_order_id = $2 AND status IN ($4, $5)`,
+		bracketID, clientOrderID, LegStatusPlacing, LegStatusPlanned, LegStatusFailed)
+	if err != nil {
+		return false, fmt.Errorf("mark bracket leg placing: %w", err)
+	}
+	return tag.RowsAffected() == 1, nil
+}
+
+// UpdateBracketStatusIf transitions a bracket's status only from an expected
+// prior state; reports whether the transition applied.
+func (r *BracketRepo) UpdateBracketStatusIf(ctx context.Context, bracketID uuid.UUID, expected, status string) (bool, error) {
+	tag, err := r.pool.Exec(ctx, `
+		UPDATE brackets SET status = $3, updated_at = CURRENT_TIMESTAMP
+		WHERE bracket_id = $1 AND status = $2`,
+		bracketID, expected, status)
+	if err != nil {
+		return false, fmt.Errorf("conditional bracket status update: %w", err)
+	}
+	return tag.RowsAffected() == 1, nil
+}
+
+// GetByEntryClientOrderID loads a bracket (with legs) by its entry client
+// order id; returns nil when none exists.
+func (r *BracketRepo) GetByEntryClientOrderID(ctx context.Context, venue, entryClientOrderID string) (*BracketRecord, error) {
+	rec, err := r.getByEntryClientOrderID(ctx, venue, entryClientOrderID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return rec, nil
+}
+
+// GetByLegClientOrderID loads the bracket (with legs) owning any leg with the
+// given client order id; returns nil when none exists.
+func (r *BracketRepo) GetByLegClientOrderID(ctx context.Context, venue, clientOrderID string) (*BracketRecord, error) {
+	var bracketID uuid.UUID
+	err := r.pool.QueryRow(ctx, `
+		SELECT l.bracket_id
+		FROM bracket_legs l
+		JOIN brackets b ON b.bracket_id = l.bracket_id
+		WHERE b.venue = $1 AND l.client_order_id = $2`,
+		venue, clientOrderID,
+	).Scan(&bracketID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("load bracket by leg client order id: %w", err)
+	}
+
+	var rec BracketRecord
+	err = r.pool.QueryRow(ctx, `
+		SELECT bracket_id, venue, symbol, side, quantity, entry_price,
+		       stop_loss_price, entry_client_order_id, status, legs_on_fill, created_at
+		FROM brackets WHERE bracket_id = $1`, bracketID,
+	).Scan(
+		&rec.BracketID, &rec.Venue, &rec.Symbol, &rec.Side, &rec.Quantity,
+		&rec.EntryPrice, &rec.StopLossPrice, &rec.EntryClientOrderID,
+		&rec.Status, &rec.LegsOnFill, &rec.CreatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load bracket by id: %w", err)
+	}
+	legs, err := r.loadLegs(ctx, rec.BracketID)
+	if err != nil {
+		return nil, err
+	}
+	rec.Legs = legs
+	return &rec, nil
 }
 
 // LoadOpenBrackets returns non-terminal brackets created within lookback,

--- a/app/router/internal/storage/bracket_repo_integration_test.go
+++ b/app/router/internal/storage/bracket_repo_integration_test.go
@@ -32,10 +32,15 @@ func newBracketTestRepo(t *testing.T) (*BracketRepo, context.Context) {
 	// with a unique-suffix-free schema and clean up after ourselves.
 	_, err = pool.Exec(ctx, `CREATE EXTENSION IF NOT EXISTS pgcrypto`)
 	require.NoError(t, err)
-	migration, err := os.ReadFile("../../../../db/migrations/030_brackets.sql")
-	require.NoError(t, err)
-	_, err = pool.Exec(ctx, string(migration))
-	require.NoError(t, err)
+	for _, file := range []string{
+		"../../../../db/migrations/030_brackets.sql",
+		"../../../../db/migrations/031_bracket_leg_placing.sql",
+	} {
+		migration, err := os.ReadFile(file)
+		require.NoError(t, err)
+		_, err = pool.Exec(ctx, string(migration))
+		require.NoError(t, err)
+	}
 	t.Cleanup(func() {
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cleanupCancel()
@@ -147,4 +152,62 @@ func TestBracketRepo_StatusTransitionsAndOpenBracketScan(t *testing.T) {
 	for i := range open {
 		assert.NotEqual(t, entryID, open[i].EntryClientOrderID, "closed bracket must leave the open scan")
 	}
+}
+
+func TestBracketRepo_TryMarkLegPlacingClaimsExactlyOnce(t *testing.T) {
+	repo, ctx := newBracketTestRepo(t)
+	entryID := "it-" + uuid.NewString()[:8]
+	rec, inserted, err := repo.Reserve(ctx, sampleBracket(entryID))
+	require.NoError(t, err)
+	require.True(t, inserted)
+
+	first, err := repo.TryMarkLegPlacing(ctx, rec.BracketID, entryID+"-sl")
+	require.NoError(t, err)
+	second, err := repo.TryMarkLegPlacing(ctx, rec.BracketID, entryID+"-sl")
+	require.NoError(t, err)
+	assert.Equal(t, [2]bool{true, false}, [2]bool{first, second})
+
+	// FAILED legs are re-claimable so transient errors cannot strand a position
+	require.NoError(t, repo.UpdateLegStatus(ctx, rec.BracketID, entryID+"-sl", LegStatusFailed, 0))
+	reclaimed, err := repo.TryMarkLegPlacing(ctx, rec.BracketID, entryID+"-sl")
+	require.NoError(t, err)
+	assert.True(t, reclaimed)
+}
+
+func TestBracketRepo_GetByLegClientOrderIDRoundTrips(t *testing.T) {
+	repo, ctx := newBracketTestRepo(t)
+	entryID := "it-" + uuid.NewString()[:8]
+	rec, inserted, err := repo.Reserve(ctx, sampleBracket(entryID))
+	require.NoError(t, err)
+	require.True(t, inserted)
+
+	found, err := repo.GetByLegClientOrderID(ctx, "SPOT", entryID+"-tp1")
+	require.NoError(t, err)
+	require.NotNil(t, found)
+	assert.Equal(t, rec.BracketID, found.BracketID)
+	assert.Len(t, found.Legs, 3)
+
+	missing, err := repo.GetByLegClientOrderID(ctx, "SPOT", "no-such-leg")
+	require.NoError(t, err)
+	assert.Nil(t, missing)
+
+	wrongVenue, err := repo.GetByLegClientOrderID(ctx, "USD_M", entryID+"-tp1")
+	require.NoError(t, err)
+	assert.Nil(t, wrongVenue)
+}
+
+func TestBracketRepo_UpdateBracketStatusIfGuardsTransition(t *testing.T) {
+	repo, ctx := newBracketTestRepo(t)
+	entryID := "it-" + uuid.NewString()[:8]
+	rec, inserted, err := repo.Reserve(ctx, sampleBracket(entryID))
+	require.NoError(t, err)
+	require.True(t, inserted)
+
+	applied, err := repo.UpdateBracketStatusIf(ctx, rec.BracketID, BracketStatusReserved, BracketStatusEntryPlaced)
+	require.NoError(t, err)
+	assert.True(t, applied)
+
+	notApplied, err := repo.UpdateBracketStatusIf(ctx, rec.BracketID, BracketStatusReserved, BracketStatusEntryPlaced)
+	require.NoError(t, err)
+	assert.False(t, notApplied, "guarded transition must not fire from the wrong state")
 }

--- a/db/migrations/031_bracket_leg_placing.sql
+++ b/db/migrations/031_bracket_leg_placing.sql
@@ -1,0 +1,11 @@
+-- 031_bracket_leg_placing.sql: PLACING claim state for fill-triggered legs.
+-- The leg armer claims a PLANNED leg (compare-and-set to PLACING) before
+-- POSTing so duplicate fill events cannot double-place protective legs.
+
+ALTER TABLE bracket_legs DROP CONSTRAINT IF EXISTS bracket_legs_status_check;
+ALTER TABLE bracket_legs ADD CONSTRAINT bracket_legs_status_check CHECK (
+    status IN ('PLANNED', 'PLACING', 'PLACED', 'FILLED', 'CANCELED', 'EXPIRED', 'FAILED')
+);
+
+-- The leg armer resolves every user-data event by leg client order id
+CREATE INDEX IF NOT EXISTS idx_bracket_legs_client_order_id ON bracket_legs (client_order_id);


### PR DESCRIPTION
## Summary

C4 — the core order-safety change of the series. Futures brackets currently POST ReduceOnly TPs before any position exists → `-2022` rejection; this PR defers exit legs until the entry actually fills, behind `BRACKET_LEGS_ON_FILL` (**default off**).

- **Entry-only placement**: exit legs stay PLANNED in the durable record (#194). Review round 1 caught that the record held **pre-rounding** prices — the armer would have POSTed off-tick SLs rejected with `-4014` at the exact moment positions opened, with retries poisoned by the same stored price. Rounding now precedes the reservation, and the armer defensively re-rounds (self-repairs pre-existing raw records).
- **LegArmer** consumes the serialized user-data stream (#195): entry FILLED (or terminal with partial fills — partial positions must be protected too) → per-leg PLANNED→PLACING compare-and-set claim (duplicate events can't double-place) → TP LIMIT ReduceOnly sized by executed quantity + SL STOP_MARKET ClosePosition under the reserved ids via #193's idempotent submission. **FAILED legs are re-claimable** — a transient POST error cannot permanently strand a position.
- **Explicit OCO**: SL fill cancels TPs; the final TP fill cancels the SL; dead entries release legs; CLOSED/FAILED brackets ignore late duplicates.
- **Crash recovery**: a replayed bracket whose adopted entry is terminal/filled places legs synchronously — its fill event is gone forever, and a live position means no `-2022`. Deferred bookkeeping uses a guarded `RESERVED→ENTRY_PLACED` transition so the HTTP goroutine can't downgrade an armer-advanced bracket.
- Migration **031**: PLACING status + `bracket_legs(client_order_id)` index (every user-data event resolves by leg id).

**⚠️ Flag must stay OFF until C6 (startup reconciler) merges**: a crash between fill and arming leaves `ENTRY_FILLED` brackets with PLANNED/PLACING legs that only a boot sweep repairs. C6 spec (from review): treat PLACING, FAILED, ENTRY_FILLED/ENTRY_PLACED as re-examinable work items.

Known/deferred (review round 1, disclosed): cached duplicate-request responses omit `legs_pending_trigger` (cosmetic); the engine is blind to futures leg fills (pre-existing — nothing emits `order_update.v1` for futures fills; C-series backlog).

## Review process note

QCHECK round 1: independent adversarial review → **BLOCK** (pre-rounding record C-1, no crash-recovery arming H-1, permanent FAILED legs H-2, +2 MEDIUMs). All findings fixed with dedicated regression tests. Round-2 re-verification was performed by me inline (subagent session quota exhausted until 8:20pm): verified the single record-write site runs post-rounding, both record-price readers re-round, the replay divergence guard is price-independent, and account-scoped ORDER_TRADE_UPDATE survives listen-key rotation for still-live adopted entries.

## Test plan

- 13 LegArmer tests: arm-on-fill (qty-sized), duplicate idempotency, pre-fill no-op, partial-fill-on-cancel arming, zero-fill release, SL-cancels-TPs, final-TP-cancels-SL, multi-TP (SL survives until last TP), placement-failure → FAILED+ENTRY_FILLED, FAILED re-claim, closed-bracket immunity, unknown-id no-op, sync-bracket immunity
- 9 bracket-store manager tests incl. defer-path (entry-only POST, planned ids in response, ENTRY_PLACED), no-store fallback, adopted-filled-entry sync placement
- 7 repo integration tests (TEST_DATABASE_URL-gated) incl. CAS exactly-once + FAILED re-claim, leg-id lookup with venue filter, guarded status transition; migrations 030+031 applied in fixture
- Full router suite, go vet, -race, 3× flake-stable, gofmt clean

**Deploy: apply migrations 030 + 031 before rolling. Keep BRACKET_LEGS_ON_FILL unset until C6.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)