### PR TITLE
feat(router): place spot bracket exits as OCO pairs on entry fill (C5)

### DIFF
--- a/app/router/cmd/router/main.go
+++ b/app/router/cmd/router/main.go
@@ -203,9 +203,45 @@ func main() {
 	if legArmer != nil {
 		// Deferring legs is only safe when an armer exists to place them
 		orderManager.SetLegsOnFill(true)
+	}
+
+	// The entry-fill watcher is spot's fill trigger (no production spot
+	// user-data stream) and the futures fallback sweep for events missed
+	// while the router was down.
+	var entryFillWatcher *orders.EntryFillWatcher
+	if legsOnFill && dbPool != nil {
+		var spotArmer *orders.SpotLegArmer
+		if spotClient != nil {
+			spotArmer = orders.NewSpotLegArmer(
+				storage.NewBracketRepo(dbPool),
+				spotClient,
+				eventEmitter,
+				logger.With().Str("component", "spot_leg_armer").Logger(),
+			)
+			orderManager.SetSpotLegsOnFill(true)
+			logger.Info().Msg("BRACKET_LEGS_ON_FILL enabled: spot exits placed as OCO on entry fill")
+		}
+		pollInterval := 2 * time.Second
+		if raw := os.Getenv("ENTRY_FILL_POLL_INTERVAL"); raw != "" {
+			if parsed, err := time.ParseDuration(raw); err == nil && parsed > 0 {
+				pollInterval = parsed
+			}
+		}
+		entryFillWatcher = orders.NewEntryFillWatcher(
+			storage.NewBracketRepo(dbPool),
+			spotClient,
+			spotArmer,
+			futuresClient,
+			legArmer,
+			pollInterval,
+			0, // default lookback
+			logger.With().Str("component", "entry_fill_watcher").Logger(),
+		)
+		entryFillWatcher.Start(context.Background())
+		logger.Info().Dur("interval", pollInterval).Msg("Entry fill watcher started")
 	} else if legsOnFill {
-		logger.Warn().Msg("BRACKET_LEGS_ON_FILL set but DATABASE_URL or futures trading " +
-			"is missing; exit legs will place synchronously")
+		logger.Warn().Msg("BRACKET_LEGS_ON_FILL set but DATABASE_URL is missing; " +
+			"exit legs will place synchronously")
 	}
 	var spotReconciler *orders.SpotReconciler
 	if spotClient != nil {
@@ -303,6 +339,9 @@ func main() {
 
 		if userDataIngestor != nil {
 			_ = userDataIngestor.Stop(context.Background())
+		}
+		if entryFillWatcher != nil {
+			entryFillWatcher.Stop()
 		}
 		if fundingCancel != nil {
 			fundingCancel()

--- a/app/router/internal/binance/oco.go
+++ b/app/router/internal/binance/oco.go
@@ -1,0 +1,36 @@
+package binance
+
+import (
+	"context"
+	"fmt"
+
+	"router/internal/rest"
+)
+
+// PlaceSpotOCO places a spot OCO exit pair (take-profit + stop) whose legs
+// the exchange sibling-cancels natively.
+func (c *Client) PlaceSpotOCO(ctx context.Context, req rest.OCORequest) (*rest.OCOResponse, error) {
+	if c.restClient == nil {
+		return nil, fmt.Errorf("rest client not available")
+	}
+	if c.isFutures {
+		return nil, fmt.Errorf("OCO order lists are spot-only")
+	}
+	resp, err := c.restClient.PlaceSpotOCO(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to place spot OCO: %w", err)
+	}
+	return resp, nil
+}
+
+// GetOCOByListClientOrderID resolves an OCO's state by list client order id.
+func (c *Client) GetOCOByListClientOrderID(ctx context.Context, listClientOrderID string) (*rest.OCOResponse, error) {
+	if c.restClient == nil {
+		return nil, fmt.Errorf("rest client not available")
+	}
+	resp, err := c.restClient.GetOCOByListClientOrderID(ctx, listClientOrderID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query spot OCO: %w", err)
+	}
+	return resp, nil
+}

--- a/app/router/internal/orders/bracket.go
+++ b/app/router/internal/orders/bracket.go
@@ -20,7 +20,10 @@ type bracketPlacementResult struct {
 // placeSpotBracket places a bracket order for spot trading. A non-nil
 // adoptedEntry is a replayed entry already live on the exchange: it is used
 // as the main order instead of POSTing, and exit legs place idempotently.
-func (m *Manager) placeSpotBracket(ctx context.Context, client *binance.Client, req *PlaceBracketRequest, bracketID string, adoptedEntry *binance.OrderResponse) (*bracketPlacementResult, error) {
+// With legsDeferred the exits stay PLANNED for the entry-fill watcher to
+// place as OCO pairs — synchronous spot TP+SL double-reserve the base asset,
+// which is the bug this mode fixes.
+func (m *Manager) placeSpotBracket(ctx context.Context, client *binance.Client, req *PlaceBracketRequest, bracketID string, adoptedEntry *binance.OrderResponse, legsDeferred bool) (*bracketPlacementResult, error) {
 	result := &bracketPlacementResult{
 		IDs: ClientOrderIDs{
 			TakeProfits: make([]string, len(req.TakeProfitPrices)),
@@ -60,6 +63,17 @@ func (m *Manager) placeSpotBracket(ctx context.Context, client *binance.Client, 
 	}
 	result.IDs.Main = mainOrderID
 	result.Main = mainResp
+
+	if legsDeferred {
+		// Report the reserved exit ids; the watcher arms OCO pairs on fill
+		copy(result.IDs.TakeProfits, plannedIDs.TakeProfits)
+		result.IDs.StopLoss = plannedIDs.StopLoss
+		m.logger.Info().
+			Str("symbol", req.Symbol).
+			Str("bracket_id", bracketID).
+			Msg("Spot exits deferred until entry fill (OCO)")
+		return result, nil
+	}
 
 	// 2. Place take profit orders (as limit orders)
 	// For spot, we can place these immediately

--- a/app/router/internal/orders/bracket_store_test.go
+++ b/app/router/internal/orders/bracket_store_test.go
@@ -72,11 +72,12 @@ func (f *fakeBracketStore) UpdateLegStatus(_ context.Context, _ uuid.UUID, clien
 	return nil
 }
 
-// bracketExchange serves the futures order endpoints, recording POSTed ids.
+// bracketExchange serves the order endpoints, recording POSTed ids.
 type bracketExchange struct {
 	mu             sync.Mutex
+	orderPath      string // defaults to /fapi/v1/order
 	postedIDs      []string
-	getStatus      int             // GET /fapi/v1/order: 200 live order, else -2013
+	getStatus      int             // GET order: 200 live order, else -2013
 	getOrderStatus string          // order status served on GET 200 (default NEW)
 	getExecutedQty string          // executed qty served on GET 200 (default "0")
 	postDupIDs     map[string]bool // POSTs of these ids are rejected as -4116 duplicates
@@ -90,8 +91,12 @@ func (f *bracketExchange) posted() []string {
 }
 
 func (f *bracketExchange) handler() http.HandlerFunc {
+	orderPath := f.orderPath
+	if orderPath == "" {
+		orderPath = "/fapi/v1/order"
+	}
 	return func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/fapi/v1/order" {
+		if r.URL.Path != orderPath {
 			w.WriteHeader(http.StatusNotFound)
 			_, _ = w.Write([]byte(`{"error":"not found"}`))
 			return
@@ -416,4 +421,70 @@ func TestPlaceBracketOrder_ReplayAdoptedFilledEntryPlacesLegsSynchronously(t *te
 	assert.ElementsMatch(t, []string{"engine-tp-9", "engine-sl-9"}, fake.posted(),
 		"the fill event is gone forever; legs must place now, not wait for it")
 	assert.False(t, resp.LegsPendingTrigger)
+}
+
+func TestPlaceBracketOrder_SpotReplayAdoptedFilledEntryKeepsLegsDeferred(t *testing.T) {
+	store := newFakeBracketStore()
+	store.existingRecord = &storage.BracketRecord{
+		BracketID:          uuid.New(),
+		Venue:              "SPOT",
+		Symbol:             "BTCUSDT",
+		Side:               "BUY",
+		EntryClientOrderID: "engine-main-9",
+		Status:             storage.BracketStatusEntryPlaced,
+		LegsOnFill:         true,
+	}
+	fake := &bracketExchange{
+		orderPath:      "/api/v3/order",
+		getStatus:      http.StatusOK,
+		getOrderStatus: "FILLED",
+		getExecutedQty: "0.02",
+	}
+	server := httptest.NewServer(fake.handler())
+	t.Cleanup(server.Close)
+	signer := auth.NewSignerWithRecvWindow("key", "secret", 5000)
+	spotRest := rest.NewClient(server.URL, signer)
+	spotClient, err := binance.NewSpotClient(server.URL, signer, spotRest, zerolog.Nop())
+	require.NoError(t, err)
+	manager := NewManager(spotClient, nil, nil, zerolog.Nop())
+	manager.SetBracketStore(store)
+	manager.SetSpotLegsOnFill(true)
+
+	req := storeBracketRequest()
+	req.IsFutures = false
+
+	resp, err := manager.PlaceBracketOrder(context.Background(), req)
+
+	require.NoError(t, err)
+	assert.Empty(t, fake.posted(),
+		"a spot replay must neither re-POST the entry nor fall back to the synchronous exit path")
+	assert.True(t, resp.LegsPendingTrigger,
+		"the entry-fill watcher owns spot exits even when the adopted entry is already filled")
+}
+
+func TestPlaceBracketOrder_SpotLegsOnFillDefersExitsForOCO(t *testing.T) {
+	store := newFakeBracketStore()
+	fake := &bracketExchange{orderPath: "/api/v3/order"}
+	server := httptest.NewServer(fake.handler())
+	t.Cleanup(server.Close)
+	signer := auth.NewSignerWithRecvWindow("key", "secret", 5000)
+	spotRest := rest.NewClient(server.URL, signer)
+	spotClient, err := binance.NewSpotClient(server.URL, signer, spotRest, zerolog.Nop())
+	require.NoError(t, err)
+	manager := NewManager(spotClient, nil, nil, zerolog.Nop())
+	manager.SetBracketStore(store)
+	manager.SetSpotLegsOnFill(true)
+
+	req := storeBracketRequest()
+	req.IsFutures = false
+
+	resp, err := manager.PlaceBracketOrder(context.Background(), req)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"engine-main-9"}, fake.posted(),
+		"spot exits must wait for the watcher's OCO placement")
+	assert.True(t, resp.LegsPendingTrigger)
+	require.Len(t, store.reserved, 1)
+	assert.True(t, store.reserved[0].LegsOnFill)
+	assert.Equal(t, []string{storage.BracketStatusEntryPlaced}, store.bracketUpdates)
 }

--- a/app/router/internal/orders/entry_fill_watcher.go
+++ b/app/router/internal/orders/entry_fill_watcher.go
@@ -1,0 +1,180 @@
+package orders
+
+import (
+	"context"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"router/internal/binance"
+	"router/internal/rest"
+	"router/internal/storage"
+)
+
+const defaultEntryFillLookback = 168 * time.Hour
+
+// watcherStore is the store slice the watcher needs beyond the armers.
+type watcherStore interface {
+	armerStore
+	LoadOpenBrackets(ctx context.Context, lookback time.Duration) ([]storage.BracketRecord, error)
+}
+
+// EntryFillWatcher polls open deferred brackets and arms exit legs once
+// their entries fill. Spot has no production user-data stream, so this loop
+// IS the spot fill trigger; for futures it is a fallback sweep behind the
+// event-driven leg armer (a fill received while the router was down would
+// otherwise never arm). The brackets table is the queue, so the watcher is
+// restart-safe by construction.
+type EntryFillWatcher struct {
+	store         watcherStore
+	spotClient    *binance.Client
+	spotArmer     *SpotLegArmer
+	futures       *LegArmer
+	futuresClient *binance.Client
+	interval      time.Duration
+	lookback      time.Duration
+	logger        zerolog.Logger
+
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+func NewEntryFillWatcher(
+	store watcherStore,
+	spotClient *binance.Client,
+	spotArmer *SpotLegArmer,
+	futuresClient *binance.Client,
+	futuresArmer *LegArmer,
+	interval time.Duration,
+	lookback time.Duration,
+	logger zerolog.Logger,
+) *EntryFillWatcher {
+	if interval <= 0 {
+		interval = 2 * time.Second
+	}
+	if lookback <= 0 {
+		lookback = defaultEntryFillLookback
+	}
+	return &EntryFillWatcher{
+		store:         store,
+		spotClient:    spotClient,
+		spotArmer:     spotArmer,
+		futures:       futuresArmer,
+		futuresClient: futuresClient,
+		interval:      interval,
+		lookback:      lookback,
+		logger:        logger,
+	}
+}
+
+func (w *EntryFillWatcher) Start(ctx context.Context) {
+	ctx, w.cancel = context.WithCancel(ctx)
+	w.done = make(chan struct{})
+	go func() {
+		defer close(w.done)
+		ticker := time.NewTicker(w.interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				w.pollOnce(ctx)
+			}
+		}
+	}()
+}
+
+func (w *EntryFillWatcher) Stop() {
+	if w.cancel != nil {
+		w.cancel()
+	}
+	if w.done != nil {
+		<-w.done
+	}
+}
+
+func (w *EntryFillWatcher) pollOnce(ctx context.Context) {
+	brackets, err := w.store.LoadOpenBrackets(ctx, w.lookback)
+	if err != nil {
+		w.logger.Warn().Err(err).Msg("entry fill watcher: load failed")
+		return
+	}
+
+	for i := range brackets {
+		record := &brackets[i]
+		if !record.LegsOnFill {
+			continue
+		}
+		// RESERVED is included: a crash between the entry POST and the
+		// bookkeeping write leaves a live entry on a RESERVED bracket, and
+		// nothing else would ever protect its fill. A not-yet-POSTed entry
+		// just resolves to -2013 and is skipped.
+		if record.Status != storage.BracketStatusReserved &&
+			record.Status != storage.BracketStatusEntryPlaced &&
+			record.Status != storage.BracketStatusEntryFilled {
+			continue
+		}
+		w.checkBracket(ctx, record)
+	}
+}
+
+func (w *EntryFillWatcher) checkBracket(ctx context.Context, record *storage.BracketRecord) {
+	client := w.spotClient
+	if record.Venue == "USD_M" {
+		client = w.futuresClient
+	}
+	if client == nil {
+		return
+	}
+
+	entry, err := client.GetOrderByClientID(ctx, record.Symbol, record.EntryClientOrderID)
+	if err != nil {
+		if !rest.IsOrderNotFound(err) {
+			w.logger.Warn().Err(err).
+				Str("client_order_id", record.EntryClientOrderID).
+				Msg("entry fill watcher: entry lookup failed")
+		}
+		return
+	}
+
+	switch normalizeOrderStatus(entry.Status) {
+	case "FILLED":
+		w.arm(ctx, record, entry)
+	case "CANCELED", "EXPIRED", "REJECTED":
+		if entry.ExecutedQty.IsPositive() {
+			// A partial position exists and must still be protected
+			w.arm(ctx, record, entry)
+			return
+		}
+		w.releaseDeadBracket(ctx, record)
+	}
+}
+
+func (w *EntryFillWatcher) arm(ctx context.Context, record *storage.BracketRecord, entry *binance.OrderResponse) {
+	if record.Venue == "USD_M" {
+		if w.futures != nil {
+			w.futures.armLegs(ctx, record, entry.ExecutedQty)
+		}
+		return
+	}
+	if w.spotArmer != nil {
+		w.spotArmer.Arm(ctx, record, entry)
+	}
+}
+
+func (w *EntryFillWatcher) releaseDeadBracket(ctx context.Context, record *storage.BracketRecord) {
+	for _, leg := range record.Legs {
+		if leg.Role == "ENTRY" || leg.Status == storage.LegStatusPlanned {
+			if err := w.store.UpdateLegStatus(ctx, record.BracketID, leg.ClientOrderID,
+				storage.LegStatusCanceled, leg.ExchangeOrderID); err != nil {
+				w.logger.Warn().Err(err).Str("client_order_id", leg.ClientOrderID).
+					Msg("entry fill watcher: failed to release leg")
+			}
+		}
+	}
+	if err := w.store.UpdateBracketStatus(ctx, record.BracketID, storage.BracketStatusClosed); err != nil {
+		w.logger.Warn().Err(err).Str("bracket_id", record.BracketID.String()).
+			Msg("entry fill watcher: failed to close dead bracket")
+	}
+}

--- a/app/router/internal/orders/entry_fill_watcher_test.go
+++ b/app/router/internal/orders/entry_fill_watcher_test.go
@@ -1,0 +1,144 @@
+package orders
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"router/internal/storage"
+)
+
+type fakeWatcherStore struct {
+	fakeArmerStore
+}
+
+func (f *fakeWatcherStore) LoadOpenBrackets(_ context.Context, _ time.Duration) ([]storage.BracketRecord, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.record == nil {
+		return nil, nil
+	}
+	rec := *f.record
+	rec.Legs = append([]storage.BracketLegRecord(nil), f.record.Legs...)
+	return []storage.BracketRecord{rec}, nil
+}
+
+func newWatcherFixture(t *testing.T, fake *spotOCOExchange, store *fakeWatcherStore) *EntryFillWatcher {
+	t.Helper()
+	spotArmer, spotClient := newSpotArmerFixture(t, fake, &store.fakeArmerStore)
+	return NewEntryFillWatcher(
+		store, spotClient, spotArmer, nil, nil,
+		time.Millisecond, time.Hour, zerolog.Nop(),
+	)
+}
+
+func TestEntryFillWatcher_ArmsSpotBracketWhenEntryFills(t *testing.T) {
+	store := &fakeWatcherStore{fakeArmerStore{record: spotArmerRecord()}}
+	fake := &spotOCOExchange{}
+	watcher := newWatcherFixture(t, fake, store)
+
+	watcher.pollOnce(context.Background())
+
+	require.Len(t, fake.requests(), 1, "filled entry must arm the OCO pair")
+	assert.Contains(t, store.bracketUpdates, storage.BracketStatusLegsPlaced)
+}
+
+func TestEntryFillWatcher_WaitsWhileEntryInvisibleOrOpen(t *testing.T) {
+	store := &fakeWatcherStore{fakeArmerStore{record: spotArmerRecord()}}
+	fake := &spotOCOExchange{getStatuses: []string{"NOT_FOUND", "NEW"}}
+	watcher := newWatcherFixture(t, fake, store)
+
+	watcher.pollOnce(context.Background()) // -2013: not visible yet
+	watcher.pollOnce(context.Background()) // NEW: resting, no fill
+
+	assert.Empty(t, fake.requests())
+	assert.Empty(t, store.bracketUpdates)
+}
+
+func TestEntryFillWatcher_ReleasesDeadEntryBracket(t *testing.T) {
+	store := &fakeWatcherStore{fakeArmerStore{record: spotArmerRecord()}}
+	fake := &spotOCOExchange{getStatuses: []string{"CANCELED"}, getOrderQty: "0"}
+	watcher := newWatcherFixture(t, fake, store)
+
+	watcher.pollOnce(context.Background())
+
+	assert.Empty(t, fake.requests())
+	assert.Contains(t, store.legUpdates, "arm-tp1:CANCELED")
+	assert.Contains(t, store.bracketUpdates, storage.BracketStatusClosed)
+}
+
+func TestEntryFillWatcher_ArmsPartialFillOnCanceledEntry(t *testing.T) {
+	store := &fakeWatcherStore{fakeArmerStore{record: spotArmerRecord()}}
+	fake := &spotOCOExchange{getStatuses: []string{"CANCELED"}, getOrderQty: "0.01"}
+	watcher := newWatcherFixture(t, fake, store)
+
+	watcher.pollOnce(context.Background())
+
+	requests := fake.requests()
+	require.Len(t, requests, 1, "a partial position must still be protected")
+	assert.Equal(t, "0.01", requests[0].Get("quantity"))
+}
+
+func TestEntryFillWatcher_SkipsSynchronousAndSettledBrackets(t *testing.T) {
+	syncRecord := spotArmerRecord()
+	syncRecord.LegsOnFill = false
+	store := &fakeWatcherStore{fakeArmerStore{record: syncRecord}}
+	fake := &spotOCOExchange{}
+	watcher := newWatcherFixture(t, fake, store)
+
+	watcher.pollOnce(context.Background())
+
+	settled := spotArmerRecord()
+	settled.Status = storage.BracketStatusClosed
+	store.mu.Lock()
+	store.record = settled
+	store.mu.Unlock()
+
+	watcher.pollOnce(context.Background())
+
+	assert.Empty(t, fake.requests())
+}
+
+func TestEntryFillWatcher_SweepsReservedBrackets(t *testing.T) {
+	record := spotArmerRecord()
+	record.Status = storage.BracketStatusReserved // crash before bookkeeping write
+	store := &fakeWatcherStore{fakeArmerStore{record: record}}
+	fake := &spotOCOExchange{}
+	watcher := newWatcherFixture(t, fake, store)
+
+	watcher.pollOnce(context.Background())
+
+	require.Len(t, fake.requests(), 1,
+		"a RESERVED bracket with a live filled entry must still be protected")
+	assert.Contains(t, store.bracketUpdates, storage.BracketStatusLegsPlaced)
+}
+
+func TestEntryFillWatcher_ReleaseKeepsEntryExchangeID(t *testing.T) {
+	record := spotArmerRecord()
+	record.Legs[0].ExchangeOrderID = 555
+	store := &fakeWatcherStore{fakeArmerStore{record: record}}
+	fake := &spotOCOExchange{getStatuses: []string{"CANCELED"}, getOrderQty: "0"}
+	watcher := newWatcherFixture(t, fake, store)
+
+	watcher.pollOnce(context.Background())
+
+	assert.Contains(t, store.bracketUpdates, storage.BracketStatusClosed)
+	assert.Equal(t, int64(555), store.legExchangeIDs["arm-main"],
+		"releasing a dead bracket must not erase the entry's exchange order id")
+}
+
+func TestEntryFillWatcher_StartStopLifecycle(t *testing.T) {
+	store := &fakeWatcherStore{fakeArmerStore{record: spotArmerRecord()}}
+	fake := &spotOCOExchange{}
+	watcher := newWatcherFixture(t, fake, store)
+
+	watcher.Start(context.Background())
+	require.Eventually(t, func() bool {
+		return len(fake.requests()) == 1
+	}, 2*time.Second, 5*time.Millisecond, "the polling loop must arm on its own")
+	watcher.Stop()
+}

--- a/app/router/internal/orders/leg_armer.go
+++ b/app/router/internal/orders/leg_armer.go
@@ -13,13 +13,14 @@ import (
 	"router/internal/websocket"
 )
 
-// armerStore is the slice of the bracket store the leg armer needs.
+// armerStore is the slice of the bracket store the leg armers need.
 type armerStore interface {
 	GetByEntryClientOrderID(ctx context.Context, venue, entryClientOrderID string) (*storage.BracketRecord, error)
 	GetByLegClientOrderID(ctx context.Context, venue, clientOrderID string) (*storage.BracketRecord, error)
 	TryMarkLegPlacing(ctx context.Context, bracketID uuid.UUID, clientOrderID string) (bool, error)
 	UpdateLegStatus(ctx context.Context, bracketID uuid.UUID, clientOrderID, status string, exchangeOrderID int64) error
 	UpdateBracketStatus(ctx context.Context, bracketID uuid.UUID, status string) error
+	InsertLeg(ctx context.Context, leg storage.BracketLegRecord) error
 }
 
 // LegArmer places protective TP/SL legs when a deferred bracket's entry

--- a/app/router/internal/orders/leg_armer_test.go
+++ b/app/router/internal/orders/leg_armer_test.go
@@ -26,7 +26,8 @@ type fakeArmerStore struct {
 	mu             sync.Mutex
 	record         *storage.BracketRecord
 	bracketUpdates []string
-	legUpdates     []string // "clientOrderID:status"
+	legUpdates     []string         // "clientOrderID:status"
+	legExchangeIDs map[string]int64 // last exchange id written per leg
 }
 
 func (f *fakeArmerStore) get(clientOrderID string, entryOnly bool) *storage.BracketRecord {
@@ -79,6 +80,10 @@ func (f *fakeArmerStore) UpdateLegStatus(_ context.Context, _ uuid.UUID, clientO
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.legUpdates = append(f.legUpdates, clientOrderID+":"+status)
+	if f.legExchangeIDs == nil {
+		f.legExchangeIDs = map[string]int64{}
+	}
+	f.legExchangeIDs[clientOrderID] = exchangeOrderID
 	for i := range f.record.Legs {
 		if f.record.Legs[i].ClientOrderID == clientOrderID {
 			f.record.Legs[i].Status = status
@@ -95,6 +100,14 @@ func (f *fakeArmerStore) UpdateBracketStatus(_ context.Context, _ uuid.UUID, sta
 	defer f.mu.Unlock()
 	f.bracketUpdates = append(f.bracketUpdates, status)
 	f.record.Status = status
+	return nil
+}
+
+func (f *fakeArmerStore) InsertLeg(_ context.Context, leg storage.BracketLegRecord) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.legUpdates = append(f.legUpdates, leg.ClientOrderID+":"+leg.Status)
+	f.record.Legs = append(f.record.Legs, leg)
 	return nil
 }
 

--- a/app/router/internal/orders/manager.go
+++ b/app/router/internal/orders/manager.go
@@ -36,9 +36,10 @@ type Manager struct {
 	// Durable reservation store; nil keeps in-memory-only idempotency
 	bracketStore BracketStore
 
-	// Defer futures TP/SL placement until the entry fills (requires the
-	// bracket store: planned legs must survive a crash)
-	legsOnFill bool
+	// Defer TP/SL placement until the entry fills (requires the bracket
+	// store: planned legs must survive a crash)
+	legsOnFill     bool // futures, armed by the user-data leg armer
+	spotLegsOnFill bool // spot, armed by the entry-fill watcher via OCO
 
 	// Logger
 	logger zerolog.Logger
@@ -68,12 +69,28 @@ func (m *Manager) SetLegsOnFill(enabled bool) {
 	m.legsOnFill = enabled
 }
 
+// SetSpotLegsOnFill defers spot exits (as OCO pairs) until the entry fills.
+func (m *Manager) SetSpotLegsOnFill(enabled bool) {
+	m.spotLegsOnFill = enabled
+}
+
 // futuresLegsDeferred reports whether this request's exit legs are placed by
 // the leg armer on entry fill instead of synchronously.
 func (m *Manager) futuresLegsDeferred(req *PlaceBracketRequest) bool {
 	return m.legsOnFill &&
 		m.bracketStore != nil &&
 		req.IsFutures &&
+		req.ClientOrderIDs != nil &&
+		req.ClientOrderIDs.Main != ""
+}
+
+// spotLegsDeferred reports whether this request's exits are placed as OCO
+// pairs by the entry-fill watcher instead of synchronously (which
+// double-reserves the base asset across the resting TP and SL).
+func (m *Manager) spotLegsDeferred(req *PlaceBracketRequest) bool {
+	return m.spotLegsOnFill &&
+		m.bracketStore != nil &&
+		!req.IsFutures &&
 		req.ClientOrderIDs != nil &&
 		req.ClientOrderIDs.Main != ""
 }
@@ -348,7 +365,7 @@ func (m *Manager) PlaceBracketOrder(ctx context.Context, req *PlaceBracketReques
 	// is verified against the exchange so it is adopted, never re-POSTed.
 	var reservedBracketID uuid.UUID
 	var adoptedEntry *binance.OrderResponse
-	legsDeferred := m.futuresLegsDeferred(req)
+	legsDeferred := m.futuresLegsDeferred(req) || m.spotLegsDeferred(req)
 	if m.bracketStore != nil && req.ClientOrderIDs != nil && req.ClientOrderIDs.Main != "" {
 		record, inserted, reserveErr := m.bracketStore.Reserve(ctx, bracketRecordFromRequest(req, legsDeferred))
 		switch {
@@ -370,12 +387,16 @@ func (m *Manager) PlaceBracketOrder(ctx context.Context, req *PlaceBracketReques
 				return nil, replayErr
 			}
 			adoptedEntry = entry
-			if adoptedEntry != nil &&
+			if adoptedEntry != nil && req.IsFutures &&
 				(isTerminalOrderStatus(normalizeOrderStatus(adoptedEntry.Status)) ||
 					adoptedEntry.ExecutedQty.IsPositive()) {
-				// The fill event was consumed (or lost) in a previous process
-				// life and will never arrive again — place exit legs now.
-				// A position exists, so ReduceOnly cannot -2022.
+				// The futures fill event was consumed (or lost) in a previous
+				// process life and will never arrive again — place exit legs
+				// now. A position exists, so ReduceOnly cannot -2022.
+				// Spot stays deferred: its trigger is the polling watcher (no
+				// event to lose), and the synchronous spot path would
+				// double-reserve the base asset and fail closed by
+				// market-selling a healthy position.
 				legsDeferred = false
 			}
 		}
@@ -403,13 +424,19 @@ func (m *Manager) PlaceBracketOrder(ctx context.Context, req *PlaceBracketReques
 	}
 
 	// Pre-check algo order count to avoid Binance MAX_NUM_ALGO_ORDERS rejection.
-	// Binance allows 5 algo orders per symbol; a bracket needs at least 1 SL slot.
+	// Binance allows 5 algo orders per symbol. A synchronous bracket needs 1
+	// SL slot; deferred spot exits need one STOP_LOSS_LIMIT per OCO slice.
+	requiredAlgoSlots := 1
+	if legsDeferred && !req.IsFutures && len(req.TakeProfitPrices) > 1 {
+		requiredAlgoSlots = len(req.TakeProfitPrices)
+	}
 	algoCount, algoErr := countAlgoOrders(ctx, client, req.Symbol)
 	if algoErr != nil {
 		m.logger.Warn().Err(algoErr).Str("symbol", req.Symbol).
 			Msg("Algo order count check failed; proceeding with placement")
-	} else if algoCount >= 5 {
-		return nil, fmt.Errorf("too many open algo orders for %s: %d/5", req.Symbol, algoCount)
+	} else if algoCount+requiredAlgoSlots > 5 {
+		return nil, fmt.Errorf("too many open algo orders for %s: %d/5 with %d slots needed",
+			req.Symbol, algoCount, requiredAlgoSlots)
 	}
 
 	// Place the bracket orders
@@ -425,7 +452,7 @@ func (m *Manager) PlaceBracketOrder(ctx context.Context, req *PlaceBracketReques
 	if req.IsFutures {
 		placement, err = m.placeFuturesBracket(ctx, client, req, bracketID, adoptedEntry, legsDeferred)
 	} else {
-		placement, err = m.placeSpotBracket(ctx, client, req, bracketID, adoptedEntry)
+		placement, err = m.placeSpotBracket(ctx, client, req, bracketID, adoptedEntry, legsDeferred)
 	}
 	response.LegsPendingTrigger = legsDeferred && err == nil
 	if placement != nil {

--- a/app/router/internal/orders/spot_oco.go
+++ b/app/router/internal/orders/spot_oco.go
@@ -1,0 +1,566 @@
+package orders
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"sort"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/shopspring/decimal"
+
+	"router/internal/binance"
+	"router/internal/rest"
+	"router/internal/storage"
+)
+
+const maxClientOrderIDLength = 36
+
+// Repoll knobs bridging the exchange's post-accept visibility lag when an
+// OCO placement outcome must be resolved by query (test-overridable).
+var (
+	ocoRepollDelay    = 500 * time.Millisecond
+	ocoRepollAttempts = 2
+)
+
+// sliceOutcome is what became of one OCO slice during an arm pass.
+type sliceOutcome int
+
+const (
+	slicePlaced  sliceOutcome = iota // OCO live on the exchange (or adopted)
+	sliceClosed                      // slice settled: closed at market or nothing left to protect
+	sliceFailed                      // placement failed; FAILED legs are re-claimed next poll
+	slicePending                     // outcome unknown; resolved against the exchange next poll
+)
+
+// spotOCOSlice pairs one take-profit slice with its share of the stop.
+type spotOCOSlice struct {
+	index  int
+	tpLeg  storage.BracketLegRecord
+	stopID string // reserved SL id for the first slice, derived beyond that
+	req    rest.OCORequest
+}
+
+// SpotLegArmer places OCO exit pairs for deferred spot brackets once their
+// entry fills. Spot has no production user-data stream, so the entry-fill
+// watcher drives it by polling; the exchange sibling-cancels each pair, so
+// no router-side exit-event handling is needed.
+type SpotLegArmer struct {
+	store   armerStore
+	client  *binance.Client
+	emitter EventEmitter
+	logger  zerolog.Logger
+}
+
+func NewSpotLegArmer(
+	store armerStore,
+	spotClient *binance.Client,
+	emitter EventEmitter,
+	logger zerolog.Logger,
+) *SpotLegArmer {
+	return &SpotLegArmer{
+		store:   store,
+		client:  spotClient,
+		emitter: emitter,
+		logger:  logger,
+	}
+}
+
+// Arm places OCO exits for the entry's executed quantity. Idempotent through
+// the per-leg PLANNED|FAILED→PLACING claim, exchange-resolved recovery of
+// PLACING legs, and duplicate-list adoption; the watcher's polling loop is
+// the retry mechanism for anything left FAILED or unresolved.
+func (a *SpotLegArmer) Arm(ctx context.Context, record *storage.BracketRecord, entry *binance.OrderResponse) {
+	if entry == nil || !entry.ExecutedQty.IsPositive() {
+		return
+	}
+	if record.Status == storage.BracketStatusClosed || record.Status == storage.BracketStatusFailed {
+		return
+	}
+
+	step := decimal.Zero
+	if s, err := a.client.StepSize(ctx, record.Symbol); err == nil {
+		step = s
+	}
+	qty := a.protectableQuantity(ctx, record.Symbol, entry, step)
+	if !qty.IsPositive() {
+		a.logger.Error().
+			Str("bracket_id", record.BracketID.String()).
+			Str("symbol", record.Symbol).
+			Str("executed_qty", entry.ExecutedQty.String()).
+			Msg("spot armer: fill nets to unsellable dust after fees; closing bracket")
+		a.releaseUnarmedLegs(ctx, record)
+		return
+	}
+
+	slices := a.buildSpotExitOCOs(ctx, record, qty)
+	if len(slices) == 0 {
+		a.logger.Error().
+			Str("bracket_id", record.BracketID.String()).
+			Str("symbol", record.Symbol).
+			Msg("spot armer: no reserved TP/SL legs; cannot protect position")
+		a.updateBracketStatus(ctx, record, storage.BracketStatusEntryFilled)
+		return
+	}
+
+	var placed, failed, pending int
+	for _, slice := range slices {
+		if !slice.req.Quantity.IsPositive() {
+			// Dust slice: the remainder rides in the last slice, so no
+			// stop coverage is lost by cancelling this pair.
+			a.updateLegStatus(ctx, record, slice.tpLeg.ClientOrderID, storage.LegStatusCanceled, 0, decimal.Zero, slice.index+1)
+			a.updateLegStatus(ctx, record, slice.stopID, storage.LegStatusCanceled, 0, decimal.Zero, slice.index+1)
+			continue
+		}
+		switch a.armSlice(ctx, record, slice) {
+		case slicePlaced:
+			placed++
+		case sliceFailed:
+			failed++
+		case slicePending:
+			pending++
+		}
+	}
+
+	status := storage.BracketStatusEntryFilled // keeps the watcher retrying
+	switch {
+	case failed == 0 && pending == 0 && placed > 0:
+		status = storage.BracketStatusLegsPlaced
+	case failed == 0 && pending == 0:
+		status = storage.BracketStatusClosed // every slice settled without a resting exit
+	}
+	a.updateBracketStatus(ctx, record, status)
+}
+
+// protectableQuantity nets base-asset entry commissions out of the executed
+// quantity (spot BUY fees are deducted from the received asset, so the gross
+// fill overstates what can be sold) and floors to the lot step so every
+// derived slice stays step-aligned.
+func (a *SpotLegArmer) protectableQuantity(
+	ctx context.Context,
+	symbol string,
+	entry *binance.OrderResponse,
+	step decimal.Decimal,
+) decimal.Decimal {
+	qty := entry.ExecutedQty
+	if entry.OrderID > 0 {
+		info, infoErr := a.client.GetSymbolInfo(ctx, symbol)
+		if infoErr == nil && info != nil && info.BaseAsset != "" {
+			if trades, err := a.client.GetMyTrades(ctx, symbol, entry.OrderID); err == nil {
+				for _, trade := range trades {
+					if trade.CommissionAsset == info.BaseAsset {
+						qty = qty.Sub(trade.Commission)
+					}
+				}
+			} else {
+				a.logger.Warn().Err(err).Str("symbol", symbol).
+					Msg("spot armer: trade lookup failed; using gross fill quantity")
+			}
+		}
+	}
+	if step.IsPositive() {
+		qty = qty.Div(step).Floor().Mul(step)
+	}
+	return qty
+}
+
+// buildSpotExitOCOs pairs every take-profit slice with a stop slice of the
+// same quantity at the shared stop price, so total stop coverage always
+// equals the protected position.
+func (a *SpotLegArmer) buildSpotExitOCOs(
+	ctx context.Context,
+	record *storage.BracketRecord,
+	executedQty decimal.Decimal,
+) []spotOCOSlice {
+	tpLegs := legsByRole(record, "TP")
+	slLegs := legsByRole(record, "SL")
+	if len(tpLegs) == 0 || len(slLegs) == 0 {
+		return nil
+	}
+	// Slice index ↔ leg pairing must be stable across restarts: derived
+	// stop ids are keyed by position, and leg load order is not guaranteed.
+	// Arm-time SL-role inserts carry tp_index >= 1, so the reservation's SL
+	// always sorts first.
+	sort.SliceStable(tpLegs, func(i, j int) bool { return tpLegs[i].TPIndex < tpLegs[j].TPIndex })
+	sort.SliceStable(slLegs, func(i, j int) bool { return slLegs[i].TPIndex < slLegs[j].TPIndex })
+	reservedStopID := slLegs[0].ClientOrderID
+
+	exitSide := getOppositeSide(record.Side)
+	step := decimal.Zero
+	tickSize := decimal.Zero
+	if s, err := a.client.StepSize(ctx, record.Symbol); err == nil {
+		step = s
+	}
+	if info, err := a.client.GetSymbolInfo(ctx, record.Symbol); err == nil && info != nil {
+		tickSize = info.TickSize
+	}
+	quantities := splitTakeProfitQuantities(executedQty, len(tpLegs), step)
+
+	stopPrice := record.StopLossPrice
+	tpDir, slDir := binance.RoundUp, binance.RoundDown
+	if record.Side == "SELL" {
+		tpDir, slDir = binance.RoundDown, binance.RoundUp
+	}
+	if rounded, err := a.client.RoundPriceDirection(ctx, record.Symbol, stopPrice, slDir); err == nil {
+		stopPrice = rounded
+	}
+	stopLimitPrice := stopLossLimitPriceForSpotBracket(stopPrice, record.Side, tickSize)
+
+	slices := make([]spotOCOSlice, 0, len(tpLegs))
+	for i, tpLeg := range tpLegs {
+		tpPrice := tpLeg.Price
+		if rounded, err := a.client.RoundPriceDirection(ctx, record.Symbol, tpPrice, tpDir); err == nil {
+			tpPrice = rounded
+		}
+		stopID := reservedStopID
+		if i > 0 {
+			// A single SL was reserved; extra slices need their own stop ids
+			stopID = deriveSliceID(reservedStopID, i)
+		}
+		tpPriceLimit := decimal.Zero
+		if record.Side == "SELL" {
+			// BUY exits are TAKE_PROFIT_LIMITs: activation cancels the OCO
+			// sibling, so the limit sits marketably above the trigger to
+			// convert a touch into a fill instead of a stop-less rest.
+			tpPriceLimit = stopLossLimitPriceForSpotBracket(tpPrice, "SELL", tickSize)
+		}
+		slices = append(slices, spotOCOSlice{
+			index:  i,
+			tpLeg:  tpLeg,
+			stopID: stopID,
+			req: rest.OCORequest{
+				Symbol:             record.Symbol,
+				Side:               exitSide,
+				Quantity:           quantities[i],
+				Price:              tpPrice,
+				PriceLimit:         tpPriceLimit,
+				StopPrice:          stopPrice,
+				StopLimitPrice:     stopLimitPrice,
+				ListClientOrderID:  deriveSliceID(record.EntryClientOrderID+"-oco", i),
+				LimitClientOrderID: tpLeg.ClientOrderID,
+				StopClientOrderID:  stopID,
+			},
+		})
+	}
+	return slices
+}
+
+// armSlice claims and places one OCO pair. The claim is on the TP leg id
+// (unique per slice); statuses left by prior lives are resolved against the
+// exchange, never guessed at.
+func (a *SpotLegArmer) armSlice(ctx context.Context, record *storage.BracketRecord, slice spotOCOSlice) sliceOutcome {
+	leg := slice.tpLeg
+	switch leg.Status {
+	case storage.LegStatusPlaced, storage.LegStatusFilled:
+		return slicePlaced
+	case storage.LegStatusCanceled, storage.LegStatusExpired:
+		return sliceClosed
+	case storage.LegStatusPlacing:
+		// A previous life crashed mid-placement; only the exchange knows
+		// whether the list landed.
+		return a.resolveStalePlacing(ctx, record, slice)
+	case storage.LegStatusPlanned, storage.LegStatusFailed:
+	default:
+		return sliceFailed
+	}
+
+	claimed, err := a.store.TryMarkLegPlacing(ctx, record.BracketID, leg.ClientOrderID)
+	if err != nil {
+		a.logger.Error().Err(err).Str("client_order_id", leg.ClientOrderID).
+			Msg("spot armer: failed to claim leg")
+		return sliceFailed
+	}
+	if !claimed {
+		// The record is stale versus the store; re-read next poll
+		return slicePending
+	}
+
+	resp, err := a.client.PlaceSpotOCO(ctx, slice.req)
+	if err == nil {
+		a.persistSliceOutcome(ctx, record, slice, resp)
+		return slicePlaced
+	}
+
+	switch {
+	case rest.IsDuplicateClientOrderID(err) || errors.Is(err, rest.ErrAmbiguousSubmit):
+		return a.resolveAfterUnknownOutcome(ctx, record, slice, err)
+	case rest.IsPriceRelationRejection(err):
+		// Price gapped past the exit levels while the slice was unprotected;
+		// the same OCO can never be accepted, so fail closed at market.
+		a.logger.Error().Err(err).
+			Str("client_order_id", leg.ClientOrderID).
+			Str("symbol", record.Symbol).
+			Msg("spot armer: OCO prices already breached; closing slice at market")
+		return a.emergencyCloseSlice(ctx, record, slice)
+	default:
+		a.logger.Error().Err(err).
+			Str("client_order_id", leg.ClientOrderID).
+			Str("symbol", record.Symbol).
+			Msg("spot armer: OCO placement FAILED — position may be unprotected")
+		a.updateLegStatus(ctx, record, leg.ClientOrderID, storage.LegStatusFailed, 0, slice.req.Quantity, slice.index+1)
+		a.updateLegStatus(ctx, record, slice.stopID, storage.LegStatusFailed, 0, slice.req.Quantity, slice.index+1)
+		return sliceFailed
+	}
+}
+
+// resolveAfterUnknownOutcome settles a POST whose result is unknown
+// (transport ambiguity) or asserted-duplicate. #193 discipline: never blind
+// re-POST — the previous attempt may be live, and a re-accepted list would
+// double-sell the position.
+func (a *SpotLegArmer) resolveAfterUnknownOutcome(
+	ctx context.Context,
+	record *storage.BracketRecord,
+	slice spotOCOSlice,
+	postErr error,
+) sliceOutcome {
+	duplicate := rest.IsDuplicateClientOrderID(postErr)
+	adopted, err := a.getOCOWithRepoll(ctx, slice.req.ListClientOrderID)
+	if err == nil {
+		a.logger.Warn().Str("list_client_order_id", slice.req.ListClientOrderID).
+			Msg("spot armer: adopted existing OCO list")
+		a.persistSliceOutcome(ctx, record, slice, adopted)
+		return slicePlaced
+	}
+	if rest.IsOrderNotFound(err) && !duplicate {
+		// Confirmed absent: the ambiguous POST never landed; safe to retry
+		a.updateLegStatus(ctx, record, slice.tpLeg.ClientOrderID, storage.LegStatusFailed, 0, slice.req.Quantity, slice.index+1)
+		a.updateLegStatus(ctx, record, slice.stopID, storage.LegStatusFailed, 0, slice.req.Quantity, slice.index+1)
+		return sliceFailed
+	}
+	// Duplicate-but-invisible, or the query itself failed: unresolved. The
+	// leg stays PLACING so the next poll re-checks the exchange instead of
+	// re-POSTing.
+	a.logger.Error().Err(postErr).
+		Str("list_client_order_id", slice.req.ListClientOrderID).
+		AnErr("query_error", err).
+		Msg("spot armer: OCO outcome unresolved; re-checking next poll")
+	return slicePending
+}
+
+// resolveStalePlacing recovers a leg a previous process life left PLACING:
+// adopt the list if it landed, release the claim to FAILED if the exchange
+// confirms it never did.
+func (a *SpotLegArmer) resolveStalePlacing(
+	ctx context.Context,
+	record *storage.BracketRecord,
+	slice spotOCOSlice,
+) sliceOutcome {
+	adopted, err := a.getOCOWithRepoll(ctx, slice.req.ListClientOrderID)
+	if err == nil {
+		a.logger.Warn().Str("list_client_order_id", slice.req.ListClientOrderID).
+			Msg("spot armer: adopted OCO list left PLACING by a previous run")
+		a.persistSliceOutcome(ctx, record, slice, adopted)
+		return slicePlaced
+	}
+	if rest.IsOrderNotFound(err) {
+		a.updateLegStatus(ctx, record, slice.tpLeg.ClientOrderID, storage.LegStatusFailed, 0, slice.req.Quantity, slice.index+1)
+		a.updateLegStatus(ctx, record, slice.stopID, storage.LegStatusFailed, 0, slice.req.Quantity, slice.index+1)
+		return sliceFailed
+	}
+	a.logger.Warn().Err(err).Str("list_client_order_id", slice.req.ListClientOrderID).
+		Msg("spot armer: PLACING leg unresolved; re-checking next poll")
+	return slicePending
+}
+
+// getOCOWithRepoll queries an order list by its list client id, re-polling
+// on -2013 to bridge the exchange's post-accept visibility lag (#193).
+func (a *SpotLegArmer) getOCOWithRepoll(ctx context.Context, listClientOrderID string) (*rest.OCOResponse, error) {
+	resp, err := a.client.GetOCOByListClientOrderID(ctx, listClientOrderID)
+	for attempt := 0; attempt < ocoRepollAttempts && err != nil && rest.IsOrderNotFound(err); attempt++ {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(ocoRepollDelay):
+		}
+		resp, err = a.client.GetOCOByListClientOrderID(ctx, listClientOrderID)
+	}
+	return resp, err
+}
+
+// emergencyCloseSlice market-closes one slice's quantity when its OCO can
+// never be accepted (price already through the exit levels). The derived
+// close id keeps the close idempotent across retries and restarts.
+func (a *SpotLegArmer) emergencyCloseSlice(
+	ctx context.Context,
+	record *storage.BracketRecord,
+	slice spotOCOSlice,
+) sliceOutcome {
+	closeID := deriveSliceID(record.EntryClientOrderID+"-mc", slice.index)
+	resp, err := submitResolvingAmbiguity(
+		ctx, a.logger, a.client, record.Symbol, closeID, false,
+		func(ctx context.Context) (*binance.OrderResponse, error) {
+			return a.client.PlaceSpotOrder(ctx, binance.SpotOrderRequest{
+				Symbol:           record.Symbol,
+				Side:             slice.req.Side,
+				Type:             "MARKET",
+				Quantity:         slice.req.Quantity,
+				NewClientOrderID: closeID,
+			})
+		})
+	if err != nil {
+		a.logger.Error().Err(err).
+			Str("client_order_id", closeID).
+			Str("symbol", record.Symbol).
+			Msg("spot armer: emergency market close FAILED — position unprotected")
+		a.updateLegStatus(ctx, record, slice.tpLeg.ClientOrderID, storage.LegStatusFailed, 0, slice.req.Quantity, slice.index+1)
+		a.updateLegStatus(ctx, record, slice.stopID, storage.LegStatusFailed, 0, slice.req.Quantity, slice.index+1)
+		return sliceFailed
+	}
+
+	a.updateLegStatus(ctx, record, slice.tpLeg.ClientOrderID, storage.LegStatusCanceled, 0, decimal.Zero, slice.index+1)
+	a.updateLegStatus(ctx, record, slice.stopID, storage.LegStatusCanceled, 0, decimal.Zero, slice.index+1)
+	// Record the close as a placed SL-role leg for provenance
+	a.updateLegStatus(ctx, record, closeID, storage.LegStatusPlaced, resp.OrderID, slice.req.Quantity, slice.index+1)
+	a.emitCloseUpdate(ctx, record, slice, closeID, resp)
+	return sliceClosed
+}
+
+func (a *SpotLegArmer) persistSliceOutcome(
+	ctx context.Context,
+	record *storage.BracketRecord,
+	slice spotOCOSlice,
+	resp *rest.OCOResponse,
+) {
+	exchangeIDs := make(map[string]int64, len(resp.Orders))
+	for _, order := range resp.Orders {
+		exchangeIDs[order.ClientOrderID] = order.OrderID
+	}
+	a.updateLegStatus(ctx, record, slice.tpLeg.ClientOrderID, storage.LegStatusPlaced,
+		exchangeIDs[slice.tpLeg.ClientOrderID], slice.req.Quantity, slice.index+1)
+	a.updateLegStatus(ctx, record, slice.stopID, storage.LegStatusPlaced,
+		exchangeIDs[slice.stopID], slice.req.Quantity, slice.index+1)
+	a.emitSliceUpdates(ctx, record, slice, resp)
+}
+
+// updateLegStatus persists a leg outcome; ids without a reserved row (stop
+// slices and emergency closes derived at arm time) get one inserted. The
+// insert's tpIndex must be >= 1 so the reservation's SL keeps sorting first
+// and reservedStopID stays stable across arm passes.
+func (a *SpotLegArmer) updateLegStatus(
+	ctx context.Context,
+	record *storage.BracketRecord,
+	clientOrderID, status string,
+	exchangeOrderID int64,
+	quantity decimal.Decimal,
+	tpIndex int,
+) {
+	if legByClientOrderID(record, clientOrderID) == nil {
+		if err := a.store.InsertLeg(ctx, storage.BracketLegRecord{
+			BracketID:       record.BracketID,
+			Role:            "SL",
+			TPIndex:         tpIndex,
+			ClientOrderID:   clientOrderID,
+			StopPrice:       record.StopLossPrice,
+			Quantity:        quantity,
+			Status:          status,
+			ExchangeOrderID: exchangeOrderID,
+		}); err != nil {
+			a.logger.Warn().Err(err).Str("client_order_id", clientOrderID).
+				Msg("spot armer: failed to insert derived leg")
+		}
+		return
+	}
+	if err := a.store.UpdateLegStatus(ctx, record.BracketID, clientOrderID, status, exchangeOrderID); err != nil {
+		a.logger.Warn().Err(err).
+			Str("client_order_id", clientOrderID).
+			Str("status", status).
+			Msg("spot armer: failed to persist leg status")
+	}
+}
+
+func (a *SpotLegArmer) updateBracketStatus(ctx context.Context, record *storage.BracketRecord, status string) {
+	if err := a.store.UpdateBracketStatus(ctx, record.BracketID, status); err != nil {
+		a.logger.Warn().Err(err).Str("bracket_id", record.BracketID.String()).
+			Msg("spot armer: failed to persist bracket status")
+	}
+}
+
+// releaseUnarmedLegs cancels every leg that never reached the exchange and
+// closes the bracket — used when there is nothing protectable to arm.
+func (a *SpotLegArmer) releaseUnarmedLegs(ctx context.Context, record *storage.BracketRecord) {
+	for _, leg := range record.Legs {
+		if leg.Status == storage.LegStatusPlanned || leg.Status == storage.LegStatusFailed {
+			a.updateLegStatus(ctx, record, leg.ClientOrderID, storage.LegStatusCanceled, leg.ExchangeOrderID, decimal.Zero, leg.TPIndex)
+		}
+	}
+	a.updateBracketStatus(ctx, record, storage.BracketStatusClosed)
+}
+
+func (a *SpotLegArmer) emitSliceUpdates(
+	ctx context.Context,
+	record *storage.BracketRecord,
+	slice spotOCOSlice,
+	resp *rest.OCOResponse,
+) {
+	if a.emitter == nil {
+		return
+	}
+	for _, report := range resp.OrderReports {
+		update := &OrderUpdate{
+			EventType:     "order_update.v1",
+			Venue:         "SPOT",
+			Symbol:        record.Symbol,
+			OrderID:       report.OrderID,
+			ClientOrderID: report.ClientOrderID,
+			Status:        normalizeOrderStatus(report.Status),
+			Side:          slice.req.Side,
+			OrderType:     report.Type,
+			Price:         report.Price,
+			Quantity:      report.OrigQty,
+			UpdateTime:    time.Now().UTC(),
+		}
+		if err := a.emitter.EmitOrderUpdate(ctx, update); err != nil {
+			a.logger.Warn().Err(err).
+				Str("client_order_id", report.ClientOrderID).
+				Msg("spot armer: failed to emit order update")
+		}
+	}
+}
+
+func (a *SpotLegArmer) emitCloseUpdate(
+	ctx context.Context,
+	record *storage.BracketRecord,
+	slice spotOCOSlice,
+	closeID string,
+	resp *binance.OrderResponse,
+) {
+	if a.emitter == nil {
+		return
+	}
+	update := &OrderUpdate{
+		EventType:     "order_update.v1",
+		Venue:         "SPOT",
+		Symbol:        record.Symbol,
+		OrderID:       resp.OrderID,
+		ClientOrderID: closeID,
+		Status:        normalizeOrderStatus(resp.Status),
+		Side:          slice.req.Side,
+		OrderType:     "MARKET",
+		Price:         resp.Price,
+		Quantity:      resp.OrigQty,
+		UpdateTime:    time.Now().UTC(),
+	}
+	if err := a.emitter.EmitOrderUpdate(ctx, update); err != nil {
+		a.logger.Warn().Err(err).
+			Str("client_order_id", closeID).
+			Msg("spot armer: failed to emit close update")
+	}
+}
+
+// deriveSliceID appends a slice suffix while respecting Binance's 36-char
+// client order id limit. When truncation is needed, part of the tail is
+// replaced with a hash of the full base so ids that differ only in their
+// final characters cannot collide.
+func deriveSliceID(base string, index int) string {
+	suffix := fmt.Sprintf("-%d", index)
+	if len(base)+len(suffix) <= maxClientOrderIDLength {
+		return base + suffix
+	}
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(base))
+	tag := fmt.Sprintf("-%08x", h.Sum32())
+	keep := maxClientOrderIDLength - len(suffix) - len(tag)
+	return base[:keep] + tag + suffix
+}

--- a/app/router/internal/orders/spot_oco_test.go
+++ b/app/router/internal/orders/spot_oco_test.go
@@ -1,0 +1,690 @@
+package orders
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"router/internal/auth"
+	"router/internal/binance"
+	"router/internal/rest"
+	"router/internal/storage"
+)
+
+// spotOCOExchange serves the spot OCO endpoints, recording placements and
+// enforcing the real /api/v3/orderList/oco contract (above/below parameters;
+// the legacy order/oco parameter names are rejected).
+type spotOCOExchange struct {
+	mu          sync.Mutex
+	ocoRequests []url.Values
+	closeReqs   []url.Values
+	getStatuses []string // per GET /api/v3/order: order status (default FILLED)
+	getCount    int
+	failOCO     bool   // OCO POSTs fail with -1102
+	dupOCO      bool   // OCO POSTs fail with -2010 duplicate
+	rejectMsg   string // OCO POSTs fail with -2010 and this message
+	failClose   bool   // market close POSTs fail with -2010 insufficient balance
+	hijackPosts int    // abort this many OCO POSTs mid-connection (ambiguous outcome)
+	serveInfo   bool   // serve /api/v3/exchangeInfo (tick 0.01, step 0.00001)
+	trades      string // JSON array served on GET /api/v3/myTrades
+	knownLists  map[string]url.Values
+	getOrderQty string
+	nextOrderID int64
+}
+
+func (f *spotOCOExchange) requests() []url.Values {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]url.Values(nil), f.ocoRequests...)
+}
+
+func (f *spotOCOExchange) closes() []url.Values {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]url.Values(nil), f.closeReqs...)
+}
+
+func (f *spotOCOExchange) rememberList(q url.Values) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.knownLists == nil {
+		f.knownLists = map[string]url.Values{}
+	}
+	f.knownLists[q.Get("listClientOrderId")] = q
+}
+
+// validateOCOContract enforces the orderList/oco parameter shape so tests
+// fail loudly if the client regresses to the legacy order/oco names.
+func validateOCOContract(q url.Values) (int, string) {
+	for _, legacy := range []string{
+		"price", "stopPrice", "stopLimitPrice", "stopLimitTimeInForce",
+		"limitClientOrderId", "stopClientOrderId",
+	} {
+		if q.Get(legacy) != "" {
+			return -1103, "An unknown parameter was sent: " + legacy
+		}
+	}
+	for _, required := range []string{"symbol", "side", "quantity", "aboveType", "belowType"} {
+		if q.Get(required) == "" {
+			return -1102, "Mandatory parameter '" + required + "' was not sent."
+		}
+	}
+	for _, half := range []string{"above", "below"} {
+		switch q.Get(half + "Type") {
+		case "LIMIT_MAKER":
+			if q.Get(half+"Price") == "" {
+				return -1102, "Mandatory parameter '" + half + "Price' was not sent."
+			}
+		case "STOP_LOSS_LIMIT", "TAKE_PROFIT_LIMIT":
+			if q.Get(half+"Price") == "" || q.Get(half+"StopPrice") == "" || q.Get(half+"TimeInForce") == "" {
+				return -1102, "Mandatory parameters for '" + half + "Type' were not sent."
+			}
+		default:
+			return -1102, "Unsupported " + half + "Type: " + q.Get(half+"Type")
+		}
+	}
+	return 0, ""
+}
+
+func (f *spotOCOExchange) ocoResponse(q url.Values, withReports bool) map[string]any {
+	f.mu.Lock()
+	f.nextOrderID += 2
+	aboveID, belowID := f.nextOrderID-1, f.nextOrderID
+	f.mu.Unlock()
+	resp := map[string]any{
+		"orderListId":       700,
+		"listClientOrderId": q.Get("listClientOrderId"),
+		"listOrderStatus":   "EXECUTING",
+		"orders": []map[string]any{
+			{"symbol": q.Get("symbol"), "orderId": aboveID, "clientOrderId": q.Get("aboveClientOrderId")},
+			{"symbol": q.Get("symbol"), "orderId": belowID, "clientOrderId": q.Get("belowClientOrderId")},
+		},
+	}
+	if withReports {
+		resp["orderReports"] = []map[string]any{
+			{"symbol": q.Get("symbol"), "orderId": aboveID, "clientOrderId": q.Get("aboveClientOrderId"),
+				"type": q.Get("aboveType"), "status": "NEW", "price": q.Get("abovePrice"),
+				"stopPrice": zeroIfEmpty(q.Get("aboveStopPrice")), "origQty": q.Get("quantity")},
+			{"symbol": q.Get("symbol"), "orderId": belowID, "clientOrderId": q.Get("belowClientOrderId"),
+				"type": q.Get("belowType"), "status": "NEW", "price": q.Get("belowPrice"),
+				"stopPrice": zeroIfEmpty(q.Get("belowStopPrice")), "origQty": q.Get("quantity")},
+		}
+	}
+	return resp
+}
+
+func zeroIfEmpty(v string) string {
+	if v == "" {
+		return "0"
+	}
+	return v
+}
+
+func (f *spotOCOExchange) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v3/orderList/oco":
+			if code, msg := validateOCOContract(q); code != 0 {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]any{"code": code, "msg": msg})
+				return
+			}
+			f.mu.Lock()
+			hijack := f.hijackPosts > 0
+			if hijack {
+				f.hijackPosts--
+			}
+			f.mu.Unlock()
+			if hijack {
+				if hj, ok := w.(http.Hijacker); ok {
+					if conn, _, err := hj.Hijack(); err == nil {
+						_ = conn.Close()
+					}
+				}
+				return
+			}
+			if f.failOCO {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"code":-1102,"msg":"Mandatory parameter was not sent."}`))
+				return
+			}
+			if f.dupOCO {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"code":-2010,"msg":"Duplicate order sent."}`))
+				return
+			}
+			if f.rejectMsg != "" {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]any{"code": -2010, "msg": f.rejectMsg})
+				return
+			}
+			f.mu.Lock()
+			f.ocoRequests = append(f.ocoRequests, q)
+			f.mu.Unlock()
+			f.rememberList(q)
+			_ = json.NewEncoder(w).Encode(f.ocoResponse(q, true))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v3/orderList":
+			f.mu.Lock()
+			known, ok := f.knownLists[q.Get("origClientOrderId")]
+			f.mu.Unlock()
+			if !ok {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"code":-2013,"msg":"Order list does not exist."}`))
+				return
+			}
+			// The production query endpoint returns no orderReports
+			_ = json.NewEncoder(w).Encode(f.ocoResponse(known, false))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v3/order":
+			if f.failClose {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"code":-2010,"msg":"Account has insufficient balance for requested action."}`))
+				return
+			}
+			f.mu.Lock()
+			f.closeReqs = append(f.closeReqs, q)
+			count := len(f.closeReqs)
+			f.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"symbol": q.Get("symbol"), "orderId": 9100 + count,
+				"clientOrderId": q.Get("newClientOrderId"), "status": "FILLED",
+				"executedQty": q.Get("quantity"), "origQty": q.Get("quantity"),
+				"cummulativeQuoteQty": "975", "price": "0",
+				"type": "MARKET", "side": q.Get("side"), "timeInForce": "GTC",
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v3/myTrades":
+			if f.trades == "" {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"error":"not found"}`))
+				return
+			}
+			_, _ = w.Write([]byte(f.trades))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v3/exchangeInfo":
+			if !f.serveInfo {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"error":"not found"}`))
+				return
+			}
+			writeSpotExchangeInfo(w)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v3/order":
+			f.mu.Lock()
+			status := "FILLED"
+			if f.getCount < len(f.getStatuses) {
+				status = f.getStatuses[f.getCount]
+			}
+			f.getCount++
+			qty := f.getOrderQty
+			f.mu.Unlock()
+			if status == "NOT_FOUND" {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"code":-2013,"msg":"Order does not exist."}`))
+				return
+			}
+			if qty == "" {
+				qty = "0.02"
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"symbol": "BTCUSDT", "orderId": 321, "clientOrderId": q.Get("origClientOrderId"),
+				"price": "50000", "origQty": "0.02", "executedQty": qty,
+				"cummulativeQuoteQty": "1000", "status": status,
+				"timeInForce": "GTC", "type": "LIMIT", "side": "BUY",
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"not found"}`))
+		}
+	}
+}
+
+func newSpotArmerFixture(t *testing.T, fake *spotOCOExchange, store *fakeArmerStore) (*SpotLegArmer, *binance.Client) {
+	t.Helper()
+	server := httptest.NewServer(fake.handler())
+	t.Cleanup(server.Close)
+
+	signer := auth.NewSignerWithRecvWindow("key", "secret", 5000)
+	logger := zerolog.Nop()
+	spotRest := rest.NewClient(server.URL, signer)
+	spotClient, err := binance.NewSpotClient(server.URL, signer, spotRest, logger)
+	require.NoError(t, err)
+	spotClient.SetExchangeInfoCache(
+		binance.NewExchangeInfoCache(spotRest, nil, time.Hour, logger),
+	)
+
+	return NewSpotLegArmer(store, spotClient, nil, logger), spotClient
+}
+
+func spotArmerRecord() *storage.BracketRecord {
+	rec := armerRecord()
+	rec.Venue = "SPOT"
+	return rec
+}
+
+// spotSellRecord models a SELL entry whose exit OCO is on the BUY side.
+func spotSellRecord() *storage.BracketRecord {
+	rec := spotArmerRecord()
+	rec.Side = "SELL"
+	rec.StopLossPrice = decimal.RequireFromString("51000")
+	rec.Legs[1].Price = decimal.RequireFromString("49000")
+	rec.Legs[2].StopPrice = decimal.RequireFromString("51000")
+	return rec
+}
+
+func spotEntry(qty string) *binance.OrderResponse {
+	return &binance.OrderResponse{
+		OrderID:     321,
+		Status:      "FILLED",
+		ExecutedQty: decimal.RequireFromString(qty),
+	}
+}
+
+// fastRepoll shrinks the resolution repoll so unresolved-outcome tests do
+// not sleep.
+func fastRepoll(t *testing.T) {
+	t.Helper()
+	prevDelay, prevAttempts := ocoRepollDelay, ocoRepollAttempts
+	ocoRepollDelay, ocoRepollAttempts = time.Millisecond, 1
+	t.Cleanup(func() { ocoRepollDelay, ocoRepollAttempts = prevDelay, prevAttempts })
+}
+
+// presetSellList registers an OCO list as already live on the exchange, as
+// if a previous process life placed it.
+func presetSellList(fake *spotOCOExchange, list, tpID, slID string) {
+	fake.rememberList(url.Values{
+		"symbol": {"BTCUSDT"}, "side": {"SELL"}, "quantity": {"0.02"},
+		"listClientOrderId":  {list},
+		"aboveType":          {"LIMIT_MAKER"},
+		"aboveClientOrderId": {tpID},
+		"abovePrice":         {"51000"},
+		"belowType":          {"STOP_LOSS_LIMIT"},
+		"belowClientOrderId": {slID},
+		"belowPrice":         {"48755"},
+		"belowStopPrice":     {"49000"},
+		"belowTimeInForce":   {"GTC"},
+	})
+}
+
+func TestSpotLegArmer_EntryFillPlacesOCOPairWithAboveBelowContract(t *testing.T) {
+	store := &fakeArmerStore{record: spotArmerRecord()}
+	fake := &spotOCOExchange{}
+	armer, _ := newSpotArmerFixture(t, fake, store)
+
+	armer.Arm(context.Background(), store.record, spotEntry("0.02"))
+
+	requests := fake.requests()
+	require.Len(t, requests, 1)
+	q := requests[0]
+	assert.Equal(t, map[string]string{
+		"symbol":             "BTCUSDT",
+		"side":               "SELL",
+		"quantity":           "0.02",
+		"listClientOrderId":  "arm-main-oco-0",
+		"aboveType":          "LIMIT_MAKER",
+		"aboveClientOrderId": "arm-tp1",
+		"abovePrice":         "51000",
+		"belowType":          "STOP_LOSS_LIMIT",
+		"belowClientOrderId": "arm-sl",
+		"belowPrice":         "48755",
+		"belowStopPrice":     "49000",
+		"belowTimeInForce":   "GTC",
+	}, map[string]string{
+		"symbol":             q.Get("symbol"),
+		"side":               q.Get("side"),
+		"quantity":           q.Get("quantity"),
+		"listClientOrderId":  q.Get("listClientOrderId"),
+		"aboveType":          q.Get("aboveType"),
+		"aboveClientOrderId": q.Get("aboveClientOrderId"),
+		"abovePrice":         q.Get("abovePrice"),
+		"belowType":          q.Get("belowType"),
+		"belowClientOrderId": q.Get("belowClientOrderId"),
+		"belowPrice":         q.Get("belowPrice"),
+		"belowStopPrice":     q.Get("belowStopPrice"),
+		"belowTimeInForce":   q.Get("belowTimeInForce"),
+	})
+	assert.Contains(t, store.legUpdates, "arm-tp1:PLACED")
+	assert.Contains(t, store.legUpdates, "arm-sl:PLACED")
+	assert.Equal(t, []string{storage.BracketStatusLegsPlaced}, store.bracketUpdates)
+}
+
+func TestSpotLegArmer_BuyExitUsesTakeProfitLimitBelow(t *testing.T) {
+	store := &fakeArmerStore{record: spotSellRecord()}
+	fake := &spotOCOExchange{}
+	armer, _ := newSpotArmerFixture(t, fake, store)
+
+	armer.Arm(context.Background(), store.record, spotEntry("0.02"))
+
+	requests := fake.requests()
+	require.Len(t, requests, 1)
+	q := requests[0]
+	assert.Equal(t, map[string]string{
+		"side":               "BUY",
+		"aboveType":          "STOP_LOSS_LIMIT",
+		"aboveClientOrderId": "arm-sl",
+		"abovePrice":         "51255",
+		"aboveStopPrice":     "51000",
+		"aboveTimeInForce":   "GTC",
+		"belowType":          "TAKE_PROFIT_LIMIT",
+		"belowClientOrderId": "arm-tp1",
+		"belowPrice":         "49245", // marketably above the trigger: activation cancels the stop sibling
+		"belowStopPrice":     "49000",
+		"belowTimeInForce":   "GTC",
+	}, map[string]string{
+		"side":               q.Get("side"),
+		"aboveType":          q.Get("aboveType"),
+		"aboveClientOrderId": q.Get("aboveClientOrderId"),
+		"abovePrice":         q.Get("abovePrice"),
+		"aboveStopPrice":     q.Get("aboveStopPrice"),
+		"aboveTimeInForce":   q.Get("aboveTimeInForce"),
+		"belowType":          q.Get("belowType"),
+		"belowClientOrderId": q.Get("belowClientOrderId"),
+		"belowPrice":         q.Get("belowPrice"),
+		"belowStopPrice":     q.Get("belowStopPrice"),
+		"belowTimeInForce":   q.Get("belowTimeInForce"),
+	})
+	assert.Equal(t, []string{storage.BracketStatusLegsPlaced}, store.bracketUpdates)
+}
+
+func TestSpotLegArmer_DuplicateArmIsIdempotent(t *testing.T) {
+	store := &fakeArmerStore{record: spotArmerRecord()}
+	fake := &spotOCOExchange{}
+	armer, _ := newSpotArmerFixture(t, fake, store)
+
+	armer.Arm(context.Background(), store.record, spotEntry("0.02"))
+	armer.Arm(context.Background(), store.record, spotEntry("0.02"))
+
+	assert.Len(t, fake.requests(), 1, "duplicate arms must never double-place OCO pairs")
+}
+
+func TestSpotLegArmer_FailureLeavesLegsReclaimableForNextPoll(t *testing.T) {
+	store := &fakeArmerStore{record: spotArmerRecord()}
+	fake := &spotOCOExchange{failOCO: true}
+	armer, _ := newSpotArmerFixture(t, fake, store)
+
+	armer.Arm(context.Background(), store.record, spotEntry("0.02"))
+
+	assert.Contains(t, store.legUpdates, "arm-tp1:FAILED")
+	assert.Equal(t, []string{storage.BracketStatusEntryFilled}, store.bracketUpdates)
+
+	// The watcher polls again; the FAILED leg must be re-claimable
+	fake.failOCO = false
+	armer.Arm(context.Background(), store.record, spotEntry("0.02"))
+
+	assert.Len(t, fake.requests(), 1)
+	assert.Contains(t, store.legUpdates, "arm-tp1:PLACED")
+	assert.Contains(t, store.bracketUpdates, storage.BracketStatusLegsPlaced)
+}
+
+func TestSpotLegArmer_DuplicateListAdoptsExchangeState(t *testing.T) {
+	store := &fakeArmerStore{record: spotArmerRecord()}
+	fake := &spotOCOExchange{dupOCO: true}
+	presetSellList(fake, "arm-main-oco-0", "arm-tp1", "arm-sl")
+	armer, _ := newSpotArmerFixture(t, fake, store)
+
+	armer.Arm(context.Background(), store.record, spotEntry("0.02"))
+
+	assert.Contains(t, store.legUpdates, "arm-tp1:PLACED")
+	assert.Contains(t, store.legUpdates, "arm-sl:PLACED")
+	assert.Equal(t, []string{storage.BracketStatusLegsPlaced}, store.bracketUpdates)
+}
+
+func TestSpotLegArmer_DuplicateButInvisibleStaysPendingNotRePosted(t *testing.T) {
+	fastRepoll(t)
+	store := &fakeArmerStore{record: spotArmerRecord()}
+	fake := &spotOCOExchange{dupOCO: true} // duplicate asserted, list never visible
+	armer, _ := newSpotArmerFixture(t, fake, store)
+
+	armer.Arm(context.Background(), store.record, spotEntry("0.02"))
+
+	assert.Empty(t, fake.requests(), "an unresolved duplicate must never re-POST")
+	assert.NotContains(t, store.legUpdates, "arm-tp1:FAILED",
+		"unresolved outcomes stay PLACING for exchange-side resolution, not FAILED for blind retry")
+	assert.Equal(t, []string{storage.BracketStatusEntryFilled}, store.bracketUpdates)
+}
+
+func TestSpotLegArmer_AmbiguousPostAdoptsLandedList(t *testing.T) {
+	store := &fakeArmerStore{record: spotArmerRecord()}
+	fake := &spotOCOExchange{hijackPosts: 1}
+	presetSellList(fake, "arm-main-oco-0", "arm-tp1", "arm-sl")
+	armer, _ := newSpotArmerFixture(t, fake, store)
+
+	armer.Arm(context.Background(), store.record, spotEntry("0.02"))
+
+	assert.Empty(t, fake.requests(), "the landed list must be adopted, never re-POSTed")
+	assert.Contains(t, store.legUpdates, "arm-tp1:PLACED")
+	assert.Contains(t, store.legUpdates, "arm-sl:PLACED")
+	assert.Equal(t, []string{storage.BracketStatusLegsPlaced}, store.bracketUpdates)
+}
+
+func TestSpotLegArmer_AmbiguousPostConfirmedAbsentFailsForRetry(t *testing.T) {
+	fastRepoll(t)
+	store := &fakeArmerStore{record: spotArmerRecord()}
+	fake := &spotOCOExchange{hijackPosts: 1}
+	armer, _ := newSpotArmerFixture(t, fake, store)
+
+	armer.Arm(context.Background(), store.record, spotEntry("0.02"))
+
+	assert.Contains(t, store.legUpdates, "arm-tp1:FAILED")
+	assert.Contains(t, store.legUpdates, "arm-sl:FAILED")
+	assert.Equal(t, []string{storage.BracketStatusEntryFilled}, store.bracketUpdates)
+
+	armer.Arm(context.Background(), store.record, spotEntry("0.02"))
+
+	assert.Len(t, fake.requests(), 1, "a confirmed-absent submit is safe to retry once")
+	assert.Contains(t, store.bracketUpdates, storage.BracketStatusLegsPlaced)
+}
+
+func TestSpotLegArmer_StalePlacingLegAdoptedFromExchange(t *testing.T) {
+	record := spotArmerRecord()
+	record.Legs[1].Status = storage.LegStatusPlacing // crashed mid-placement
+	store := &fakeArmerStore{record: record}
+	fake := &spotOCOExchange{}
+	presetSellList(fake, "arm-main-oco-0", "arm-tp1", "arm-sl")
+	armer, _ := newSpotArmerFixture(t, fake, store)
+
+	armer.Arm(context.Background(), store.record, spotEntry("0.02"))
+
+	assert.Empty(t, fake.requests(), "an already-landed list must be adopted, not re-POSTed")
+	assert.Contains(t, store.legUpdates, "arm-tp1:PLACED")
+	assert.Contains(t, store.legUpdates, "arm-sl:PLACED")
+	assert.Equal(t, []string{storage.BracketStatusLegsPlaced}, store.bracketUpdates)
+}
+
+func TestSpotLegArmer_StalePlacingLegConfirmedAbsentBecomesFailed(t *testing.T) {
+	fastRepoll(t)
+	record := spotArmerRecord()
+	record.Legs[1].Status = storage.LegStatusPlacing
+	store := &fakeArmerStore{record: record}
+	fake := &spotOCOExchange{}
+	armer, _ := newSpotArmerFixture(t, fake, store)
+
+	armer.Arm(context.Background(), store.record, spotEntry("0.02"))
+
+	assert.Empty(t, fake.requests())
+	assert.Contains(t, store.legUpdates, "arm-tp1:FAILED",
+		"a PLACING leg the exchange has never seen must become re-claimable")
+	assert.Equal(t, []string{storage.BracketStatusEntryFilled}, store.bracketUpdates)
+
+	armer.Arm(context.Background(), store.record, spotEntry("0.02"))
+	assert.Len(t, fake.requests(), 1)
+	assert.Contains(t, store.bracketUpdates, storage.BracketStatusLegsPlaced)
+}
+
+func TestSpotLegArmer_PriceGapFailsClosedAtMarket(t *testing.T) {
+	store := &fakeArmerStore{record: spotArmerRecord()}
+	fake := &spotOCOExchange{rejectMsg: "The relationship of the prices for the orders is not correct."}
+	armer, _ := newSpotArmerFixture(t, fake, store)
+
+	armer.Arm(context.Background(), store.record, spotEntry("0.02"))
+
+	closes := fake.closes()
+	require.Len(t, closes, 1, "a gapped-through exit must fail closed at market")
+	assert.Equal(t, [4]string{"MARKET", "SELL", "0.02", "arm-main-mc-0"}, [4]string{
+		closes[0].Get("type"), closes[0].Get("side"),
+		closes[0].Get("quantity"), closes[0].Get("newClientOrderId"),
+	})
+	assert.Contains(t, store.legUpdates, "arm-tp1:CANCELED")
+	assert.Contains(t, store.legUpdates, "arm-sl:CANCELED")
+	assert.Contains(t, store.legUpdates, "arm-main-mc-0:PLACED",
+		"the close must be recorded for provenance")
+	assert.Equal(t, []string{storage.BracketStatusClosed}, store.bracketUpdates)
+}
+
+func TestSpotLegArmer_EmergencyCloseFailureLeavesLegsRetryable(t *testing.T) {
+	store := &fakeArmerStore{record: spotArmerRecord()}
+	fake := &spotOCOExchange{
+		rejectMsg: "The relationship of the prices for the orders is not correct.",
+		failClose: true,
+	}
+	armer, _ := newSpotArmerFixture(t, fake, store)
+
+	armer.Arm(context.Background(), store.record, spotEntry("0.02"))
+
+	assert.Contains(t, store.legUpdates, "arm-tp1:FAILED")
+	assert.Contains(t, store.legUpdates, "arm-sl:FAILED")
+	assert.Equal(t, []string{storage.BracketStatusEntryFilled}, store.bracketUpdates,
+		"a failed emergency close must keep the bracket in the retry loop")
+}
+
+func TestSpotLegArmer_NetsBaseAssetCommissionFromQuantity(t *testing.T) {
+	store := &fakeArmerStore{record: spotArmerRecord()}
+	fake := &spotOCOExchange{
+		serveInfo: true,
+		trades: `[
+			{"symbol":"BTCUSDT","id":1,"orderId":321,"price":"50000","qty":"0.01","commission":"0.00001","commissionAsset":"BTC","time":1,"isBuyer":true},
+			{"symbol":"BTCUSDT","id":2,"orderId":321,"price":"50000","qty":"0.01","commission":"0.00001","commissionAsset":"BTC","time":2,"isBuyer":true},
+			{"symbol":"BTCUSDT","id":3,"orderId":321,"price":"50000","qty":"0","commission":"0.5","commissionAsset":"USDT","time":3,"isBuyer":true}
+		]`,
+	}
+	armer, _ := newSpotArmerFixture(t, fake, store)
+
+	armer.Arm(context.Background(), store.record, spotEntry("0.02"))
+
+	requests := fake.requests()
+	require.Len(t, requests, 1)
+	assert.Equal(t, "0.01998", requests[0].Get("quantity"),
+		"base-asset fees must be netted or the exit sell exceeds the free balance")
+}
+
+func TestSpotLegArmer_DustFillClosesBracketInsteadOfLoopingForever(t *testing.T) {
+	store := &fakeArmerStore{record: spotArmerRecord()}
+	fake := &spotOCOExchange{serveInfo: true}
+	armer, _ := newSpotArmerFixture(t, fake, store)
+
+	armer.Arm(context.Background(), store.record, spotEntry("0.000005"))
+
+	assert.Empty(t, fake.requests(), "an unsellable dust fill can never arm")
+	assert.Contains(t, store.legUpdates, "arm-tp1:CANCELED")
+	assert.Contains(t, store.legUpdates, "arm-sl:CANCELED")
+	assert.Equal(t, []string{storage.BracketStatusClosed}, store.bracketUpdates)
+}
+
+func TestSpotLegArmer_ZeroQuantitySliceSkippedWithoutBlockingArm(t *testing.T) {
+	record := spotArmerRecord()
+	record.Legs = []storage.BracketLegRecord{
+		{Role: "ENTRY", ClientOrderID: "arm-main", Status: storage.LegStatusPlaced, Quantity: decimal.RequireFromString("0.02")},
+		{Role: "TP", TPIndex: 1, ClientOrderID: "arm-tp1", Status: storage.LegStatusPlanned, Price: decimal.RequireFromString("51000")},
+		{Role: "TP", TPIndex: 2, ClientOrderID: "arm-tp2", Status: storage.LegStatusPlanned, Price: decimal.RequireFromString("52000")},
+		{Role: "SL", ClientOrderID: "arm-sl", Status: storage.LegStatusPlanned, StopPrice: decimal.RequireFromString("49000")},
+	}
+	store := &fakeArmerStore{record: record}
+	fake := &spotOCOExchange{serveInfo: true}
+	armer, _ := newSpotArmerFixture(t, fake, store)
+
+	// One step of quantity across two TPs: the first slice floors to zero
+	armer.Arm(context.Background(), store.record, spotEntry("0.00001"))
+
+	requests := fake.requests()
+	require.Len(t, requests, 1, "the dust slice must be skipped, not retried forever")
+	assert.Equal(t, "0.00001", requests[0].Get("quantity"))
+	assert.Contains(t, store.legUpdates, "arm-tp1:CANCELED")
+	assert.Contains(t, store.legUpdates, "arm-sl:CANCELED",
+		"the dust slice's stop share is cancelled with it")
+	assert.Equal(t, []string{storage.BracketStatusLegsPlaced}, store.bracketUpdates)
+}
+
+func TestSpotLegArmer_ReservedStopStaysStableDespiteInsertedSLLegs(t *testing.T) {
+	record := spotArmerRecord()
+	record.Legs = []storage.BracketLegRecord{
+		{Role: "ENTRY", ClientOrderID: "arm-main", Status: storage.LegStatusPlaced, Quantity: decimal.RequireFromString("0.02")},
+		// An emergency-close leg from a previous pass, loaded BEFORE the
+		// reserved SL to simulate adverse tie-ordering
+		{Role: "SL", TPIndex: 1, ClientOrderID: "arm-main-mc-0", Status: storage.LegStatusPlaced, Quantity: decimal.RequireFromString("0.01")},
+		{Role: "TP", TPIndex: 1, ClientOrderID: "arm-tp1", Status: storage.LegStatusCanceled, Price: decimal.RequireFromString("51000")},
+		{Role: "TP", TPIndex: 2, ClientOrderID: "arm-tp2", Status: storage.LegStatusPlanned, Price: decimal.RequireFromString("52000")},
+		{Role: "SL", TPIndex: 0, ClientOrderID: "arm-sl", Status: storage.LegStatusPlanned, StopPrice: decimal.RequireFromString("49000")},
+	}
+	store := &fakeArmerStore{record: record}
+	fake := &spotOCOExchange{}
+	armer, _ := newSpotArmerFixture(t, fake, store)
+
+	armer.Arm(context.Background(), store.record, spotEntry("0.02"))
+
+	requests := fake.requests()
+	require.Len(t, requests, 1, "only the still-planned slice places")
+	assert.Equal(t, "arm-sl-1", requests[0].Get("belowClientOrderId"),
+		"derived stop ids must stay keyed to the reservation's SL, not arm-time inserts")
+}
+
+func TestSpotLegArmer_MultiTPSlicesShareStopWithDerivedIDs(t *testing.T) {
+	record := spotArmerRecord()
+	record.Legs = []storage.BracketLegRecord{
+		{Role: "ENTRY", ClientOrderID: "arm-main", Status: storage.LegStatusPlaced, Quantity: decimal.RequireFromString("0.02")},
+		{Role: "TP", TPIndex: 1, ClientOrderID: "arm-tp1", Status: storage.LegStatusPlanned, Price: decimal.RequireFromString("51000")},
+		{Role: "TP", TPIndex: 2, ClientOrderID: "arm-tp2", Status: storage.LegStatusPlanned, Price: decimal.RequireFromString("52000")},
+		{Role: "SL", ClientOrderID: "arm-sl", Status: storage.LegStatusPlanned, StopPrice: decimal.RequireFromString("49000")},
+	}
+	store := &fakeArmerStore{record: record}
+	fake := &spotOCOExchange{}
+	armer, _ := newSpotArmerFixture(t, fake, store)
+
+	armer.Arm(context.Background(), store.record, spotEntry("0.02"))
+
+	requests := fake.requests()
+	require.Len(t, requests, 2)
+	assert.Equal(t, "arm-sl", requests[0].Get("belowClientOrderId"))
+	assert.Equal(t, "arm-sl-1", requests[1].Get("belowClientOrderId"),
+		"extra slices derive their own stop ids")
+	assert.Contains(t, store.legUpdates, "arm-sl-1:PLACED",
+		"derived stop legs must be recorded")
+	total := decimal.RequireFromString(requests[0].Get("quantity")).
+		Add(decimal.RequireFromString(requests[1].Get("quantity")))
+	assert.True(t, decimal.RequireFromString("0.02").Equal(total),
+		"stop coverage must equal the protected position")
+}
+
+func TestSpotLegArmer_SettledBracketIsIgnored(t *testing.T) {
+	record := spotArmerRecord()
+	record.Status = storage.BracketStatusClosed
+	store := &fakeArmerStore{record: record}
+	fake := &spotOCOExchange{}
+	armer, _ := newSpotArmerFixture(t, fake, store)
+
+	armer.Arm(context.Background(), store.record, spotEntry("0.02"))
+
+	assert.Empty(t, fake.requests())
+	assert.Empty(t, store.bracketUpdates)
+}
+
+func TestDeriveSliceID_TruncationCannotCollide(t *testing.T) {
+	baseA := strings.Repeat("a", 35) + "x"
+	baseB := strings.Repeat("a", 35) + "y"
+
+	idA := deriveSliceID(baseA, 0)
+	idB := deriveSliceID(baseB, 0)
+
+	assert.NotEqual(t, idA, idB,
+		"bases differing only in truncated tail characters must not collide")
+	assert.LessOrEqual(t, len(idA), maxClientOrderIDLength)
+	assert.Equal(t, idA, deriveSliceID(baseA, 0), "derived ids must be stable across calls")
+	assert.Equal(t, "short-0", deriveSliceID("short", 0))
+}

--- a/app/router/internal/rest/errors.go
+++ b/app/router/internal/rest/errors.go
@@ -110,6 +110,30 @@ func IsDuplicateClientOrderID(err error) bool {
 	return binanceErr.Code == -4116
 }
 
+// IsPriceRelationRejection reports whether the matching engine rejected an
+// order because the market already sits on the wrong side of its prices —
+// for an OCO exit this means price gapped past a leg before it was placed,
+// so retrying the same prices can never succeed.
+func IsPriceRelationRejection(err error) bool {
+	var binanceErr *BinanceError
+	if !errors.As(err, &binanceErr) {
+		return false
+	}
+	if binanceErr.Code != -2010 && binanceErr.Code != -1010 {
+		return false
+	}
+	for _, msg := range []string{
+		"The relationship of the prices for the orders is not correct",
+		"Order would immediately match and take",
+		"Order would trigger immediately",
+	} {
+		if strings.Contains(binanceErr.Message, msg) {
+			return true
+		}
+	}
+	return false
+}
+
 // IsOrderNotFound reports whether the error is Binance saying the queried
 // order is not visible. NOT proof a submit never landed: freshly accepted
 // orders can lag the query path, so callers must re-poll before acting.

--- a/app/router/internal/rest/oco.go
+++ b/app/router/internal/rest/oco.go
@@ -1,0 +1,152 @@
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/shopspring/decimal"
+)
+
+// OCORequest describes a spot One-Cancels-the-Other exit pair: a LIMIT_MAKER
+// take-profit and a STOP_LOSS_LIMIT stop, sharing one quantity.
+type OCORequest struct {
+	Symbol   string
+	Side     string // exit side (SELL for a BUY entry)
+	Quantity decimal.Decimal
+	Price    decimal.Decimal // take-profit price (trigger, for BUY exits)
+	// PriceLimit is the take-profit's limit price when the leg is a trigger
+	// type (BUY exits use TAKE_PROFIT_LIMIT): set marketably past the
+	// trigger so activation converts to a fill, since the OCO sibling is
+	// cancelled on activation rather than on fill. Ignored for LIMIT_MAKER
+	// take-profits; falls back to Price when zero.
+	PriceLimit         decimal.Decimal
+	StopPrice          decimal.Decimal // stop trigger
+	StopLimitPrice     decimal.Decimal // stop limit price
+	ListClientOrderID  string
+	LimitClientOrderID string
+	StopClientOrderID  string
+}
+
+type OCOOrderRef struct {
+	Symbol        string `json:"symbol"`
+	OrderID       int64  `json:"orderId"`
+	ClientOrderID string `json:"clientOrderId"`
+}
+
+type OCOOrderReport struct {
+	Symbol        string          `json:"symbol"`
+	OrderID       int64           `json:"orderId"`
+	ClientOrderID string          `json:"clientOrderId"`
+	Type          string          `json:"type"`
+	Status        string          `json:"status"`
+	Price         decimal.Decimal `json:"price"`
+	StopPrice     decimal.Decimal `json:"stopPrice"`
+	OrigQty       decimal.Decimal `json:"origQty"`
+}
+
+type OCOResponse struct {
+	OrderListID       int64            `json:"orderListId"`
+	ListClientOrderID string           `json:"listClientOrderId"`
+	ListOrderStatus   string           `json:"listOrderStatus"`
+	Orders            []OCOOrderRef    `json:"orders"`
+	OrderReports      []OCOOrderReport `json:"orderReports"`
+}
+
+// PlaceSpotOCO places a spot OCO exit pair. Only meaningful on the spot
+// venue; the exchange cancels the sibling when either leg executes.
+//
+// /api/v3/orderList/oco describes the pair as an "above" and a "below"
+// order relative to the last traded price. A SELL exit protecting a long
+// puts the LIMIT_MAKER take-profit above and the STOP_LOSS_LIMIT below. A
+// BUY exit mirrors that, except LIMIT_MAKER is not a supported belowType,
+// so the take-profit becomes a TAKE_PROFIT_LIMIT triggering at its own
+// limit price.
+func (c *Client) PlaceSpotOCO(ctx context.Context, req OCORequest) (*OCOResponse, error) {
+	if c.signer == nil {
+		return nil, fmt.Errorf("signer required for PlaceSpotOCO")
+	}
+	if req.Symbol == "" || req.Side == "" {
+		return nil, fmt.Errorf("symbol and side are required")
+	}
+	if !req.Quantity.IsPositive() {
+		return nil, fmt.Errorf("quantity must be positive")
+	}
+	if !req.Price.IsPositive() || !req.StopPrice.IsPositive() || !req.StopLimitPrice.IsPositive() {
+		return nil, fmt.Errorf("price, stopPrice and stopLimitPrice are required")
+	}
+
+	params := url.Values{}
+	params.Set("symbol", req.Symbol)
+	params.Set("side", req.Side)
+	params.Set("quantity", req.Quantity.String())
+	if req.ListClientOrderID != "" {
+		params.Set("listClientOrderId", req.ListClientOrderID)
+	}
+	switch req.Side {
+	case "SELL":
+		params.Set("aboveType", "LIMIT_MAKER")
+		params.Set("abovePrice", req.Price.String())
+		params.Set("belowType", "STOP_LOSS_LIMIT")
+		params.Set("belowPrice", req.StopLimitPrice.String())
+		params.Set("belowStopPrice", req.StopPrice.String())
+		params.Set("belowTimeInForce", "GTC")
+		if req.LimitClientOrderID != "" {
+			params.Set("aboveClientOrderId", req.LimitClientOrderID)
+		}
+		if req.StopClientOrderID != "" {
+			params.Set("belowClientOrderId", req.StopClientOrderID)
+		}
+	case "BUY":
+		takeProfitLimit := req.PriceLimit
+		if !takeProfitLimit.IsPositive() {
+			takeProfitLimit = req.Price
+		}
+		params.Set("aboveType", "STOP_LOSS_LIMIT")
+		params.Set("abovePrice", req.StopLimitPrice.String())
+		params.Set("aboveStopPrice", req.StopPrice.String())
+		params.Set("aboveTimeInForce", "GTC")
+		params.Set("belowType", "TAKE_PROFIT_LIMIT")
+		params.Set("belowPrice", takeProfitLimit.String())
+		params.Set("belowStopPrice", req.Price.String())
+		params.Set("belowTimeInForce", "GTC")
+		if req.StopClientOrderID != "" {
+			params.Set("aboveClientOrderId", req.StopClientOrderID)
+		}
+		if req.LimitClientOrderID != "" {
+			params.Set("belowClientOrderId", req.LimitClientOrderID)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported OCO side %q", req.Side)
+	}
+
+	body, err := c.doRequest(ctx, "POST", "/api/v3/orderList/oco", params, true)
+	if err != nil {
+		return nil, ErrorWithContext(err, "PlaceSpotOCO")
+	}
+
+	var resp OCOResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, ErrorWithContext(err, "PlaceSpotOCO")
+	}
+	return &resp, nil
+}
+
+// GetOCOByListClientOrderID resolves an OCO's state by its list client order
+// id — the recovery path when a placement outcome is ambiguous.
+func (c *Client) GetOCOByListClientOrderID(ctx context.Context, listClientOrderID string) (*OCOResponse, error) {
+	params := url.Values{}
+	params.Set("origClientOrderId", listClientOrderID)
+
+	body, err := c.doRequest(ctx, "GET", "/api/v3/orderList", params, true)
+	if err != nil {
+		return nil, ErrorWithContext(err, "GetOCOByListClientOrderID")
+	}
+
+	var resp OCOResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, ErrorWithContext(err, "GetOCOByListClientOrderID")
+	}
+	return &resp, nil
+}

--- a/app/router/internal/storage/bracket_repo.go
+++ b/app/router/internal/storage/bracket_repo.go
@@ -178,6 +178,34 @@ func (r *BracketRepo) UpdateLegStatus(
 	return nil
 }
 
+// InsertLeg adds a leg to an existing bracket — used for stop slices derived
+// at arm time beyond the single reserved SL leg.
+func (r *BracketRepo) InsertLeg(ctx context.Context, leg BracketLegRecord) error {
+	if leg.BracketID == uuid.Nil || leg.ClientOrderID == "" {
+		return fmt.Errorf("bracket id and client order id are required")
+	}
+	legID := leg.LegID
+	if legID == uuid.Nil {
+		legID = uuid.New()
+	}
+	status := leg.Status
+	if status == "" {
+		status = LegStatusPlanned
+	}
+	_, err := r.pool.Exec(ctx, `
+		INSERT INTO bracket_legs (
+			leg_id, bracket_id, role, tp_index, client_order_id,
+			exchange_order_id, price, stop_price, quantity, status
+		) VALUES ($1,$2,$3,$4,$5,NULLIF($6,0),$7,$8,$9,$10)
+		ON CONFLICT (bracket_id, client_order_id) DO NOTHING`,
+		legID, leg.BracketID, leg.Role, leg.TPIndex, leg.ClientOrderID,
+		leg.ExchangeOrderID, leg.Price, leg.StopPrice, leg.Quantity, status)
+	if err != nil {
+		return fmt.Errorf("insert bracket leg: %w", err)
+	}
+	return nil
+}
+
 // TryMarkLegPlacing claims a leg for placement (compare-and-set to PLACING).
 // Exactly one caller wins per leg, making duplicate fill events unable to
 // double-place protective legs. FAILED legs are re-claimable: a transient

--- a/app/router/internal/storage/bracket_repo_integration_test.go
+++ b/app/router/internal/storage/bracket_repo_integration_test.go
@@ -211,3 +211,29 @@ func TestBracketRepo_UpdateBracketStatusIfGuardsTransition(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, notApplied, "guarded transition must not fire from the wrong state")
 }
+
+func TestBracketRepo_InsertLegAddsDerivedStopSlice(t *testing.T) {
+	repo, ctx := newBracketTestRepo(t)
+	entryID := "it-" + uuid.NewString()[:8]
+	rec, inserted, err := repo.Reserve(ctx, sampleBracket(entryID))
+	require.NoError(t, err)
+	require.True(t, inserted)
+
+	derived := BracketLegRecord{
+		BracketID:       rec.BracketID,
+		Role:            "SL",
+		ClientOrderID:   entryID + "-sl-1",
+		StopPrice:       decimal.RequireFromString("49000"),
+		Quantity:        decimal.RequireFromString("0.01"),
+		Status:          LegStatusPlaced,
+		ExchangeOrderID: 9009,
+	}
+	require.NoError(t, repo.InsertLeg(ctx, derived))
+	// Conflicting re-insert must be a no-op, not an error
+	require.NoError(t, repo.InsertLeg(ctx, derived))
+
+	found, err := repo.GetByLegClientOrderID(ctx, "SPOT", entryID+"-sl-1")
+	require.NoError(t, err)
+	require.NotNil(t, found)
+	assert.Len(t, found.Legs, 4)
+}

--- a/db/migrations/032_orders_limit_maker.sql
+++ b/db/migrations/032_orders_limit_maker.sql
@@ -1,0 +1,19 @@
+-- 032_orders_limit_maker.sql: spot OCO exits.
+-- OCO take-profit legs are LIMIT_MAKER orders, and legs placed inside an
+-- order list carry the exchange's orderListId for reconciliation.
+
+ALTER TABLE orders DROP CONSTRAINT IF EXISTS orders_type_check;
+ALTER TABLE orders ADD CONSTRAINT orders_type_check CHECK (
+    type IN (
+        'MARKET',
+        'LIMIT',
+        'LIMIT_MAKER',
+        'STOP_MARKET',
+        'STOP_LOSS',
+        'STOP_LOSS_LIMIT',
+        'TAKE_PROFIT',
+        'TAKE_PROFIT_LIMIT'
+    )
+);
+
+ALTER TABLE orders ADD COLUMN IF NOT EXISTS order_list_id BIGINT;


### PR DESCRIPTION
## Summary

C5 of the router order-lifecycle campaign (#193 → #194 → #195 → #196 → this). Deferred spot brackets now place their exits as native OCO pairs when the entry fills, fixing the double-reservation bug where a synchronous spot TP + SL both lock the base asset.

- **`rest.PlaceSpotOCO`** — `POST /api/v3/orderList/oco` with the current above/below contract (verified against Binance spot docs). SELL exits: `LIMIT_MAKER` above + `STOP_LOSS_LIMIT` below. BUY exits: `STOP_LOSS_LIMIT` above + `TAKE_PROFIT_LIMIT` below, with the limit set marketably past the trigger (activation cancels the sibling, so a touch must convert to a fill). `GetOCOByListClientOrderID` resolves unknown outcomes.
- **`SpotLegArmer`** — one OCO per TP slice, all sharing the SL stop price; slice quantities via `splitTakeProfitQuantities`, so stop coverage always equals the protected position. Exit quantity nets base-asset entry commissions (`GetMyTrades`) and floors to lot step. Extra-slice stop ids derive from the reserved SL id (`≤36` chars; hash-tail on truncation so ids can't collide).
- **#193 discipline for OCO lists** — ambiguous/duplicate POSTs and crash-stale `PLACING` legs resolve against the exchange (adopt if landed, FAILED-for-retry only when confirmed absent, stay `PLACING` when unresolved). Never blind re-POSTs a list id.
- **Fail-closed on price gaps** — `-2010` price-relation rejections (price gapped past the exits while unprotected) market-close the slice with an idempotent derived id instead of retrying a permanently-rejected OCO.
- **`EntryFillWatcher`** — DB poll loop (`ENTRY_FILL_POLL_INTERVAL`, default 2s) over `RESERVED`/`ENTRY_PLACED`/`ENTRY_FILLED` deferred brackets; the brackets table is the queue, so it is restart-safe. Spot's only fill trigger (no production spot user-data stream); futures fallback sweep for fills missed while the router was down.
- **Manager** — spot replays keep exits deferred (H-4: the old path could market-sell a healthy position on crash-replay); algo pre-check budgets one `STOP_LOSS_LIMIT` slot per spot TP slice.
- **Migration 032** — `orders.type` CHECK gains `LIMIT_MAKER`; adds nullable `order_list_id`.

**Flag stays OFF until C6.** `BRACKET_LEGS_ON_FILL` remains default-false; C6's reconciler must land first (it sweeps `PLACING`/`FAILED`/`ENTRY_FILLED` work items at startup).

## QCHECK

Round 1 (independent subagent): **BLOCK** — C-1 legacy `order/oco` params sent to `orderList/oco` (every placement would 400), H-1 stranded-PLACING recovery missing, H-2 ambiguous-POST blind retry, H-3 no fail-closed on price gaps, H-4 spot replay fell back to the broken synchronous path, H-5 gross-quantity exits exceed sellable balance. All fixed with regression tests (~17 new tests). Round 2: **PASS**; two post-PASS medium findings (reserved-stop id stability across arm passes; TAKE_PROFIT_LIMIT marketable margin) fixed inline and self-verified with regression tests.

## Disclosed residuals (deferred to C6 unless noted)

- Derived stop/close legs are recorded in `bracket_legs` but not the `orders` table, TP intents persist as `LIMIT`, and nothing populates `orders.order_list_id` yet (persistence.go is off-limits this campaign; groundwork column only).
- Spot exit fills are not observed after placement: the exchange sibling-cancel keeps money safe, but brackets sit `LEGS_PLACED` until C6 closes them and the engine is blind to spot exit fills (mirrors the futures gap disclosed in #196).
- Futures-side stale-`PLACING` recovery remains C6 scope (disclosed in #196).
- Sub-MIN_NOTIONAL slices reject-and-retry loudly; gross-quantity fallback when the trades lookup fails can transiently reproduce the insufficient-balance retry loop (self-heals).
- Narrow futures sweep race (lost CAS + coincident DB write failure) can pin `LEGS_PLACED` with a FAILED leg; C6 sweep repairs.

## Testnet soak checklist additions (blocking)

1. Verify `GET /api/v3/orderList` returns **completed** lists by `origClientOrderId` — recovery paths treat confirmed `-2013` as safe-to-retry; if the endpoint only returned open lists, a filled list would read as absent and re-POST.
2. Confirm rejection-text parity on `orderList/oco` for the three price-relation messages and `-2010 "Duplicate order sent."` for duplicate `listClientOrderId`.

## Deploy notes

Apply migrations 030 + 031 + 032 before rolling the router.

## Test evidence

- `gofmt` / `go vet` clean; full `go test -race ./...` passes (17 packages).
- 7 bracket-repo integration tests pass against real Postgres (`TEST_DATABASE_URL`).
- Pre-existing, unrelated integration failures noted for follow-up: `TestPositionRepo_*` (ON CONFLICT/index mismatch) and `TestOrderRepo_ApplyFillUpdate` (temp-table DDL missing migration-023 columns) — both predate this branch and touch files this PR does not.