### PR TITLE
feat(router): startup reconciler repairs open brackets and gates readiness (C6)

### DIFF
--- a/app/router/cmd/router/main.go
+++ b/app/router/cmd/router/main.go
@@ -265,12 +265,79 @@ func main() {
 		}
 	}
 
+	// The startup reconciler repairs whatever a crash or missed event left
+	// behind in the brackets table before the router reports ready, and
+	// serves on-demand passes via POST /internal/reconcile.
+	var startupReconciler *orders.StartupReconciler
+	if dbPool != nil {
+		reconcileWatcher := entryFillWatcher
+		if reconcileWatcher == nil {
+			// Not started: the reconciler only borrows its entry-phase logic
+			reconcileWatcher = orders.NewEntryFillWatcher(
+				storage.NewBracketRepo(dbPool),
+				spotClient,
+				nil,
+				futuresClient,
+				legArmer,
+				0, // default interval (unused, never started)
+				0, // default lookback
+				logger.With().Str("component", "entry_fill_watcher").Logger(),
+			)
+		}
+		startupReconciler = orders.NewStartupReconciler(
+			storage.NewBracketRepo(dbPool),
+			reconcileWatcher,
+			spotClient,
+			futuresClient,
+			eventEmitter,
+			0, // default lookback
+			logger.With().Str("component", "startup_reconciler").Logger(),
+		)
+	}
+
 	// Create HTTP handlers
 	handlers := api.NewHandlers(orderManager, logger, intentPersister, spotTradeProcessor)
 	if cfg.Binance.Testnet {
 		handlers.SetExecutionEnv("testnet")
 	} else {
 		handlers.SetExecutionEnv("mainnet")
+	}
+
+	if startupReconciler != nil {
+		handlers.SetReady(false)
+		go func() {
+			defer handlers.SetReady(true)
+			const maxAttempts = 3
+			for attempt := 1; attempt <= maxAttempts; attempt++ {
+				reconcileCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+				summary, err := startupReconciler.Reconcile(reconcileCtx)
+				cancel()
+				if err == nil {
+					event := logger.Info()
+					if summary.Errors > 0 || summary.UnrepairedLegs > 0 {
+						// Completed the sweep but left work behind; surface it
+						event = logger.Error()
+					}
+					event.
+						Int("brackets_swept", summary.BracketsSwept).
+						Int("legs_resolved", summary.LegsResolved).
+						Int("brackets_closed", summary.BracketsClosed).
+						Int("unrepaired_legs", summary.UnrepairedLegs).
+						Int("errors", summary.Errors).
+						Msg("Startup reconciliation complete")
+					return
+				}
+				logger.Error().Err(err).Int("attempt", attempt).
+					Msg("Startup reconciliation failed")
+				if attempt < maxAttempts {
+					time.Sleep(time.Duration(attempt) * 5 * time.Second)
+				}
+			}
+			// Fail open: a broken DB must not brick deploys. The gap is
+			// repairable via POST /internal/reconcile.
+			logger.Error().Msg("Startup reconciliation exhausted retries; " +
+				"serving anyway — POST /internal/reconcile to repair")
+		}()
 	}
 
 	// Create and configure HTTP server
@@ -292,6 +359,12 @@ func main() {
 		mux.HandleFunc("/stats", api.NewStatsHandler(api.NewPostgresStatsProvider(dbPool), logger))
 		executionQualityHandler := api.NewExecutionQualityHandler(dbPool, logger.With().Str("component", "execution_quality").Logger())
 		mux.HandleFunc("/internal/stats/execution-quality", executionQualityHandler.GetExecutionQuality)
+	}
+	if startupReconciler != nil {
+		mux.HandleFunc(
+			"/internal/reconcile",
+			api.NewReconcileHandler(startupReconciler, logger.With().Str("component", "startup_reconciler").Logger()),
+		)
 	}
 
 	// Create server

--- a/app/router/internal/api/handlers.go
+++ b/app/router/internal/api/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -18,7 +19,6 @@ type OrderManager interface {
 	CloseAllPositions(ctx context.Context, req *orders.CloseAllRequest) error
 	CancelOpenOrders(ctx context.Context, req *orders.CancelOpenOrdersRequest) (*orders.CancelOpenOrdersResponse, error)
 	ClosePositions(ctx context.Context, req *orders.ClosePositionsRequest) (*orders.ClosePositionsResponse, error)
-	ReconcileOrder(ctx context.Context, clientOrderID string) error
 }
 
 // Handlers contains all HTTP handlers
@@ -28,11 +28,19 @@ type Handlers struct {
 	executionPersister SpotExecutionPersister
 	logger             zerolog.Logger
 	executionEnv       string
+	notReady           atomic.Bool
 }
 
 // SetExecutionEnv records the execution environment exposed on health responses.
 func (h *Handlers) SetExecutionEnv(env string) {
 	h.executionEnv = env
+}
+
+// SetReady gates /readyz: main flips it false while startup reconciliation
+// runs and back true when the pass completes. Default is ready, so
+// deployments without a reconciler are unaffected.
+func (h *Handlers) SetReady(ready bool) {
+	h.notReady.Store(!ready)
 }
 
 type SpotExecutionPersister interface {
@@ -400,7 +408,14 @@ func (h *Handlers) ReadyzHandler(w http.ResponseWriter, r *http.Request) {
 		Str("remote_addr", r.RemoteAddr).
 		Msg("Readiness check requested")
 
-	// TODO: Check actual readiness (Binance connectivity, etc.)
+	if h.notReady.Load() {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"status":  "reconciling",
+			"service": "order-router",
+		})
+		return
+	}
+
 	writeJSON(w, http.StatusOK, map[string]string{
 		"status":  "ready",
 		"service": "order-router",

--- a/app/router/internal/api/handlers_test.go
+++ b/app/router/internal/api/handlers_test.go
@@ -58,11 +58,6 @@ func (m *MockOrderManager) ClosePositions(ctx context.Context, req *orders.Close
 	return args.Get(0).(*orders.ClosePositionsResponse), args.Error(1)
 }
 
-func (m *MockOrderManager) ReconcileOrder(ctx context.Context, clientOrderID string) error {
-	args := m.Called(ctx, clientOrderID)
-	return args.Error(0)
-}
-
 func TestHealthzHandler(t *testing.T) {
 	logger := zerolog.Nop()
 	mockManager := new(MockOrderManager)

--- a/app/router/internal/api/reconcile.go
+++ b/app/router/internal/api/reconcile.go
@@ -1,0 +1,40 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/rs/zerolog"
+
+	"router/internal/orders"
+)
+
+// ReconcileRunner runs one reconciliation pass over open brackets.
+type ReconcileRunner interface {
+	Reconcile(ctx context.Context) (*orders.ReconcileSummary, error)
+}
+
+// NewReconcileHandler serves POST /internal/reconcile: it runs a pass
+// synchronously and returns its summary. Auth comes from the router's
+// shared token middleware.
+func NewReconcileHandler(runner ReconcileRunner, logger zerolog.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "Method not allowed")
+			return
+		}
+
+		summary, err := runner.Reconcile(r.Context())
+		if err != nil {
+			if errors.Is(err, orders.ErrReconcileInFlight) {
+				writeError(w, http.StatusConflict, "reconcile already in flight")
+				return
+			}
+			logger.Error().Err(err).Msg("On-demand reconcile failed")
+			writeError(w, http.StatusInternalServerError, "reconcile failed")
+			return
+		}
+		writeJSON(w, http.StatusOK, summary)
+	}
+}

--- a/app/router/internal/api/reconcile_test.go
+++ b/app/router/internal/api/reconcile_test.go
@@ -1,0 +1,76 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"router/internal/orders"
+)
+
+type stubReconciler struct {
+	summary *orders.ReconcileSummary
+	err     error
+	calls   int
+}
+
+func (s *stubReconciler) Reconcile(_ context.Context) (*orders.ReconcileSummary, error) {
+	s.calls++
+	return s.summary, s.err
+}
+
+func TestReconcileHandler_RejectsNonPost(t *testing.T) {
+	handler := NewReconcileHandler(&stubReconciler{}, zerolog.Nop())
+
+	rec := httptest.NewRecorder()
+	handler(rec, httptest.NewRequest(http.MethodGet, "/internal/reconcile", nil))
+
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+func TestReconcileHandler_ReturnsSummary(t *testing.T) {
+	stub := &stubReconciler{summary: &orders.ReconcileSummary{BracketsSwept: 3, BracketsClosed: 1}}
+	handler := NewReconcileHandler(stub, zerolog.Nop())
+
+	rec := httptest.NewRecorder()
+	handler(rec, httptest.NewRequest(http.MethodPost, "/internal/reconcile", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got orders.ReconcileSummary
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, *stub.summary, got)
+	assert.Equal(t, 1, stub.calls)
+}
+
+func TestReconcileHandler_InFlightConflicts(t *testing.T) {
+	handler := NewReconcileHandler(&stubReconciler{err: orders.ErrReconcileInFlight}, zerolog.Nop())
+
+	rec := httptest.NewRecorder()
+	handler(rec, httptest.NewRequest(http.MethodPost, "/internal/reconcile", nil))
+
+	assert.Equal(t, http.StatusConflict, rec.Code)
+}
+
+func TestReadyzHandler_GatedOnReconciliation(t *testing.T) {
+	h := NewHandlers(nil, zerolog.Nop(), nil, nil)
+
+	readyz := func() int {
+		rec := httptest.NewRecorder()
+		h.ReadyzHandler(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+		return rec.Code
+	}
+
+	assert.Equal(t, http.StatusOK, readyz(), "deployments without a reconciler must stay ready by default")
+
+	h.SetReady(false)
+	assert.Equal(t, http.StatusServiceUnavailable, readyz(), "not ready while startup reconciliation runs")
+
+	h.SetReady(true)
+	assert.Equal(t, http.StatusOK, readyz())
+}

--- a/app/router/internal/api/routes_test.go
+++ b/app/router/internal/api/routes_test.go
@@ -8,13 +8,11 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 func TestRegisterHealthRoutes(t *testing.T) {
 	logger := zerolog.Nop()
 	mockManager := new(MockOrderManager)
-	mockManager.On("ReconcileOrder", mock.Anything, mock.Anything).Maybe()
 
 	handlers := NewHandlers(mockManager, logger, nil, nil)
 

--- a/app/router/internal/orders/entry_fill_watcher.go
+++ b/app/router/internal/orders/entry_fill_watcher.go
@@ -137,11 +137,16 @@ func (w *EntryFillWatcher) checkBracket(ctx context.Context, record *storage.Bra
 		}
 		return
 	}
+	w.checkBracketWithEntry(ctx, record, entry)
+}
 
+// checkBracketWithEntry applies the fill/dead-entry decision to an entry the
+// caller already fetched (the reconciler reuses this after its own lookup).
+func (w *EntryFillWatcher) checkBracketWithEntry(ctx context.Context, record *storage.BracketRecord, entry *binance.OrderResponse) {
 	switch normalizeOrderStatus(entry.Status) {
 	case "FILLED":
 		w.arm(ctx, record, entry)
-	case "CANCELED", "EXPIRED", "REJECTED":
+	case "CANCELED", "EXPIRED", "EXPIRED_IN_MATCH", "REJECTED":
 		if entry.ExecutedQty.IsPositive() {
 			// A partial position exists and must still be protected
 			w.arm(ctx, record, entry)
@@ -155,12 +160,20 @@ func (w *EntryFillWatcher) arm(ctx context.Context, record *storage.BracketRecor
 	if record.Venue == "USD_M" {
 		if w.futures != nil {
 			w.futures.armLegs(ctx, record, entry.ExecutedQty)
+			return
 		}
+	} else if w.spotArmer != nil {
+		w.spotArmer.Arm(ctx, record, entry)
 		return
 	}
-	if w.spotArmer != nil {
-		w.spotArmer.Arm(ctx, record, entry)
-	}
+	// A filled entry with no armer for its venue leaves the position
+	// unprotected; only an engine replay can repair it. Never silent.
+	w.logger.Error().
+		Str("bracket_id", record.BracketID.String()).
+		Str("venue", record.Venue).
+		Str("symbol", record.Symbol).
+		Str("executed_qty", entry.ExecutedQty.String()).
+		Msg("entry fill watcher: entry filled but no armer for venue; position UNPROTECTED")
 }
 
 func (w *EntryFillWatcher) releaseDeadBracket(ctx context.Context, record *storage.BracketRecord) {

--- a/app/router/internal/orders/leg_armer.go
+++ b/app/router/internal/orders/leg_armer.go
@@ -19,6 +19,7 @@ type armerStore interface {
 	GetByLegClientOrderID(ctx context.Context, venue, clientOrderID string) (*storage.BracketRecord, error)
 	TryMarkLegPlacing(ctx context.Context, bracketID uuid.UUID, clientOrderID string) (bool, error)
 	UpdateLegStatus(ctx context.Context, bracketID uuid.UUID, clientOrderID, status string, exchangeOrderID int64) error
+	UpdateLegStatusIf(ctx context.Context, bracketID uuid.UUID, clientOrderID, expected, status string, exchangeOrderID int64) (bool, error)
 	UpdateBracketStatus(ctx context.Context, bracketID uuid.UUID, status string) error
 	InsertLeg(ctx context.Context, leg storage.BracketLegRecord) error
 }

--- a/app/router/internal/orders/leg_armer_test.go
+++ b/app/router/internal/orders/leg_armer_test.go
@@ -95,6 +95,27 @@ func (f *fakeArmerStore) UpdateLegStatus(_ context.Context, _ uuid.UUID, clientO
 	return nil
 }
 
+func (f *fakeArmerStore) UpdateLegStatusIf(_ context.Context, _ uuid.UUID, clientOrderID, expected, status string, exchangeOrderID int64) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for i := range f.record.Legs {
+		if f.record.Legs[i].ClientOrderID != clientOrderID || f.record.Legs[i].Status != expected {
+			continue
+		}
+		f.record.Legs[i].Status = status
+		if exchangeOrderID != 0 {
+			f.record.Legs[i].ExchangeOrderID = exchangeOrderID
+		}
+		f.legUpdates = append(f.legUpdates, clientOrderID+":"+status)
+		if f.legExchangeIDs == nil {
+			f.legExchangeIDs = map[string]int64{}
+		}
+		f.legExchangeIDs[clientOrderID] = exchangeOrderID
+		return true, nil
+	}
+	return false, nil
+}
+
 func (f *fakeArmerStore) UpdateBracketStatus(_ context.Context, _ uuid.UUID, status string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/app/router/internal/orders/manager.go
+++ b/app/router/internal/orders/manager.go
@@ -550,61 +550,6 @@ func (m *Manager) PlaceBracketOrder(ctx context.Context, req *PlaceBracketReques
 	return response, criticalPlacementErr
 }
 
-// ReconcileOrder updates order status from exchange
-func (m *Manager) ReconcileOrder(ctx context.Context, clientOrderID string) error {
-	m.mu.RLock()
-	bracketID, exists := m.ordersByClient[clientOrderID]
-	m.mu.RUnlock()
-
-	if !exists {
-		return fmt.Errorf("order not found: %s", clientOrderID)
-	}
-
-	m.mu.RLock()
-	bracket := m.orders[bracketID]
-	m.mu.RUnlock()
-
-	// Select client
-	client := m.spotClient
-	if bracket.Type == OrderTypeFutures {
-		client = m.futuresClient
-	}
-
-	// Get open orders
-	orders, err := client.GetOpenOrders(ctx, bracket.Symbol)
-	if err != nil {
-		return fmt.Errorf("failed to get open orders: %w", err)
-	}
-
-	// Update status based on exchange data
-	for _, order := range orders {
-		if order.ClientOrderID == clientOrderID {
-			// Emit update if status changed
-			venue := "SPOT"
-			if bracket.Type == OrderTypeFutures {
-				venue = "USD_M"
-			}
-			m.emitOrderUpdateWithLogging(ctx, &OrderUpdate{
-				EventType:     "order_update.v1",
-				Venue:         venue,
-				Symbol:        order.Symbol,
-				OrderID:       order.OrderID,
-				ClientOrderID: order.ClientOrderID,
-				Status:        order.Status,
-				Side:          order.Side,
-				OrderType:     order.Type,
-				Price:         order.Price,
-				Quantity:      order.OrigQty,
-				ExecutedQty:   order.ExecutedQty,
-				UpdateTime:    time.Now(),
-			})
-			break
-		}
-	}
-
-	return nil
-}
-
 // CancelOrder cancels an order
 func (m *Manager) CancelOrder(ctx context.Context, req *CancelRequest) error {
 	if req.Symbol == "" {

--- a/app/router/internal/orders/startup_reconciler.go
+++ b/app/router/internal/orders/startup_reconciler.go
@@ -1,0 +1,500 @@
+package orders
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"router/internal/binance"
+	"router/internal/rest"
+	"router/internal/storage"
+)
+
+// ErrReconcileInFlight rejects concurrent reconcile passes; the running one
+// already covers the caller's intent.
+var ErrReconcileInFlight = errors.New("reconcile already in flight")
+
+// ReconcileSummary reports what one reconcile pass observed and repaired.
+type ReconcileSummary struct {
+	BracketsSwept   int `json:"brackets_swept"`
+	EntriesChecked  int `json:"entries_checked"`
+	LegsResolved    int `json:"legs_resolved"`
+	ExitLegsUpdated int `json:"exit_legs_updated"`
+	BracketsClosed  int `json:"brackets_closed"`
+	StaleReserved   int `json:"stale_reserved"`
+	UnrepairedLegs  int `json:"unrepaired_legs"`
+	Errors          int `json:"errors"`
+}
+
+// StartupReconciler sweeps every open bracket and repairs whatever a crash,
+// missed event, or failed placement left behind: it settles legs stuck
+// PLACING against the exchange, re-drives entry-phase brackets through the
+// entry-fill watcher's logic, observes exit-leg outcomes for LEGS_PLACED
+// brackets, and closes brackets whose position is gone. It runs once at
+// startup (gating readiness) and on demand via POST /internal/reconcile.
+type StartupReconciler struct {
+	store         watcherStore
+	watcher       *EntryFillWatcher
+	spotClient    *binance.Client
+	futuresClient *binance.Client
+	emitter       EventEmitter
+	lookback      time.Duration
+	logger        zerolog.Logger
+
+	inFlight chan struct{}
+}
+
+func NewStartupReconciler(
+	store watcherStore,
+	watcher *EntryFillWatcher,
+	spotClient *binance.Client,
+	futuresClient *binance.Client,
+	emitter EventEmitter,
+	lookback time.Duration,
+	logger zerolog.Logger,
+) *StartupReconciler {
+	if lookback <= 0 {
+		lookback = defaultEntryFillLookback
+	}
+	gate := make(chan struct{}, 1)
+	gate <- struct{}{}
+	return &StartupReconciler{
+		store:         store,
+		watcher:       watcher,
+		spotClient:    spotClient,
+		futuresClient: futuresClient,
+		emitter:       emitter,
+		lookback:      lookback,
+		logger:        logger,
+		inFlight:      gate,
+	}
+}
+
+// Reconcile runs one full pass. Single-flight: a pass already running makes
+// this return ErrReconcileInFlight.
+func (r *StartupReconciler) Reconcile(ctx context.Context) (*ReconcileSummary, error) {
+	select {
+	case <-r.inFlight:
+	default:
+		return nil, ErrReconcileInFlight
+	}
+	defer func() { r.inFlight <- struct{}{} }()
+
+	brackets, err := r.store.LoadOpenBrackets(ctx, r.lookback)
+	if err != nil {
+		return nil, err
+	}
+
+	summary := &ReconcileSummary{}
+	for i := range brackets {
+		if ctx.Err() != nil {
+			// A partial pass must not read as success: callers retry
+			return summary, ctx.Err()
+		}
+		record := &brackets[i]
+		summary.BracketsSwept++
+		r.reconcileBracket(ctx, record, summary)
+	}
+	r.logger.Info().
+		Int("brackets_swept", summary.BracketsSwept).
+		Int("entries_checked", summary.EntriesChecked).
+		Int("legs_resolved", summary.LegsResolved).
+		Int("exit_legs_updated", summary.ExitLegsUpdated).
+		Int("brackets_closed", summary.BracketsClosed).
+		Int("stale_reserved", summary.StaleReserved).
+		Int("errors", summary.Errors).
+		Msg("reconciler: pass complete")
+	return summary, nil
+}
+
+func (r *StartupReconciler) clientFor(venue string) *binance.Client {
+	if venue == "USD_M" {
+		return r.futuresClient
+	}
+	return r.spotClient
+}
+
+func (r *StartupReconciler) reconcileBracket(ctx context.Context, record *storage.BracketRecord, summary *ReconcileSummary) {
+	client := r.clientFor(record.Venue)
+	if client == nil {
+		return
+	}
+
+	// A leg stuck PLACING outlived its process; the exchange is the only
+	// authority on whether that placement landed.
+	r.resolvePlacingLegs(ctx, client, record, summary)
+
+	switch record.Status {
+	case storage.BracketStatusReserved:
+		entry, err := client.GetOrderByClientID(ctx, record.Symbol, record.EntryClientOrderID)
+		if err != nil {
+			if rest.IsOrderNotFound(err) {
+				// Never POSTed. Closing it could race an in-flight engine
+				// replay, so it is only surfaced, not repaired.
+				summary.StaleReserved++
+				r.logger.Warn().
+					Str("bracket_id", record.BracketID.String()).
+					Str("entry_client_order_id", record.EntryClientOrderID).
+					Time("created_at", record.CreatedAt).
+					Msg("reconciler: reservation has no exchange entry")
+			} else {
+				summary.Errors++
+				r.logger.Warn().Err(err).
+					Str("entry_client_order_id", record.EntryClientOrderID).
+					Msg("reconciler: reserved entry lookup failed")
+			}
+			return
+		}
+		summary.EntriesChecked++
+		r.watcher.checkBracketWithEntry(ctx, record, entry)
+	case storage.BracketStatusEntryPlaced, storage.BracketStatusEntryFilled:
+		// Entry-phase repair reuses the watcher's logic (arm on fill,
+		// release on dead entry). Unlike the 2s loop, the reconciler also
+		// drives non-deferred brackets that crashed before their exits
+		// were placed.
+		summary.EntriesChecked++
+		r.watcher.checkBracket(ctx, record)
+	case storage.BracketStatusLegsPlaced:
+		r.sweepExitLegs(ctx, client, record, summary)
+	}
+}
+
+// resolvePlacingLegs settles legs left PLACING by a crash. A live armer may
+// be placing the same leg concurrently (the startup pass overlaps the 2s
+// watcher and the user-data armer, and /internal/reconcile can fire any
+// time), so a confirmed-absent leg is demoted with a CAS guarded on PLACING
+// — a fresher armer write is never overwritten — and only after a repoll,
+// since a freshly accepted order can lag the query path (#193).
+func (r *StartupReconciler) resolvePlacingLegs(
+	ctx context.Context,
+	client *binance.Client,
+	record *storage.BracketRecord,
+	summary *ReconcileSummary,
+) {
+	for i := range record.Legs {
+		leg := &record.Legs[i]
+		if leg.Status != storage.LegStatusPlacing {
+			continue
+		}
+		resp, err := r.getOrderWithRepoll(ctx, client, record.Symbol, leg.ClientOrderID)
+		if err != nil {
+			if rest.IsOrderNotFound(err) {
+				// Confirmed absent after repoll: release the claim so an
+				// armer can re-place it, but only if still PLACING.
+				if r.demotePlacing(ctx, record, leg) {
+					summary.LegsResolved++
+				}
+			} else {
+				summary.Errors++
+				r.logger.Warn().Err(err).Str("client_order_id", leg.ClientOrderID).
+					Msg("reconciler: PLACING leg lookup failed; leaving for next pass")
+			}
+			continue
+		}
+		// Found on the exchange: adopt its real state. Terminal states must
+		// win over any concurrent armer PLACED write, so this is unguarded.
+		status, working := legStatusFromOrder(resp.Status)
+		if r.updateLeg(ctx, record, leg, status, resp.OrderID) {
+			summary.LegsResolved++
+			if !working && leg.Role != "ENTRY" {
+				// A PLACING leg that resolved terminal is an exit transition
+				// the engine never saw; forward it like the sweep would.
+				r.emitExitUpdate(ctx, record, leg, resp)
+			}
+		}
+	}
+}
+
+// demotePlacing releases a confirmed-absent PLACING claim to FAILED, guarded
+// so a concurrent armer's PLACED write wins the race. Returns whether it
+// applied.
+func (r *StartupReconciler) demotePlacing(ctx context.Context, record *storage.BracketRecord, leg *storage.BracketLegRecord) bool {
+	applied, err := r.store.UpdateLegStatusIf(ctx, record.BracketID, leg.ClientOrderID,
+		storage.LegStatusPlacing, storage.LegStatusFailed, 0)
+	if err != nil {
+		r.logger.Warn().Err(err).Str("client_order_id", leg.ClientOrderID).
+			Msg("reconciler: failed to demote PLACING leg")
+		return false
+	}
+	if applied {
+		leg.Status = storage.LegStatusFailed
+	}
+	return applied
+}
+
+// getOrderWithRepoll looks an order up by client id, re-polling on -2013 to
+// bridge the exchange's post-accept visibility lag (#193).
+func (r *StartupReconciler) getOrderWithRepoll(
+	ctx context.Context,
+	client *binance.Client,
+	symbol, clientOrderID string,
+) (*binance.OrderResponse, error) {
+	resp, err := client.GetOrderByClientID(ctx, symbol, clientOrderID)
+	for attempt := 0; attempt < ocoRepollAttempts && err != nil && rest.IsOrderNotFound(err); attempt++ {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(ocoRepollDelay):
+		}
+		resp, err = client.GetOrderByClientID(ctx, symbol, clientOrderID)
+	}
+	return resp, err
+}
+
+// sweepExitLegs observes the exchange state of every placed exit leg,
+// forwards transitions to the engine, and settles the bracket.
+//
+// Closure semantics are venue-specific. Futures exits are position-scoped:
+// an SL fill closed the whole position, so resting TPs are cancelled (and
+// vice versa). Spot exits are slice-scoped OCO pairs: the exchange cancels
+// each pair's sibling itself, and cancelling another slice's leg would
+// strip a live stop off a still-open sub-position — so spot never cancels,
+// it only closes the bracket once every exit leg is terminal.
+func (r *StartupReconciler) sweepExitLegs(
+	ctx context.Context,
+	client *binance.Client,
+	record *storage.BracketRecord,
+	summary *ReconcileSummary,
+) {
+	for i := range record.Legs {
+		leg := &record.Legs[i]
+		if leg.Role == "ENTRY" {
+			continue
+		}
+		switch leg.Status {
+		case storage.LegStatusPlaced, storage.LegStatusPlanned:
+			// PLANNED under LEGS_PLACED means a crash in persistPlacementOutcome's
+			// window (bracket status written before leg statuses) left a live
+			// exit unrecorded — resolve it against the exchange like a placed leg.
+			r.sweepOneExitLeg(ctx, client, record, leg, summary)
+		case storage.LegStatusFailed:
+			// A FAILED exit is unprotected coverage that keeps the bracket
+			// open; the armers own re-placement, so surface it, don't settle.
+			summary.UnrepairedLegs++
+			r.logger.Warn().
+				Str("bracket_id", record.BracketID.String()).
+				Str("client_order_id", leg.ClientOrderID).
+				Str("role", leg.Role).
+				Msg("reconciler: LEGS_PLACED bracket has a FAILED exit leg; awaiting re-arm")
+		}
+	}
+
+	r.settleBracket(ctx, client, record, summary)
+}
+
+// sweepOneExitLeg resolves one exit leg against the exchange, persisting and
+// emitting any terminal transition. -2013 on a leg the DB thinks is live is
+// a real anomaly (surfaced), not a silent skip.
+func (r *StartupReconciler) sweepOneExitLeg(
+	ctx context.Context,
+	client *binance.Client,
+	record *storage.BracketRecord,
+	leg *storage.BracketLegRecord,
+	summary *ReconcileSummary,
+) {
+	resp, err := client.GetOrderByClientID(ctx, record.Symbol, leg.ClientOrderID)
+	if err != nil {
+		summary.Errors++
+		if rest.IsOrderNotFound(err) {
+			summary.UnrepairedLegs++
+			r.logger.Warn().
+				Str("client_order_id", leg.ClientOrderID).
+				Str("status", leg.Status).
+				Msg("reconciler: exit leg not found on exchange; leaving for re-arm")
+		} else {
+			r.logger.Warn().Err(err).Str("client_order_id", leg.ClientOrderID).
+				Msg("reconciler: exit leg lookup failed")
+		}
+		return
+	}
+	status, working := legStatusFromOrder(resp.Status)
+	if working {
+		if leg.Status == storage.LegStatusPlanned {
+			// Record that the exit is in fact live so settlement and the
+			// engine both see it.
+			r.updateLeg(ctx, record, leg, status, resp.OrderID)
+		}
+		return
+	}
+	if !r.updateLeg(ctx, record, leg, status, resp.OrderID) {
+		return // persist failed; re-observed next pass, no premature emit
+	}
+	r.emitExitUpdate(ctx, record, leg, resp)
+	summary.ExitLegsUpdated++
+}
+
+func (r *StartupReconciler) settleBracket(
+	ctx context.Context,
+	client *binance.Client,
+	record *storage.BracketRecord,
+	summary *ReconcileSummary,
+) {
+	slFilled, allTPsFilled, allTerminal := exitLegOutcomes(record)
+
+	if record.Venue == "USD_M" {
+		if slFilled {
+			r.cancelFuturesLegs(ctx, client, record, "TP", summary)
+			r.closeBracket(ctx, record, summary)
+			return
+		}
+		if allTPsFilled {
+			r.cancelFuturesLegs(ctx, client, record, "SL", summary)
+			r.closeBracket(ctx, record, summary)
+			return
+		}
+	}
+	if allTerminal {
+		r.closeBracket(ctx, record, summary)
+	}
+}
+
+// exitLegOutcomes reduces the exit legs to the three signals settlement
+// needs. FAILED legs count as non-terminal: they represent protection that
+// never reached the exchange.
+func exitLegOutcomes(record *storage.BracketRecord) (slFilled, allTPsFilled, allTerminal bool) {
+	tpCount := 0
+	allTPsFilled = true
+	allTerminal = true
+	for _, leg := range record.Legs {
+		if leg.Role == "ENTRY" {
+			continue
+		}
+		switch leg.Status {
+		case storage.LegStatusFilled:
+			if leg.Role == "SL" {
+				slFilled = true
+			}
+		case storage.LegStatusCanceled, storage.LegStatusExpired:
+		default:
+			allTerminal = false
+		}
+		if leg.Role == "TP" {
+			tpCount++
+			if leg.Status != storage.LegStatusFilled {
+				allTPsFilled = false
+			}
+		}
+	}
+	if tpCount == 0 {
+		allTPsFilled = false
+	}
+	return slFilled, allTPsFilled, allTerminal
+}
+
+func (r *StartupReconciler) cancelFuturesLegs(
+	ctx context.Context,
+	client *binance.Client,
+	record *storage.BracketRecord,
+	role string,
+	summary *ReconcileSummary,
+) {
+	for i := range record.Legs {
+		leg := &record.Legs[i]
+		if leg.Role != role || leg.Status != storage.LegStatusPlaced || leg.ExchangeOrderID == 0 {
+			continue
+		}
+		if _, err := client.CancelOrder(ctx, record.Symbol, leg.ExchangeOrderID); err != nil {
+			summary.Errors++
+			r.logger.Warn().Err(err).Str("client_order_id", leg.ClientOrderID).
+				Msg("reconciler: sibling cancel failed; next pass retries")
+			continue
+		}
+		r.updateLeg(ctx, record, leg, storage.LegStatusCanceled, leg.ExchangeOrderID)
+	}
+}
+
+func (r *StartupReconciler) closeBracket(ctx context.Context, record *storage.BracketRecord, summary *ReconcileSummary) {
+	if err := r.store.UpdateBracketStatus(ctx, record.BracketID, storage.BracketStatusClosed); err != nil {
+		summary.Errors++
+		r.logger.Warn().Err(err).Str("bracket_id", record.BracketID.String()).
+			Msg("reconciler: failed to close bracket")
+		return
+	}
+	record.Status = storage.BracketStatusClosed
+	summary.BracketsClosed++
+}
+
+// updateLeg persists a leg status and mirrors it onto the in-memory record.
+// Returns whether the write landed, so callers only count/emit real repairs.
+func (r *StartupReconciler) updateLeg(
+	ctx context.Context,
+	record *storage.BracketRecord,
+	leg *storage.BracketLegRecord,
+	status string,
+	exchangeOrderID int64,
+) bool {
+	if err := r.store.UpdateLegStatus(ctx, record.BracketID, leg.ClientOrderID, status, exchangeOrderID); err != nil {
+		r.logger.Warn().Err(err).
+			Str("client_order_id", leg.ClientOrderID).
+			Str("status", status).
+			Msg("reconciler: failed to persist leg status")
+		return false
+	}
+	leg.Status = status
+	if exchangeOrderID != 0 {
+		leg.ExchangeOrderID = exchangeOrderID
+	}
+	return true
+}
+
+func (r *StartupReconciler) emitExitUpdate(
+	ctx context.Context,
+	record *storage.BracketRecord,
+	leg *storage.BracketLegRecord,
+	resp *binance.OrderResponse,
+) {
+	if r.emitter == nil {
+		return
+	}
+	side := resp.Side
+	if side == "" {
+		side = getOppositeSide(record.Side)
+	}
+	updateTime := time.Now().UTC()
+	if resp.TransactTime > 0 {
+		updateTime = time.UnixMilli(resp.TransactTime).UTC()
+	}
+	update := &OrderUpdate{
+		EventType:     "order_update.v1",
+		Venue:         record.Venue,
+		Symbol:        record.Symbol,
+		OrderID:       resp.OrderID,
+		ClientOrderID: leg.ClientOrderID,
+		Status:        normalizeOrderStatus(resp.Status),
+		Side:          side,
+		OrderType:     resp.Type,
+		Price:         resp.Price,
+		Quantity:      resp.OrigQty,
+		ExecutedQty:   resp.ExecutedQty,
+		UpdateTime:    updateTime,
+	}
+	if err := r.emitter.EmitOrderUpdate(ctx, update); err != nil {
+		r.logger.Warn().Err(err).
+			Str("client_order_id", leg.ClientOrderID).
+			Msg("reconciler: failed to emit exit update")
+	}
+}
+
+// legStatusFromOrder maps an exchange order status onto a leg status. Only
+// NEW/PARTIALLY_FILLED are still working; every other status is terminal, so
+// unknown values are treated as EXPIRED (drop protection loudly) rather than
+// silently kept as live — recording a dead order as live protection is the
+// exact failure C6 exists to prevent.
+func legStatusFromOrder(orderStatus string) (status string, working bool) {
+	switch normalizeOrderStatus(orderStatus) {
+	case "NEW", "PARTIALLY_FILLED", "PENDING_NEW":
+		return storage.LegStatusPlaced, true
+	case "FILLED":
+		return storage.LegStatusFilled, false
+	case "CANCELED", "PENDING_CANCEL":
+		return storage.LegStatusCanceled, false
+	case "EXPIRED", "EXPIRED_IN_MATCH":
+		return storage.LegStatusExpired, false
+	case "REJECTED":
+		return storage.LegStatusFailed, false
+	default:
+		return storage.LegStatusExpired, false
+	}
+}

--- a/app/router/internal/orders/startup_reconciler_test.go
+++ b/app/router/internal/orders/startup_reconciler_test.go
@@ -1,0 +1,507 @@
+package orders
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"router/internal/auth"
+	"router/internal/binance"
+	"router/internal/rest"
+	"router/internal/storage"
+)
+
+// reconExchange serves per-client-order-id lookups and cancels on both
+// venue order paths.
+type reconExchange struct {
+	mu       sync.Mutex
+	orders   map[string]map[string]any // keyed by clientOrderId
+	canceled []int64
+}
+
+func newReconExchange() *reconExchange {
+	return &reconExchange{orders: map[string]map[string]any{}}
+}
+
+func (f *reconExchange) set(clientOrderID string, fields map[string]any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.orders[clientOrderID] = fields
+}
+
+func (f *reconExchange) canceledIDs() []int64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]int64(nil), f.canceled...)
+}
+
+func (f *reconExchange) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		isOrderPath := r.URL.Path == "/api/v3/order" || r.URL.Path == "/fapi/v1/order"
+		switch {
+		case r.Method == http.MethodGet && isOrderPath:
+			f.mu.Lock()
+			resp, ok := f.orders[q.Get("origClientOrderId")]
+			f.mu.Unlock()
+			if !ok {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"code":-2013,"msg":"Order does not exist."}`))
+				return
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.Method == http.MethodDelete && isOrderPath:
+			orderID, _ := strconv.ParseInt(q.Get("orderId"), 10, 64)
+			f.mu.Lock()
+			f.canceled = append(f.canceled, orderID)
+			f.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"symbol": q.Get("symbol"), "orderId": orderID, "status": "CANCELED",
+				"clientOrderId": "canceled", "origQty": "0.02", "executedQty": "0",
+				"price": "0", "cummulativeQuoteQty": "0", "timeInForce": "GTC",
+				"type": "LIMIT", "side": "SELL",
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"not found"}`))
+		}
+	}
+}
+
+func exchangeOrder(clientOrderID, status, executedQty string, orderID int64) map[string]any {
+	return map[string]any{
+		"symbol": "BTCUSDT", "orderId": orderID, "clientOrderId": clientOrderID,
+		"price": "51000", "origQty": "0.02", "executedQty": executedQty,
+		"cummulativeQuoteQty": "0", "status": status, "timeInForce": "GTC",
+		"type": "LIMIT", "side": "SELL", "updateTime": 1,
+	}
+}
+
+// recordingEmitter captures every emitted update (mockSuccessEmitter only
+// keeps the last one).
+type recordingEmitter struct {
+	mu      sync.Mutex
+	updates []*OrderUpdate
+}
+
+func (e *recordingEmitter) EmitOrderUpdate(_ context.Context, update *OrderUpdate) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.updates = append(e.updates, update)
+	return nil
+}
+
+func (e *recordingEmitter) emitted() []*OrderUpdate {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append([]*OrderUpdate(nil), e.updates...)
+}
+
+func newReconcilerFixture(
+	t *testing.T,
+	handler http.HandlerFunc,
+	store *fakeWatcherStore,
+	venue string,
+) (*StartupReconciler, *recordingEmitter) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	signer := auth.NewSignerWithRecvWindow("key", "secret", 5000)
+	logger := zerolog.Nop()
+	restClient := rest.NewClient(server.URL, signer)
+
+	var spotClient, futuresClient *binance.Client
+	var err error
+	if venue == "USD_M" {
+		futuresClient, err = binance.NewFuturesClient(server.URL, signer, restClient, logger)
+	} else {
+		spotClient, err = binance.NewSpotClient(server.URL, signer, restClient, logger)
+	}
+	require.NoError(t, err)
+
+	emitter := &recordingEmitter{}
+	watcher := NewEntryFillWatcher(store, spotClient, nil, futuresClient, nil, time.Millisecond, time.Hour, logger)
+	reconciler := NewStartupReconciler(store, watcher, spotClient, futuresClient, emitter, time.Hour, logger)
+	return reconciler, emitter
+}
+
+// fastReconRepoll shrinks the -2013 repoll so confirmed-absent tests do not
+// sleep.
+func fastReconRepoll(t *testing.T) {
+	t.Helper()
+	prevDelay, prevAttempts := ocoRepollDelay, ocoRepollAttempts
+	ocoRepollDelay, ocoRepollAttempts = time.Millisecond, 1
+	t.Cleanup(func() { ocoRepollDelay, ocoRepollAttempts = prevDelay, prevAttempts })
+}
+
+// raceOnDemoteStore simulates a concurrent armer that flips a leg to a new
+// status the instant before the reconciler's guarded demote runs.
+type raceOnDemoteStore struct {
+	fakeWatcherStore
+	flipTo  string
+	flipLeg string
+	flipped bool
+}
+
+func (s *raceOnDemoteStore) UpdateLegStatusIf(ctx context.Context, bracketID uuid.UUID, clientOrderID, expected, status string, exchangeOrderID int64) (bool, error) {
+	if !s.flipped && clientOrderID == s.flipLeg {
+		s.flipped = true
+		// The armer wins: the leg is no longer PLACING when the CAS lands
+		for i := range s.record.Legs {
+			if s.record.Legs[i].ClientOrderID == s.flipLeg {
+				s.record.Legs[i].Status = s.flipTo
+			}
+		}
+	}
+	return s.fakeWatcherStore.UpdateLegStatusIf(ctx, bracketID, clientOrderID, expected, status, exchangeOrderID)
+}
+
+// legsPlacedRecord returns a bracket whose exits are live on the exchange.
+func legsPlacedRecord(venue string) *storage.BracketRecord {
+	rec := armerRecord()
+	rec.Venue = venue
+	rec.Status = storage.BracketStatusLegsPlaced
+	rec.Legs[1].Status = storage.LegStatusPlaced
+	rec.Legs[1].ExchangeOrderID = 101
+	rec.Legs[2].Status = storage.LegStatusPlaced
+	rec.Legs[2].ExchangeOrderID = 102
+	return rec
+}
+
+func TestStartupReconciler_SpotExitFillsCloseBracket(t *testing.T) {
+	store := &fakeWatcherStore{fakeArmerStore{record: legsPlacedRecord("SPOT")}}
+	fake := newReconExchange()
+	fake.set("arm-tp1", exchangeOrder("arm-tp1", "FILLED", "0.02", 101))
+	fake.set("arm-sl", exchangeOrder("arm-sl", "EXPIRED", "0", 102))
+	reconciler, emitter := newReconcilerFixture(t, fake.handler(), store, "SPOT")
+
+	summary, err := reconciler.Reconcile(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, &ReconcileSummary{
+		BracketsSwept:   1,
+		ExitLegsUpdated: 2,
+		BracketsClosed:  1,
+	}, summary)
+	assert.Contains(t, store.legUpdates, "arm-tp1:FILLED")
+	assert.Contains(t, store.legUpdates, "arm-sl:EXPIRED")
+	assert.Equal(t, []string{storage.BracketStatusClosed}, store.bracketUpdates)
+	assert.Len(t, emitter.emitted(), 2, "observed exit transitions must reach the engine")
+	assert.Empty(t, fake.canceledIDs(), "spot sibling-cancel belongs to the exchange")
+}
+
+func TestStartupReconciler_SpotOpenExitsStayOpen(t *testing.T) {
+	store := &fakeWatcherStore{fakeArmerStore{record: legsPlacedRecord("SPOT")}}
+	fake := newReconExchange()
+	fake.set("arm-tp1", exchangeOrder("arm-tp1", "NEW", "0", 101))
+	fake.set("arm-sl", exchangeOrder("arm-sl", "NEW", "0", 102))
+	reconciler, emitter := newReconcilerFixture(t, fake.handler(), store, "SPOT")
+
+	summary, err := reconciler.Reconcile(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, summary.ExitLegsUpdated)
+	assert.Empty(t, store.bracketUpdates, "working exits must keep the bracket open")
+	assert.Empty(t, emitter.emitted())
+}
+
+func TestStartupReconciler_SpotNeverCancelsSiblingSlices(t *testing.T) {
+	record := legsPlacedRecord("SPOT")
+	record.Legs = append(record.Legs,
+		storage.BracketLegRecord{Role: "TP", TPIndex: 2, ClientOrderID: "arm-tp2",
+			Status: storage.LegStatusPlaced, ExchangeOrderID: 103, Price: decimal.RequireFromString("52000")},
+		storage.BracketLegRecord{Role: "SL", TPIndex: 1, ClientOrderID: "arm-sl-1",
+			Status: storage.LegStatusPlaced, ExchangeOrderID: 104, StopPrice: decimal.RequireFromString("49000")},
+	)
+	store := &fakeWatcherStore{fakeArmerStore{record: record}}
+	fake := newReconExchange()
+	// Slice 0's stop filled and its sibling TP expired; slice 1 still works
+	fake.set("arm-sl", exchangeOrder("arm-sl", "FILLED", "0.01", 102))
+	fake.set("arm-tp1", exchangeOrder("arm-tp1", "EXPIRED", "0", 101))
+	fake.set("arm-tp2", exchangeOrder("arm-tp2", "NEW", "0", 103))
+	fake.set("arm-sl-1", exchangeOrder("arm-sl-1", "NEW", "0", 104))
+	reconciler, _ := newReconcilerFixture(t, fake.handler(), store, "SPOT")
+
+	summary, err := reconciler.Reconcile(context.Background())
+
+	require.NoError(t, err)
+	assert.Empty(t, fake.canceledIDs(),
+		"cancelling one slice's legs would strip live stops off sibling OCO slices")
+	assert.Empty(t, store.bracketUpdates, "slice 1 still protects an open sub-position")
+	assert.Equal(t, 2, summary.ExitLegsUpdated)
+}
+
+func TestStartupReconciler_FuturesSLFillCancelsTPsAndCloses(t *testing.T) {
+	store := &fakeWatcherStore{fakeArmerStore{record: legsPlacedRecord("USD_M")}}
+	fake := newReconExchange()
+	fake.set("arm-sl", exchangeOrder("arm-sl", "FILLED", "0.02", 102))
+	fake.set("arm-tp1", exchangeOrder("arm-tp1", "NEW", "0", 101))
+	reconciler, _ := newReconcilerFixture(t, fake.handler(), store, "USD_M")
+
+	summary, err := reconciler.Reconcile(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, []int64{101}, fake.canceledIDs(),
+		"the SL closed the position; resting TPs must be cancelled")
+	assert.Contains(t, store.legUpdates, "arm-sl:FILLED")
+	assert.Contains(t, store.legUpdates, "arm-tp1:CANCELED")
+	assert.Equal(t, []string{storage.BracketStatusClosed}, store.bracketUpdates)
+	assert.Equal(t, 1, summary.BracketsClosed)
+}
+
+func TestStartupReconciler_FuturesAllTPsFilledCancelsSL(t *testing.T) {
+	store := &fakeWatcherStore{fakeArmerStore{record: legsPlacedRecord("USD_M")}}
+	fake := newReconExchange()
+	fake.set("arm-tp1", exchangeOrder("arm-tp1", "FILLED", "0.02", 101))
+	fake.set("arm-sl", exchangeOrder("arm-sl", "NEW", "0", 102))
+	reconciler, _ := newReconcilerFixture(t, fake.handler(), store, "USD_M")
+
+	_, err := reconciler.Reconcile(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, []int64{102}, fake.canceledIDs())
+	assert.Contains(t, store.legUpdates, "arm-sl:CANCELED")
+	assert.Equal(t, []string{storage.BracketStatusClosed}, store.bracketUpdates)
+}
+
+func TestStartupReconciler_FuturesStalePlacingLegAdopted(t *testing.T) {
+	record := armerRecord() // USD_M, ENTRY_PLACED
+	record.Status = storage.BracketStatusEntryFilled
+	record.Legs[1].Status = storage.LegStatusPlacing // crashed mid-placement
+	store := &fakeWatcherStore{fakeArmerStore{record: record}}
+	fake := newReconExchange()
+	fake.set("arm-main", exchangeOrder("arm-main", "FILLED", "0.02", 100))
+	fake.set("arm-tp1", exchangeOrder("arm-tp1", "NEW", "0", 555))
+	reconciler, _ := newReconcilerFixture(t, fake.handler(), store, "USD_M")
+
+	summary, err := reconciler.Reconcile(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, summary.LegsResolved)
+	assert.Contains(t, store.legUpdates, "arm-tp1:PLACED")
+	assert.Equal(t, int64(555), store.legExchangeIDs["arm-tp1"],
+		"the live order's exchange id must be adopted, not re-POSTed")
+}
+
+func TestStartupReconciler_FuturesStalePlacingLegConfirmedAbsentFails(t *testing.T) {
+	fastReconRepoll(t)
+	record := armerRecord()
+	record.Status = storage.BracketStatusEntryFilled
+	record.Legs[1].Status = storage.LegStatusPlacing
+	store := &fakeWatcherStore{fakeArmerStore{record: record}}
+	fake := newReconExchange()
+	fake.set("arm-main", exchangeOrder("arm-main", "FILLED", "0.02", 100))
+	reconciler, _ := newReconcilerFixture(t, fake.handler(), store, "USD_M")
+
+	summary, err := reconciler.Reconcile(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, summary.LegsResolved)
+	assert.Contains(t, store.legUpdates, "arm-tp1:FAILED",
+		"a PLACING leg the exchange never saw must become re-claimable")
+}
+
+func TestStartupReconciler_PlacingDemoteYieldsToConcurrentArmerWrite(t *testing.T) {
+	fastReconRepoll(t)
+	record := armerRecord()
+	record.Status = storage.BracketStatusEntryFilled
+	record.Legs[1].Status = storage.LegStatusPlacing
+	// A concurrent armer places the leg PLACED between the reconciler's DB
+	// load and its guarded demote; the CAS on PLACING must not overwrite it.
+	store := &raceOnDemoteStore{
+		fakeWatcherStore: fakeWatcherStore{fakeArmerStore{record: record}},
+		flipTo:           storage.LegStatusPlaced,
+		flipLeg:          "arm-tp1",
+	}
+	fake := newReconExchange()
+	fake.set("arm-main", exchangeOrder("arm-main", "FILLED", "0.02", 100))
+	reconciler, _ := newReconcilerFixture(t, fake.handler(), &store.fakeWatcherStore, "USD_M")
+	// Rebuild against the racing store
+	reconciler.store = store
+
+	_, err := reconciler.Reconcile(context.Background())
+
+	require.NoError(t, err)
+	assert.NotContains(t, store.legUpdates, "arm-tp1:FAILED",
+		"the guarded demote must lose to a concurrent PLACED write")
+	assert.Equal(t, storage.LegStatusPlaced, legByClientOrderID(store.record, "arm-tp1").Status)
+}
+
+func TestStartupReconciler_LegsPlacedWithPlannedLegAdoptsLiveExit(t *testing.T) {
+	// Crash in persistPlacementOutcome's window: bracket LEGS_PLACED but a
+	// leg still PLANNED though live on the exchange.
+	record := legsPlacedRecord("SPOT")
+	record.Legs[1].Status = storage.LegStatusPlanned
+	record.Legs[1].ExchangeOrderID = 0
+	store := &fakeWatcherStore{fakeArmerStore{record: record}}
+	fake := newReconExchange()
+	fake.set("arm-tp1", exchangeOrder("arm-tp1", "NEW", "0", 101)) // live, working
+	fake.set("arm-sl", exchangeOrder("arm-sl", "NEW", "0", 102))
+	reconciler, _ := newReconcilerFixture(t, fake.handler(), store, "SPOT")
+
+	summary, err := reconciler.Reconcile(context.Background())
+
+	require.NoError(t, err)
+	assert.Contains(t, store.legUpdates, "arm-tp1:PLACED",
+		"a PLANNED-but-live exit must be recorded so settlement sees it")
+	assert.Equal(t, int64(101), store.legExchangeIDs["arm-tp1"])
+	assert.Empty(t, store.bracketUpdates, "both exits still working; bracket stays open")
+	assert.Equal(t, 0, summary.UnrepairedLegs)
+}
+
+func TestStartupReconciler_LegsPlacedWithFailedLegCountedNotClosed(t *testing.T) {
+	record := legsPlacedRecord("SPOT")
+	record.Legs[1].Status = storage.LegStatusFailed // never reached the exchange
+	store := &fakeWatcherStore{fakeArmerStore{record: record}}
+	fake := newReconExchange()
+	fake.set("arm-sl", exchangeOrder("arm-sl", "NEW", "0", 102))
+	reconciler, _ := newReconcilerFixture(t, fake.handler(), store, "SPOT")
+
+	summary, err := reconciler.Reconcile(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, summary.UnrepairedLegs,
+		"an unprotected FAILED exit must be surfaced, not silently skipped")
+	assert.Empty(t, store.bracketUpdates, "a bracket with unplaced protection must not be closed")
+}
+
+func TestStartupReconciler_ExpiredInMatchDropsProtection(t *testing.T) {
+	store := &fakeWatcherStore{fakeArmerStore{record: legsPlacedRecord("SPOT")}}
+	fake := newReconExchange()
+	// STP-expired SL must be recorded terminal, not kept as live protection
+	fake.set("arm-sl", exchangeOrder("arm-sl", "EXPIRED_IN_MATCH", "0", 102))
+	fake.set("arm-tp1", exchangeOrder("arm-tp1", "FILLED", "0.02", 101))
+	reconciler, _ := newReconcilerFixture(t, fake.handler(), store, "SPOT")
+
+	_, err := reconciler.Reconcile(context.Background())
+
+	require.NoError(t, err)
+	assert.Contains(t, store.legUpdates, "arm-sl:EXPIRED",
+		"EXPIRED_IN_MATCH is terminal; recording it PLACED would claim a dead stop is live")
+	assert.Equal(t, []string{storage.BracketStatusClosed}, store.bracketUpdates)
+}
+
+func TestStartupReconciler_FuturesSLAndTPBothFilledClosesOnce(t *testing.T) {
+	store := &fakeWatcherStore{fakeArmerStore{record: legsPlacedRecord("USD_M")}}
+	fake := newReconExchange()
+	fake.set("arm-sl", exchangeOrder("arm-sl", "FILLED", "0.02", 102))
+	fake.set("arm-tp1", exchangeOrder("arm-tp1", "FILLED", "0.02", 101))
+	reconciler, _ := newReconcilerFixture(t, fake.handler(), store, "USD_M")
+
+	summary, err := reconciler.Reconcile(context.Background())
+
+	require.NoError(t, err)
+	assert.Empty(t, fake.canceledIDs(), "both legs already terminal; nothing to cancel")
+	assert.Equal(t, []string{storage.BracketStatusClosed}, store.bracketUpdates)
+	assert.Equal(t, 1, summary.BracketsClosed)
+}
+
+func TestStartupReconciler_TerminalPlacingLegEmitsToEngine(t *testing.T) {
+	record := legsPlacedRecord("USD_M")
+	record.Legs[1].Status = storage.LegStatusPlacing // crashed mid-placement
+	store := &fakeWatcherStore{fakeArmerStore{record: record}}
+	fake := newReconExchange()
+	// The TP filled while the router was down; the fill was never emitted
+	fake.set("arm-tp1", exchangeOrder("arm-tp1", "FILLED", "0.02", 101))
+	fake.set("arm-sl", exchangeOrder("arm-sl", "NEW", "0", 102))
+	reconciler, emitter := newReconcilerFixture(t, fake.handler(), store, "USD_M")
+
+	_, err := reconciler.Reconcile(context.Background())
+
+	require.NoError(t, err)
+	assert.Contains(t, store.legUpdates, "arm-tp1:FILLED")
+	var emittedTP bool
+	for _, u := range emitter.emitted() {
+		if u.ClientOrderID == "arm-tp1" && u.Status == "FILLED" {
+			emittedTP = true
+		}
+	}
+	assert.True(t, emittedTP, "a PLACING leg that resolved terminal must reach the engine")
+}
+
+func TestStartupReconciler_StaleReservedCountedNotClosed(t *testing.T) {
+	record := armerRecord()
+	record.Status = storage.BracketStatusReserved
+	store := &fakeWatcherStore{fakeArmerStore{record: record}}
+	fake := newReconExchange() // entry unknown everywhere
+	reconciler, _ := newReconcilerFixture(t, fake.handler(), store, "USD_M")
+
+	summary, err := reconciler.Reconcile(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, summary.StaleReserved)
+	assert.Empty(t, store.bracketUpdates,
+		"closing a reservation can race an in-flight engine replay")
+	assert.Empty(t, store.legUpdates)
+}
+
+func TestStartupReconciler_EntryPhaseArmsThroughWatcher(t *testing.T) {
+	store := &fakeWatcherStore{fakeArmerStore{record: spotArmerRecord()}}
+	fake := &spotOCOExchange{}
+	armer, spotClient := newSpotArmerFixture(t, fake, &store.fakeArmerStore)
+	watcher := NewEntryFillWatcher(store, spotClient, armer, nil, nil, time.Millisecond, time.Hour, zerolog.Nop())
+	reconciler := NewStartupReconciler(store, watcher, spotClient, nil, nil, time.Hour, zerolog.Nop())
+
+	summary, err := reconciler.Reconcile(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, summary.EntriesChecked)
+	require.Len(t, fake.requests(), 1, "a filled deferred entry must arm its OCO exits")
+	assert.Contains(t, store.bracketUpdates, storage.BracketStatusLegsPlaced)
+}
+
+// blockingStore gates LoadOpenBrackets so a pass can be held in flight.
+type blockingStore struct {
+	fakeWatcherStore
+	release chan struct{}
+}
+
+func (b *blockingStore) LoadOpenBrackets(ctx context.Context, lookback time.Duration) ([]storage.BracketRecord, error) {
+	<-b.release
+	return b.fakeWatcherStore.LoadOpenBrackets(ctx, lookback)
+}
+
+func TestStartupReconciler_SingleFlight(t *testing.T) {
+	store := &blockingStore{
+		fakeWatcherStore: fakeWatcherStore{fakeArmerStore{record: nil}},
+		release:          make(chan struct{}),
+	}
+	fake := newReconExchange()
+	server := httptest.NewServer(fake.handler())
+	t.Cleanup(server.Close)
+	signer := auth.NewSignerWithRecvWindow("key", "secret", 5000)
+	spotClient, err := binance.NewSpotClient(server.URL, signer, rest.NewClient(server.URL, signer), zerolog.Nop())
+	require.NoError(t, err)
+	watcher := NewEntryFillWatcher(store, spotClient, nil, nil, nil, time.Millisecond, time.Hour, zerolog.Nop())
+	reconciler := NewStartupReconciler(store, watcher, spotClient, nil, nil, time.Hour, zerolog.Nop())
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := reconciler.Reconcile(context.Background())
+		firstDone <- err
+	}()
+
+	require.Eventually(t, func() bool {
+		_, err := reconciler.Reconcile(context.Background())
+		return errors.Is(err, ErrReconcileInFlight)
+	}, time.Second, 5*time.Millisecond, "a concurrent pass must be rejected")
+
+	close(store.release)
+	require.NoError(t, <-firstDone)
+
+	_, err = reconciler.Reconcile(context.Background())
+	assert.NoError(t, err, "the gate must be released after the pass completes")
+}

--- a/app/router/internal/storage/bracket_repo.go
+++ b/app/router/internal/storage/bracket_repo.go
@@ -178,6 +178,28 @@ func (r *BracketRepo) UpdateLegStatus(
 	return nil
 }
 
+// UpdateLegStatusIf transitions a leg only from the expected status. The
+// reconciler demotes crash-stale PLACING claims with it so a concurrent
+// armer's fresher write can never be overwritten.
+func (r *BracketRepo) UpdateLegStatusIf(
+	ctx context.Context,
+	bracketID uuid.UUID,
+	clientOrderID, expected, status string,
+	exchangeOrderID int64,
+) (bool, error) {
+	tag, err := r.pool.Exec(ctx, `
+		UPDATE bracket_legs
+		SET status = $4,
+		    exchange_order_id = NULLIF($5, 0),
+		    updated_at = CURRENT_TIMESTAMP
+		WHERE bracket_id = $1 AND client_order_id = $2 AND status = $3`,
+		bracketID, clientOrderID, expected, status, exchangeOrderID)
+	if err != nil {
+		return false, fmt.Errorf("guarded update bracket leg status: %w", err)
+	}
+	return tag.RowsAffected() == 1, nil
+}
+
 // InsertLeg adds a leg to an existing bracket — used for stop slices derived
 // at arm time beyond the single reserved SL leg.
 func (r *BracketRepo) InsertLeg(ctx context.Context, leg BracketLegRecord) error {

--- a/app/router/internal/storage/bracket_repo_integration_test.go
+++ b/app/router/internal/storage/bracket_repo_integration_test.go
@@ -212,6 +212,34 @@ func TestBracketRepo_UpdateBracketStatusIfGuardsTransition(t *testing.T) {
 	assert.False(t, notApplied, "guarded transition must not fire from the wrong state")
 }
 
+func TestBracketRepo_UpdateLegStatusIfGuardsLegTransition(t *testing.T) {
+	repo, ctx := newBracketTestRepo(t)
+	entryID := "it-" + uuid.NewString()[:8]
+	rec, inserted, err := repo.Reserve(ctx, sampleBracket(entryID))
+	require.NoError(t, err)
+	require.True(t, inserted)
+
+	require.NoError(t, repo.UpdateLegStatus(ctx, rec.BracketID, entryID+"-tp1", LegStatusPlacing, 0))
+
+	applied, err := repo.UpdateLegStatusIf(ctx, rec.BracketID, entryID+"-tp1", LegStatusPlacing, LegStatusFailed, 0)
+	require.NoError(t, err)
+	assert.True(t, applied, "a PLACING leg must demote to FAILED")
+
+	// A concurrent armer already moved it PLACED: the guard must not fire
+	require.NoError(t, repo.UpdateLegStatus(ctx, rec.BracketID, entryID+"-tp1", LegStatusPlaced, 999))
+	applied, err = repo.UpdateLegStatusIf(ctx, rec.BracketID, entryID+"-tp1", LegStatusPlacing, LegStatusFailed, 0)
+	require.NoError(t, err)
+	assert.False(t, applied, "the demote must lose to a fresher PLACED write")
+
+	found, err := repo.GetByLegClientOrderID(ctx, "SPOT", entryID+"-tp1")
+	require.NoError(t, err)
+	for _, leg := range found.Legs {
+		if leg.ClientOrderID == entryID+"-tp1" {
+			assert.Equal(t, [2]any{LegStatusPlaced, int64(999)}, [2]any{leg.Status, leg.ExchangeOrderID})
+		}
+	}
+}
+
 func TestBracketRepo_InsertLegAddsDerivedStopSlice(t *testing.T) {
 	repo, ctx := newBracketTestRepo(t)
 	entryID := "it-" + uuid.NewString()[:8]


### PR DESCRIPTION
## Summary

C6 of the router order-lifecycle campaign (#193 → #194 → #195 → #196 → #197 → this). A readiness-gated startup reconciler repairs whatever a crash, missed user-data event, or failed placement left behind in the `brackets` table — closing the recovery gaps that C2–C5 deliberately deferred to "the reconciler."

- **`StartupReconciler.Reconcile(ctx)`** (`internal/orders/startup_reconciler.go`) — a single-flight pass over `BracketRepo.LoadOpenBrackets`:
  - **Legs stuck `PLACING`** (both venues, any status): resolved against the exchange via `GetOrderByClientID`. A confirmed `-2013` is repolled (post-accept visibility lag, per #193) and then demoted through a new **`PLACING`-guarded CAS** (`UpdateLegStatusIf`) so a live armer placing the same leg concurrently always wins — no lost updates. This closes the futures `armSingleLeg` gap where a crash-stranded PLACING leg was never resolved.
  - **`RESERVED`**: entry queried; `-2013` → counted `StaleReserved` + warned, **not** closed (closing could race an in-flight engine replay); visible → delegated to the entry-fill watcher's fill/dead-entry logic.
  - **`ENTRY_PLACED` / `ENTRY_FILLED`**: delegated to `EntryFillWatcher.checkBracket` — arms on fill (incl. partials), releases dead entries. Runs for **all** brackets at reconcile time, not just `LegsOnFill` ones.
  - **`LEGS_PLACED`**: exit-leg sweep. Terminal transitions persist and emit `order_update.v1` to the engine (closing the "spot exit fills unobserved" gap from #197). Settlement is venue-correct: **futures** — SL filled (ClosePosition, so the whole position is gone) → cancel resting TPs → close; all TPs filled → cancel SL → close. **Spot** — **never cancels** (each OCO slice is exchange-sibling-managed; cancelling one slice's leg would strip a live stop off a still-open sub-position), closes only when every exit leg is terminal. `PLANNED`-but-live exits (the `persistPlacementOutcome` crash window) are adopted; `FAILED` exits are counted `UnrepairedLegs` + warned, never silently settled.
- **Readiness gate** (`internal/api/handlers.go`): `/readyz` returns 503 "reconciling" until the startup pass completes (`SetReady`, default ready so non-DB deployments are unaffected). `/healthz` is untouched, so liveness never flaps.
- **`POST /internal/reconcile`** (`internal/api/reconcile.go`): on-demand pass, `409` when one is already in flight, JSON summary. Token-gated by the existing auth middleware.
- **Dead code removed**: `Manager.ReconcileOrder` (in-memory-map based, zero production call sites, structurally unable to reconcile across restarts) deleted and dropped from the `api.OrderManager` interface.
- **Wiring** (`cmd/router/main.go`): reconciler built when `DATABASE_URL` is set (reusing the running `EntryFillWatcher`, or a non-started one when `BRACKET_LEGS_ON_FILL` is off), readiness held false during the initial pass (3 retries, 2-min timeout each), **fail-open** with a loud error after exhaustion so a broken DB cannot brick deploys.

## QCHECK

Round 1: **BLOCK** — no critical money-loss defect (verified: spot never cancels, futures cancels only fire once the position is fully closed, double-placement is blocked by client-id idempotency + ReduceOnly/balance semantics), but three high findings: H-1 unconditional `PLACING→FAILED` demote could race a live armer and corrupt the book; H-2 `LEGS_PLACED` brackets with `PLANNED`/`FAILED` exit legs (the `persistPlacementOutcome` crash window) were silently unrepairable; H-3 `EXPIRED_IN_MATCH` (self-trade-prevention expiry) recorded as live protection forever. All fixed (CAS + repoll, PLANNED-leg resolution + FAILED-hold counting, terminal status mapping) with regression tests. Round 2: **PASS**, no new defects; one narrow pre-existing residual (terminal PLACING legs not emitting) folded in.

## Disclosed residuals / follow-ups

- Futures `REJECTED`→`FAILED` legs are re-claimable and can retry-loop for a permanently-rejected order — pre-existing C5 dynamic via `TryMarkLegPlacing`, not introduced here.
- Brackets left open by an `UnrepairedLegs`/anomaly condition age out of the 168h `LoadOpenBrackets` lookback and become invisible to future passes — worth a stale-open metric during soak.
- `legsOnFill=off` deployments: a spot bracket that crashed between entry POST and synchronous exit placement is observed but not armed (spot armer absent in that mode) — now loudly logged as `position UNPROTECTED`; only an engine replay repairs it.

## Soak checklist additions (blocking)

1. Trigger `POST /internal/reconcile` after a mid-flight kill and confirm PLACING legs settle without double-placement (the CAS + repoll path).
2. Confirm `/readyz` flips 503→200 across a restart with open brackets, and that orchestrator readiness probes tolerate the reconcile window (≤ ~6.5min worst case before fail-open).
3. Watch `UnrepairedLegs`/`Errors` in the completion log line — a non-zero count means a bracket needs manual attention.

## Deploy notes

No new migration (reuses 030/031/032). Apply those before rolling if not already present. `BRACKET_LEGS_ON_FILL` **stays OFF** — C6 makes it safe to flip in C7 after the soak, since crash-between-fill-and-arm now self-heals on restart.

## Test evidence

- `gofmt`/`vet` clean; full `go test -race ./...` passes (17 packages).
- 9 bracket-repo integration tests pass against real Postgres (incl. the new `UpdateLegStatusIf` CAS guard test).
- New coverage: reconciler venue-specific settlement, PLACING race/CAS, PLANNED/FAILED exit handling, `EXPIRED_IN_MATCH`, single-flight, readiness gate, and the `/internal/reconcile` handler.