### PR TITLE
chore(router): enable deferred legs + reconciler for the testnet soak (C7)

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,5 @@
 # Docker Compose configuration for development environment
 
-
 networks:
   trading-network:
     driver: bridge
@@ -34,7 +33,11 @@ services:
     networks:
       - trading-network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-trading_user} -d ${POSTGRES_DB:-trading_platform}"]
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -U ${POSTGRES_USER:-trading_user} -d ${POSTGRES_DB:-trading_platform}",
+        ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -169,6 +172,10 @@ services:
       - REDIS_URL=redis://redis:6379/0
       - DATABASE_URL=postgresql://${POSTGRES_USER:-trading_user}:${POSTGRES_PASSWORD:-your_secure_password_here}@postgres:5432/${POSTGRES_DB:-trading_platform}
       - SPOT_RECONCILIATION_ENABLED=${SPOT_RECONCILIATION_ENABLED:-true}
+      # Deferred exit legs (futures leg armer + spot OCO watcher) and the
+      # startup reconciler; default ON here since this compose is testnet.
+      - BRACKET_LEGS_ON_FILL=${BRACKET_LEGS_ON_FILL:-true}
+      - ENTRY_FILL_POLL_INTERVAL=${ENTRY_FILL_POLL_INTERVAL:-2s}
       - BINANCE_API_KEY=${BINANCE_API_KEY}
       - BINANCE_SECRET_KEY=${BINANCE_SECRET_KEY}
       - BINANCE_API_SECRET=${BINANCE_API_SECRET}
@@ -202,7 +209,6 @@ services:
       retries: 5
       start_period: 15s
 
-
   bff:
     build:
       context: .
@@ -231,7 +237,7 @@ services:
       - "${BFF_PORT:-8002}:3001"
     volumes:
       - ./app/bff:/app
-      - /app/node_modules  # Exclude node_modules from volume mount
+      - /app/node_modules # Exclude node_modules from volume mount
     depends_on:
       engine:
         condition: service_healthy
@@ -248,7 +254,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "node -e \"fetch('http://localhost:3001/api/health/liveness',{cache:'no-store'}).then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))\"",
+          'node -e "fetch(''http://localhost:3001/api/health/liveness'',{cache:''no-store''}).then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"',
         ]
       interval: 10s
       timeout: 5s
@@ -288,8 +294,8 @@ services:
     container_name: trading-mailhog-dev
     restart: unless-stopped
     ports:
-      - "1025:1025"  # SMTP
-      - "8025:8025"  # Web UI
+      - "1025:1025" # SMTP
+      - "8025:8025" # Web UI
     networks:
       - trading-network
 
@@ -301,7 +307,7 @@ services:
     environment:
       PGADMIN_DEFAULT_EMAIL: admin@tradingplatform.com
       PGADMIN_DEFAULT_PASSWORD: admin
-      PGADMIN_CONFIG_SERVER_MODE: 'False'
+      PGADMIN_CONFIG_SERVER_MODE: "False"
     ports:
       - "5050:80"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 # Docker Compose configuration for Online Trading Platform
-version: '3.8'
+version: "3.8"
 
 networks:
   trading-network:
@@ -61,7 +61,11 @@ services:
     networks:
       - trading-network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-trading_user} -d ${POSTGRES_DB:-trading_platform}"]
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -U ${POSTGRES_USER:-trading_user} -d ${POSTGRES_DB:-trading_platform}",
+        ]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -147,6 +151,10 @@ services:
       - REDIS_URL=redis://redis:6379/0
       - DATABASE_URL=postgresql://${POSTGRES_USER:-trading_user}:${POSTGRES_PASSWORD:-password}@postgres:5432/${POSTGRES_DB:-trading_platform}
       - SPOT_RECONCILIATION_ENABLED=${SPOT_RECONCILIATION_ENABLED:-true}
+      # Deferred exit legs + startup reconciler; opt-in here (prod may be
+      # mainnet-capable) — flip via the environment after a testnet soak.
+      - BRACKET_LEGS_ON_FILL=${BRACKET_LEGS_ON_FILL:-false}
+      - ENTRY_FILL_POLL_INTERVAL=${ENTRY_FILL_POLL_INTERVAL:-2s}
       - TRADING_MODE=${TRADING_MODE:-paper}
       - ENVIRONMENT=${ENVIRONMENT:-development}
       - SECURITY_REQUIRED_API_KEY=${SECURITY_REQUIRED_API_KEY}
@@ -159,7 +167,15 @@ services:
     networks:
       - trading-network
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8001/healthz"]
+      test:
+        [
+          "CMD",
+          "wget",
+          "--quiet",
+          "--tries=1",
+          "--spider",
+          "http://localhost:8001/healthz",
+        ]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -240,12 +256,12 @@ services:
     container_name: trading-prometheus
     restart: unless-stopped
     command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
-      - '--storage.tsdb.path=/prometheus'
-      - '--web.console.libraries=/etc/prometheus/console_libraries'
-      - '--web.console.templates=/etc/prometheus/consoles'
-      - '--storage.tsdb.retention.time=200h'
-      - '--web.enable-lifecycle'
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.console.libraries=/etc/prometheus/console_libraries"
+      - "--web.console.templates=/etc/prometheus/consoles"
+      - "--storage.tsdb.retention.time=200h"
+      - "--web.enable-lifecycle"
     ports:
       - "${PROMETHEUS_PORT:-9090}:9090"
     volumes:

--- a/scripts/run_testnet_soak.py
+++ b/scripts/run_testnet_soak.py
@@ -338,9 +338,57 @@ def build_health_urls(environ: dict[str, str]) -> dict[str, str]:
     return {
         "engine": f"http://localhost:{engine_port}/health/simple",
         "router": f"http://localhost:{router_port}/healthz",
+        "router_ready": f"http://localhost:{router_port}/readyz",
         "bff": f"http://localhost:{bff_port}/api/health",
         "ui": f"http://localhost:{ui_port}/api/health",
     }
+
+
+# Startup log markers proving the deferred-legs + reconciler stack (C4–C6)
+# is actually live during the soak. Without these the soak would pass while
+# exercising none of the code it exists to validate.
+DEFERRED_LEGS_LOG_MARKERS = (
+    ("Durable bracket reservations enabled", "router did not enable durable bracket reservations"),
+    (
+        "BRACKET_LEGS_ON_FILL enabled: spot exits placed as OCO on entry fill",
+        "router did not enable spot OCO deferred exits (BRACKET_LEGS_ON_FILL off?)",
+    ),
+    ("Entry fill watcher started", "router did not start the entry-fill watcher"),
+    ("Startup reconciliation complete", "router did not complete a startup reconciliation pass"),
+)
+
+# Log fragments that must NOT appear: each signals an unrepaired failure the
+# reconciler/watcher is supposed to prevent.
+FORBIDDEN_LOG_MARKERS = (
+    ("SECURITY_REQUIRED_API_KEY must be configured", "router log shows missing required API key"),
+    ("401 Unauthorized", "startup logs show unauthorized internal callback or router request"),
+    (
+        "Startup reconciliation exhausted retries",
+        "startup reconciliation failed every attempt — DB or router unhealthy",
+    ),
+    ("position UNPROTECTED", "an entry filled with no armer — position left unprotected"),
+)
+
+
+def evaluate_log_signatures(combined: str, *, require_deferred_legs: bool = True) -> list[str]:
+    """Return the list of log-signature failures (empty means pass).
+
+    Pure so it can be unit-tested without a running stack. The soak requires
+    the deferred-legs stack; callers may relax that for a bare-stack probe.
+    """
+    failures: list[str] = []
+    if "Execution subscriber enabled: spot_testnet" not in combined:
+        failures.append("engine log missing spot_testnet execution marker")
+    if "Order Router starting" not in combined or "testnet" not in combined.lower():
+        failures.append("router log missing testnet startup marker")
+    if require_deferred_legs:
+        for marker, message in DEFERRED_LEGS_LOG_MARKERS:
+            if marker not in combined:
+                failures.append(message)
+    for marker, message in FORBIDDEN_LOG_MARKERS:
+        if marker in combined:
+            failures.append(message)
+    return failures
 
 
 def resolve_project_python(project_root: Path) -> str:
@@ -745,6 +793,13 @@ class TestnetSoakRunner:
     def check_stack_health(self) -> bool:
         for name in ("engine", "router", "bff", "ui"):
             self._wait_for_http(name, self.health_urls[name])
+        # /readyz is 503 while the startup reconciler runs and flips to 200
+        # once it completes, so a passing probe proves C6 reconciliation ran
+        # to completion before the stack started taking work. Allow more time
+        # than the liveness probes: the reconciler retries up to 3x with a
+        # 2-minute timeout each before failing open (~6.5m worst case), and a
+        # slow first sweep must not spuriously fail an otherwise healthy soak.
+        self._wait_for_http("router_ready", self.health_urls["router_ready"], timeout_seconds=420)
         return all(
             result.status == "pass" for result in self.results if result.name.startswith("health:")
         )
@@ -757,15 +812,7 @@ class TestnetSoakRunner:
         if stdout_abs.exists():
             combined = stdout_abs.read_text(encoding="utf-8")
 
-        failures: list[str] = []
-        if "Execution subscriber enabled: spot_testnet" not in combined:
-            failures.append("engine log missing spot_testnet execution marker")
-        if "Order Router starting" not in combined or "testnet" not in combined.lower():
-            failures.append("router log missing testnet startup marker")
-        if "SECURITY_REQUIRED_API_KEY must be configured" in combined:
-            failures.append("router log shows missing required API key")
-        if "401 Unauthorized" in combined:
-            failures.append("startup logs show unauthorized internal callback or router request")
+        failures = evaluate_log_signatures(combined)
 
         status = "pass" if not failures else "fail"
         self._record(

--- a/tests/test_run_testnet_soak.py
+++ b/tests/test_run_testnet_soak.py
@@ -137,9 +137,79 @@ def test_build_health_urls_uses_configured_host_ports():
     assert urls == {
         "engine": "http://localhost:8100/health/simple",
         "router": "http://localhost:8101/healthz",
+        "router_ready": "http://localhost:8101/readyz",
         "bff": "http://localhost:3101/api/health",
         "ui": "http://localhost:3100/api/health",
     }
+
+
+def _soak_startup_logs() -> str:
+    """A minimal combined engine+router log that satisfies every marker."""
+    return "\n".join(
+        [
+            "engine | Execution subscriber enabled: spot_testnet",
+            "router | Order Router starting testnet",
+            "router | Durable bracket reservations enabled",
+            "router | BRACKET_LEGS_ON_FILL enabled: spot exits placed as OCO on entry fill",
+            "router | Entry fill watcher started",
+            "router | Startup reconciliation complete",
+        ]
+    )
+
+
+def test_evaluate_log_signatures_passes_for_full_deferred_legs_stack():
+    module = _load_run_testnet_soak_module()
+
+    assert module.evaluate_log_signatures(_soak_startup_logs()) == []
+
+
+def test_evaluate_log_signatures_flags_missing_deferred_legs_markers():
+    module = _load_run_testnet_soak_module()
+
+    # Flag off: no spot-OCO / watcher / reconciler markers
+    logs = "\n".join(
+        [
+            "engine | Execution subscriber enabled: spot_testnet",
+            "router | Order Router starting testnet",
+        ]
+    )
+    failures = module.evaluate_log_signatures(logs)
+
+    assert failures == [
+        "router did not enable durable bracket reservations",
+        "router did not enable spot OCO deferred exits (BRACKET_LEGS_ON_FILL off?)",
+        "router did not start the entry-fill watcher",
+        "router did not complete a startup reconciliation pass",
+    ]
+
+
+def test_evaluate_log_signatures_flags_forbidden_markers():
+    module = _load_run_testnet_soak_module()
+
+    logs = _soak_startup_logs() + "\n".join(
+        [
+            "",
+            "router | Startup reconciliation exhausted retries; serving anyway",
+            "router | entry fill watcher: entry filled but no armer; position UNPROTECTED",
+        ]
+    )
+    failures = module.evaluate_log_signatures(logs)
+
+    assert "startup reconciliation failed every attempt — DB or router unhealthy" in failures
+    assert "an entry filled with no armer — position left unprotected" in failures
+
+
+def test_evaluate_log_signatures_can_relax_deferred_legs_requirement():
+    module = _load_run_testnet_soak_module()
+
+    logs = "\n".join(
+        [
+            "engine | Execution subscriber enabled: spot_testnet",
+            "router | Order Router starting testnet",
+        ]
+    )
+
+    assert module.evaluate_log_signatures(logs, require_deferred_legs=False) == []
 
 
 def test_build_periodic_order_smoke_config_uses_defaults():
@@ -592,9 +662,15 @@ def test_build_recommendations_deduplicates_identical_entries():
     CheckResult = module.CheckResult
 
     results = [
-        CheckResult(name="order_smoke:periodic:1:ETHUSDT", status="fail", message="Order smoke failed"),
-        CheckResult(name="order_smoke:periodic:2:BTCUSDT", status="fail", message="Order smoke failed"),
-        CheckResult(name="order_smoke:periodic:3:ETHUSDT", status="fail", message="Order smoke failed"),
+        CheckResult(
+            name="order_smoke:periodic:1:ETHUSDT", status="fail", message="Order smoke failed"
+        ),
+        CheckResult(
+            name="order_smoke:periodic:2:BTCUSDT", status="fail", message="Order smoke failed"
+        ),
+        CheckResult(
+            name="order_smoke:periodic:3:ETHUSDT", status="fail", message="Order smoke failed"
+        ),
     ]
 
     recommendations = module.build_recommendations(results)


### PR DESCRIPTION
## Summary

C7 of the router order-lifecycle campaign — flips `BRACKET_LEGS_ON_FILL` on for the testnet stack so the 7-day soak actually exercises the C4–C6 deferred-legs → spot OCO → startup-reconciler path (with C6 merged, the crash-between-fill-and-arm window now self-heals on restart).

- **`docker-compose.dev.yml`** router service: `BRACKET_LEGS_ON_FILL=${BRACKET_LEGS_ON_FILL:-true}` (testnet default ON — the flip) + `ENTRY_FILL_POLL_INTERVAL=${ENTRY_FILL_POLL_INTERVAL:-2s}`.
- **`docker-compose.yml`** (prod): same two vars, but `BRACKET_LEGS_ON_FILL` defaults **false** — prod may be mainnet-capable, so it stays an explicit opt-in to flip after a clean soak.
- **`scripts/run_testnet_soak.py`**:
  - probes router `/readyz` during health checks (503→200 proves the C6 startup reconciler ran to completion and lifted the readiness gate before the stack took work); the probe gets a 420s ceiling to accommodate the reconciler's fail-open budget without spuriously failing a slow first pass.
  - extracts a pure, unit-testable `evaluate_log_signatures()` that keeps the original testnet startup markers and now **requires** the C4–C6 markers (`Durable bracket reservations enabled`, `BRACKET_LEGS_ON_FILL enabled: spot exits placed as OCO on entry fill`, `Entry fill watcher started`, `Startup reconciliation complete`) and **forbids** the failure markers (`Startup reconciliation exhausted retries`, `position UNPROTECTED`, missing-API-key, 401). Without this, the soak could pass while validating none of the code it exists to prove.

## New env vars

| Var | dev default | prod default | Router parse |
|---|---|---|---|
| `BRACKET_LEGS_ON_FILL` | `true` | `false` | `strconv.ParseBool` |
| `ENTRY_FILL_POLL_INTERVAL` | `2s` | `2s` | `time.ParseDuration` |

## QCHECK

Independent subagent review: **PASS**. All six required/forbidden log strings verified as exact substrings of the real router/watcher log lines (a typo would make the soak always-pass or always-fail); env keys match `os.Getenv` reads exactly; `"2s"` is valid for `time.ParseDuration`; `router_ready` is not swept by the liveness loops. One LOW finding (the `/readyz` wait timeout vs the reconciler's ~375s fail-open budget) was addressed pre-merge by raising that probe's timeout to 420s. One informational note (prod reconciler builds a nil-spotArmer fallback watcher) is pre-existing C6 code, out of scope here.

## Test evidence

- 24 soak-runner tests + 5 launcher tests pass; ruff clean.
- `docker compose config` validates both compose files; the prettier reformatting of unrelated lines (BFF healthcheck nested quotes, etc.) renders byte-identically.
- No Go changed.

## Not included (deliberate)

The env credentials themselves (testnet keys, `EXECUTION_MODE`, tokens) are operator-supplied at soak time — the runner's `validate_soak_environment` already gates them. `.env.example` edits are hook-protected in this repo and are documented in the forthcoming manual-walkthrough runbook instead.