### PR TITLE
feat(observability): read-only router soak/health panel

### DIFF
--- a/app/bff/src/app.module.ts
+++ b/app/bff/src/app.module.ts
@@ -17,6 +17,7 @@ import { BalancesModule } from './balances/balances.module';
 import { OrdersModule } from './orders/orders.module';
 import { DashboardModule } from './dashboard/dashboard.module';
 import { SignalsModule } from './signals/signals.module';
+import { SoakModule } from './soak/soak.module';
 
 @Module({
   imports: [
@@ -63,6 +64,7 @@ import { SignalsModule } from './signals/signals.module';
     OrdersModule,
     DashboardModule,
     SignalsModule,
+    SoakModule,
   ],
 })
 export class AppModule {}

--- a/app/bff/src/router-client/router-client.service.spec.ts
+++ b/app/bff/src/router-client/router-client.service.spec.ts
@@ -403,4 +403,75 @@ describe('RouterClientService', () => {
       });
     });
   });
+
+  describe('getReadiness', () => {
+    const readyResponse = (status: number, body: unknown): AxiosResponse =>
+      ({ data: body, status, statusText: '', headers: {}, config: {} }) as any;
+
+    it('reports ready on 200', async () => {
+      mockHttpService.get.mockReturnValue(of(readyResponse(200, { status: 'ready' })));
+
+      const result = await service.getReadiness();
+
+      expect(mockHttpService.get).toHaveBeenCalledWith('http://localhost:8080/readyz', {
+        timeout: 3000,
+        validateStatus: expect.any(Function),
+      });
+      expect(result).toEqual({ ready: true, status: 'ready' });
+    });
+
+    it('treats 503 as reconciling, not an error', async () => {
+      mockHttpService.get.mockReturnValue(of(readyResponse(503, { status: 'reconciling' })));
+
+      const result = await service.getReadiness();
+
+      expect(result).toEqual({ ready: false, status: 'reconciling' });
+    });
+
+    it('reports unreachable on transport failure', async () => {
+      mockHttpService.get.mockReturnValue(throwError(() => new Error('ECONNREFUSED')));
+
+      const result = await service.getReadiness();
+
+      expect(result).toEqual({ ready: false, status: 'unreachable', error: 'ECONNREFUSED' });
+    });
+
+    it('maps a non-503 error status to unreachable, not reconciling', async () => {
+      // A proxy 502 with no JSON status must not read as "reconciling"
+      mockHttpService.get.mockReturnValue(of(readyResponse(502, {})));
+
+      const result = await service.getReadiness();
+
+      expect(result).toEqual({ ready: false, status: 'unreachable' });
+    });
+  });
+
+  describe('getReconcileStatus', () => {
+    it('GETs the read-only reconcile status with the auth header', async () => {
+      const status = {
+        has_run: true,
+        last_run_at: '2026-07-06T00:00:00Z',
+        summary: {
+          brackets_swept: 2,
+          entries_checked: 1,
+          legs_resolved: 0,
+          exit_legs_updated: 1,
+          brackets_closed: 1,
+          stale_reserved: 0,
+          unrepaired_legs: 0,
+          errors: 0,
+        },
+      };
+      mockHttpService.get.mockReturnValue(
+        of({ data: status, status: 200, statusText: 'OK', headers: {}, config: {} } as any),
+      );
+
+      const result = await service.getReconcileStatus();
+
+      const [url, config] = mockHttpService.get.mock.calls[0];
+      expect(url).toBe('http://localhost:8080/internal/reconcile');
+      expect(config.headers.Authorization).toBe('Bearer router-secret');
+      expect(result).toEqual(status);
+    });
+  });
 });

--- a/app/bff/src/router-client/router-client.service.ts
+++ b/app/bff/src/router-client/router-client.service.ts
@@ -68,6 +68,32 @@ export interface HealthCheckResult {
   };
 }
 
+export interface RouterReadiness {
+  ready: boolean;
+  // 'ready' | 'reconciling' | 'unreachable'
+  status: string;
+  error?: string;
+}
+
+// Mirrors the router's orders.ReconcileSummary (startup_reconciler.go).
+export interface ReconcileSummary {
+  brackets_swept: number;
+  entries_checked: number;
+  legs_resolved: number;
+  exit_legs_updated: number;
+  brackets_closed: number;
+  stale_reserved: number;
+  unrepaired_legs: number;
+  errors: number;
+}
+
+// Mirrors the router's orders.ReconcileStatus.
+export interface ReconcileStatus {
+  has_run: boolean;
+  last_run_at?: string;
+  summary?: ReconcileSummary;
+}
+
 export interface CloseAllRequest {
   symbol?: string;
   is_futures: boolean;
@@ -224,6 +250,42 @@ export class RouterClientService {
         },
       };
     }
+  }
+
+  async getReadiness(): Promise<RouterReadiness> {
+    const url = `${this.baseUrl}/readyz`;
+
+    try {
+      // /readyz returns 503 while the startup reconciler runs; treat that as
+      // a valid "reconciling" state, not a transport error.
+      const response = await firstValueFrom(
+        this.httpService.get<{ status?: string }>(url, {
+          timeout: 3000,
+          validateStatus: () => true,
+        }),
+      );
+      const ready = response.status >= 200 && response.status < 300;
+      // 200 -> ready, 503 -> reconciling; any other status is the router (or
+      // a proxy) misbehaving, which is not a "reconciling" state.
+      const fallback = ready ? 'ready' : response.status === 503 ? 'reconciling' : 'unreachable';
+      return {
+        ready,
+        status: response.data?.status ?? fallback,
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      return { ready: false, status: 'unreachable', error: errorMessage };
+    }
+  }
+
+  async getReconcileStatus(): Promise<ReconcileStatus> {
+    const url = `${this.baseUrl}/internal/reconcile`;
+
+    // GET is the router's read-only view of the last pass — no side effects.
+    const response = await firstValueFrom(
+      this.httpService.get<ReconcileStatus>(url, this.requestConfig({ timeout: 3000 })),
+    );
+    return response.data;
   }
 
   async closeAllPositions(request: CloseAllRequest): Promise<CloseAllResponse> {

--- a/app/bff/src/soak/dto/soak-status.dto.ts
+++ b/app/bff/src/soak/dto/soak-status.dto.ts
@@ -1,0 +1,35 @@
+// Read-only view of the router's deferred-legs + reconciler state, surfaced
+// for the soak/health observability panel.
+
+export class RouterReadinessDto {
+  ready!: boolean;
+  // 'ready' | 'reconciling' | 'unreachable'
+  status!: string;
+  error?: string;
+}
+
+// Mirrors the router's orders.ReconcileSummary (startup_reconciler.go).
+export class RouterReconcileSummaryDto {
+  bracketsSwept!: number;
+  entriesChecked!: number;
+  legsResolved!: number;
+  exitLegsUpdated!: number;
+  bracketsClosed!: number;
+  staleReserved!: number;
+  unrepairedLegs!: number;
+  errors!: number;
+}
+
+export class RouterReconcileDto {
+  hasRun!: boolean;
+  lastRunAt?: string;
+  summary?: RouterReconcileSummaryDto;
+  // True when the router's reconcile status could not be fetched.
+  unavailable?: boolean;
+}
+
+export class RouterSoakStatusDto {
+  readiness!: RouterReadinessDto;
+  reconcile!: RouterReconcileDto;
+  checkedAt!: string;
+}

--- a/app/bff/src/soak/soak.controller.spec.ts
+++ b/app/bff/src/soak/soak.controller.spec.ts
@@ -1,0 +1,25 @@
+import { GUARDS_METADATA } from '@nestjs/common/constants';
+import { SoakController } from './soak.controller';
+import { SoakService } from './soak.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import type { RouterSoakStatusDto } from './dto/soak-status.dto';
+
+describe('SoakController', () => {
+  it('is protected by JwtAuthGuard', () => {
+    const guards = Reflect.getMetadata(GUARDS_METADATA, SoakController) as unknown[];
+    expect(guards).toEqual(expect.arrayContaining([JwtAuthGuard]));
+  });
+
+  it('returns the router soak status from SoakService', async () => {
+    const status: RouterSoakStatusDto = {
+      readiness: { ready: true, status: 'ready' },
+      reconcile: { hasRun: true },
+      checkedAt: '2026-07-06T00:00:00.000Z',
+    };
+    const soakService = { getStatus: jest.fn().mockResolvedValue(status) };
+    const controller = new SoakController(soakService as unknown as SoakService);
+
+    await expect(controller.getStatus()).resolves.toBe(status);
+    expect(soakService.getStatus).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/bff/src/soak/soak.controller.ts
+++ b/app/bff/src/soak/soak.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Logger, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { SoakService } from './soak.service';
+import { RouterSoakStatusDto } from './dto/soak-status.dto';
+
+@UseGuards(JwtAuthGuard)
+@Controller('soak')
+export class SoakController {
+  private readonly logger = new Logger(SoakController.name);
+
+  constructor(private readonly soakService: SoakService) {}
+
+  @Get('status')
+  async getStatus(): Promise<RouterSoakStatusDto> {
+    this.logger.debug('Fetching router soak status');
+    return this.soakService.getStatus();
+  }
+}

--- a/app/bff/src/soak/soak.module.ts
+++ b/app/bff/src/soak/soak.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { RouterClientModule } from '../router-client/router-client.module';
+import { SoakController } from './soak.controller';
+import { SoakService } from './soak.service';
+
+@Module({
+  imports: [RouterClientModule],
+  controllers: [SoakController],
+  providers: [SoakService],
+})
+export class SoakModule {}

--- a/app/bff/src/soak/soak.service.spec.ts
+++ b/app/bff/src/soak/soak.service.spec.ts
@@ -1,0 +1,74 @@
+import { SoakService } from './soak.service';
+import type {
+  ReconcileStatus,
+  RouterClientService,
+  RouterReadiness,
+} from '../router-client/router-client.service';
+
+function buildService(overrides: {
+  readiness: RouterReadiness;
+  reconcile?: () => Promise<ReconcileStatus>;
+}) {
+  const routerClient = {
+    getReadiness: jest.fn().mockResolvedValue(overrides.readiness),
+    getReconcileStatus: jest
+      .fn()
+      .mockImplementation(overrides.reconcile ?? (() => Promise.resolve({ has_run: false }))),
+  };
+  const service = new SoakService(routerClient as unknown as RouterClientService);
+  return { service, routerClient };
+}
+
+describe('SoakService', () => {
+  it('aggregates readiness and maps the reconcile summary to camelCase', async () => {
+    const { service } = buildService({
+      readiness: { ready: true, status: 'ready' },
+      reconcile: () =>
+        Promise.resolve({
+          has_run: true,
+          last_run_at: '2026-07-06T00:00:00Z',
+          summary: {
+            brackets_swept: 4,
+            entries_checked: 2,
+            legs_resolved: 1,
+            exit_legs_updated: 3,
+            brackets_closed: 1,
+            stale_reserved: 0,
+            unrepaired_legs: 2,
+            errors: 0,
+          },
+        }),
+    });
+
+    const status = await service.getStatus();
+
+    expect(status.readiness).toEqual({ ready: true, status: 'ready' });
+    expect(status.reconcile).toEqual({
+      hasRun: true,
+      lastRunAt: '2026-07-06T00:00:00Z',
+      summary: {
+        bracketsSwept: 4,
+        entriesChecked: 2,
+        legsResolved: 1,
+        exitLegsUpdated: 3,
+        bracketsClosed: 1,
+        staleReserved: 0,
+        unrepairedLegs: 2,
+        errors: 0,
+      },
+    });
+    expect(typeof status.checkedAt).toBe('string');
+  });
+
+  it('marks reconcile unavailable but still returns readiness when the reconcile query fails', async () => {
+    const { service } = buildService({
+      readiness: { ready: false, status: 'reconciling' },
+      reconcile: () => Promise.reject(new Error('router 500')),
+    });
+
+    const status = await service.getStatus();
+
+    expect(status.readiness).toEqual({ ready: false, status: 'reconciling' });
+    expect(status.reconcile).toEqual({ hasRun: false, unavailable: true });
+  });
+});

--- a/app/bff/src/soak/soak.service.ts
+++ b/app/bff/src/soak/soak.service.ts
@@ -1,0 +1,43 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { RouterClientService, type ReconcileSummary } from '../router-client/router-client.service';
+import { RouterReconcileSummaryDto, RouterSoakStatusDto } from './dto/soak-status.dto';
+
+@Injectable()
+export class SoakService {
+  private readonly logger = new Logger(SoakService.name);
+
+  constructor(private readonly routerClient: RouterClientService) {}
+
+  async getStatus(): Promise<RouterSoakStatusDto> {
+    const readiness = await this.routerClient.getReadiness();
+
+    let reconcile: RouterSoakStatusDto['reconcile'] = { hasRun: false, unavailable: true };
+    try {
+      const status = await this.routerClient.getReconcileStatus();
+      reconcile = {
+        hasRun: status.has_run,
+        lastRunAt: status.last_run_at,
+        summary: status.summary ? mapSummary(status.summary) : undefined,
+      };
+    } catch (error) {
+      // Readiness alone is still useful; surface reconcile as unavailable
+      // rather than failing the whole panel.
+      this.logger.warn(`Router reconcile status unavailable: ${error}`);
+    }
+
+    return { readiness, reconcile, checkedAt: new Date().toISOString() };
+  }
+}
+
+function mapSummary(summary: ReconcileSummary): RouterReconcileSummaryDto {
+  return {
+    bracketsSwept: summary.brackets_swept,
+    entriesChecked: summary.entries_checked,
+    legsResolved: summary.legs_resolved,
+    exitLegsUpdated: summary.exit_legs_updated,
+    bracketsClosed: summary.brackets_closed,
+    staleReserved: summary.stale_reserved,
+    unrepairedLegs: summary.unrepaired_legs,
+    errors: summary.errors,
+  };
+}

--- a/app/router/internal/api/reconcile.go
+++ b/app/router/internal/api/reconcile.go
@@ -10,31 +10,36 @@ import (
 	"router/internal/orders"
 )
 
-// ReconcileRunner runs one reconciliation pass over open brackets.
+// ReconcileRunner runs one reconciliation pass over open brackets and
+// exposes the last pass read-only.
 type ReconcileRunner interface {
 	Reconcile(ctx context.Context) (*orders.ReconcileSummary, error)
+	Status() orders.ReconcileStatus
 }
 
-// NewReconcileHandler serves POST /internal/reconcile: it runs a pass
+// NewReconcileHandler serves /internal/reconcile. GET returns the last
+// pass's summary read-only (no side effects); POST runs a pass
 // synchronously and returns its summary. Auth comes from the router's
 // shared token middleware.
 func NewReconcileHandler(runner ReconcileRunner, logger zerolog.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			writeError(w, http.StatusMethodNotAllowed, "Method not allowed")
-			return
-		}
-
-		summary, err := runner.Reconcile(r.Context())
-		if err != nil {
-			if errors.Is(err, orders.ErrReconcileInFlight) {
-				writeError(w, http.StatusConflict, "reconcile already in flight")
+		switch r.Method {
+		case http.MethodGet:
+			writeJSON(w, http.StatusOK, runner.Status())
+		case http.MethodPost:
+			summary, err := runner.Reconcile(r.Context())
+			if err != nil {
+				if errors.Is(err, orders.ErrReconcileInFlight) {
+					writeError(w, http.StatusConflict, "reconcile already in flight")
+					return
+				}
+				logger.Error().Err(err).Msg("On-demand reconcile failed")
+				writeError(w, http.StatusInternalServerError, "reconcile failed")
 				return
 			}
-			logger.Error().Err(err).Msg("On-demand reconcile failed")
-			writeError(w, http.StatusInternalServerError, "reconcile failed")
-			return
+			writeJSON(w, http.StatusOK, summary)
+		default:
+			writeError(w, http.StatusMethodNotAllowed, "Method not allowed")
 		}
-		writeJSON(w, http.StatusOK, summary)
 	}
 }

--- a/app/router/internal/api/reconcile_test.go
+++ b/app/router/internal/api/reconcile_test.go
@@ -16,6 +16,7 @@ import (
 
 type stubReconciler struct {
 	summary *orders.ReconcileSummary
+	status  orders.ReconcileStatus
 	err     error
 	calls   int
 }
@@ -25,13 +26,34 @@ func (s *stubReconciler) Reconcile(_ context.Context) (*orders.ReconcileSummary,
 	return s.summary, s.err
 }
 
-func TestReconcileHandler_RejectsNonPost(t *testing.T) {
+func (s *stubReconciler) Status() orders.ReconcileStatus {
+	return s.status
+}
+
+func TestReconcileHandler_RejectsUnsupportedMethod(t *testing.T) {
 	handler := NewReconcileHandler(&stubReconciler{}, zerolog.Nop())
+
+	rec := httptest.NewRecorder()
+	handler(rec, httptest.NewRequest(http.MethodDelete, "/internal/reconcile", nil))
+
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+func TestReconcileHandler_GetReturnsStatusWithoutRunning(t *testing.T) {
+	stub := &stubReconciler{status: orders.ReconcileStatus{
+		HasRun:  true,
+		Summary: &orders.ReconcileSummary{BracketsSwept: 5, UnrepairedLegs: 1},
+	}}
+	handler := NewReconcileHandler(stub, zerolog.Nop())
 
 	rec := httptest.NewRecorder()
 	handler(rec, httptest.NewRequest(http.MethodGet, "/internal/reconcile", nil))
 
-	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got orders.ReconcileStatus
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, [2]any{true, 1}, [2]any{got.HasRun, got.Summary.UnrepairedLegs})
+	assert.Equal(t, 0, stub.calls, "GET must be read-only — it must not trigger a pass")
 }
 
 func TestReconcileHandler_ReturnsSummary(t *testing.T) {

--- a/app/router/internal/orders/startup_reconciler.go
+++ b/app/router/internal/orders/startup_reconciler.go
@@ -3,6 +3,7 @@ package orders
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -44,6 +45,20 @@ type StartupReconciler struct {
 	logger        zerolog.Logger
 
 	inFlight chan struct{}
+
+	// Last completed pass, cached for read-only observability (GET
+	// /internal/reconcile) so an operator can see reconciler state without
+	// triggering a mutating pass.
+	mu         sync.Mutex
+	lastResult *ReconcileSummary
+	lastRunAt  time.Time
+}
+
+// ReconcileStatus is the read-only view of the reconciler's last pass.
+type ReconcileStatus struct {
+	HasRun    bool              `json:"has_run"`
+	LastRunAt *time.Time        `json:"last_run_at,omitempty"`
+	Summary   *ReconcileSummary `json:"summary,omitempty"`
 }
 
 func NewStartupReconciler(
@@ -106,7 +121,29 @@ func (r *StartupReconciler) Reconcile(ctx context.Context) (*ReconcileSummary, e
 		Int("stale_reserved", summary.StaleReserved).
 		Int("errors", summary.Errors).
 		Msg("reconciler: pass complete")
+	r.storeResult(summary)
 	return summary, nil
+}
+
+// storeResult caches the last completed pass for read-only observability.
+func (r *StartupReconciler) storeResult(summary *ReconcileSummary) {
+	snapshot := *summary
+	r.mu.Lock()
+	r.lastResult = &snapshot
+	r.lastRunAt = time.Now().UTC()
+	r.mu.Unlock()
+}
+
+// Status returns the read-only view of the last completed reconcile pass.
+func (r *StartupReconciler) Status() ReconcileStatus {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.lastResult == nil {
+		return ReconcileStatus{HasRun: false}
+	}
+	summary := *r.lastResult
+	runAt := r.lastRunAt
+	return ReconcileStatus{HasRun: true, LastRunAt: &runAt, Summary: &summary}
 }
 
 func (r *StartupReconciler) clientFor(venue string) *binance.Client {

--- a/app/router/internal/orders/startup_reconciler_test.go
+++ b/app/router/internal/orders/startup_reconciler_test.go
@@ -474,6 +474,29 @@ func (b *blockingStore) LoadOpenBrackets(ctx context.Context, lookback time.Dura
 	return b.fakeWatcherStore.LoadOpenBrackets(ctx, lookback)
 }
 
+func TestStartupReconciler_StatusCachesLastCompletedPass(t *testing.T) {
+	store := &fakeWatcherStore{fakeArmerStore{record: legsPlacedRecord("SPOT")}}
+	fake := newReconExchange()
+	fake.set("arm-tp1", exchangeOrder("arm-tp1", "FILLED", "0.02", 101))
+	fake.set("arm-sl", exchangeOrder("arm-sl", "EXPIRED", "0", 102))
+	reconciler, _ := newReconcilerFixture(t, fake.handler(), store, "SPOT")
+
+	before := reconciler.Status()
+	require.False(t, before.HasRun, "no pass has run yet")
+
+	summary, err := reconciler.Reconcile(context.Background())
+	require.NoError(t, err)
+
+	after := reconciler.Status()
+	assert.True(t, after.HasRun)
+	require.NotNil(t, after.Summary)
+	assert.Equal(t, *summary, *after.Summary, "status must reflect the last pass")
+	require.NotNil(t, after.LastRunAt)
+	// The cached summary is a copy: mutating it must not change the source
+	after.Summary.BracketsClosed = 999
+	assert.NotEqual(t, 999, reconciler.Status().Summary.BracketsClosed)
+}
+
 func TestStartupReconciler_SingleFlight(t *testing.T) {
 	store := &blockingStore{
 		fakeWatcherStore: fakeWatcherStore{fakeArmerStore{record: nil}},

--- a/app/ui/src/app/soak/page.tsx
+++ b/app/ui/src/app/soak/page.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { AppShell } from '@/components/shell'
+import { PageHeader } from '@/components/common/PageHeader'
+import { IntegrationPill } from '@/components/common/IntegrationPill'
+import { RouterSoakPanel } from '@/components/soak/RouterSoakPanel'
+import { useSoak } from '@/hooks/useSoak'
+
+export default function SoakPage() {
+  const { status, loading, error } = useSoak()
+
+  return (
+    <AppShell>
+      <div className="flex flex-col gap-8">
+        <PageHeader
+          title="Router Soak"
+          actions={<IntegrationPill transport="REST" endpoint="/soak/status" />}
+        />
+        <div className="max-w-xl">
+          <RouterSoakPanel status={status} loading={loading} error={error ?? undefined} />
+        </div>
+      </div>
+    </AppShell>
+  )
+}

--- a/app/ui/src/components/shell/AppSidebar.tsx
+++ b/app/ui/src/components/shell/AppSidebar.tsx
@@ -16,6 +16,7 @@ const NAV_ITEMS = [
   { path: '/portfolio', label: 'Portfolio', icon: 'work' },
   { path: '/history', label: 'History', icon: 'history' },
   { path: '/analytics', label: 'Analytics', icon: 'bar_chart' },
+  { path: '/soak', label: 'Soak', icon: 'monitor_heart' },
   { path: '/settings', label: 'Settings', icon: 'settings' },
 ] as const
 

--- a/app/ui/src/components/shell/AppTopbar.tsx
+++ b/app/ui/src/components/shell/AppTopbar.tsx
@@ -58,6 +58,7 @@ const NAV_ITEMS = [
   { path: '/portfolio', label: 'Portfolio', icon: 'work' },
   { path: '/history', label: 'History', icon: 'history' },
   { path: '/analytics', label: 'Analytics', icon: 'bar_chart' },
+  { path: '/soak', label: 'Soak', icon: 'monitor_heart' },
   { path: '/settings', label: 'Settings', icon: 'settings' },
 ] as const
 

--- a/app/ui/src/components/shell/CommandPalette.tsx
+++ b/app/ui/src/components/shell/CommandPalette.tsx
@@ -18,6 +18,7 @@ const NAV_ITEMS = [
   { label: 'Trading', path: '/trades', icon: 'candlestick_chart' },
   { label: 'History', path: '/history', icon: 'history' },
   { label: 'Analytics', path: '/analytics', icon: 'bar_chart' },
+  { label: 'Soak', path: '/soak', icon: 'monitor_heart' },
   { label: 'Settings', path: '/settings', icon: 'settings' },
 ] as const
 

--- a/app/ui/src/components/soak/RouterSoakPanel.spec.tsx
+++ b/app/ui/src/components/soak/RouterSoakPanel.spec.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { RouterSoakPanel } from './RouterSoakPanel'
+import type { RouterSoakStatus } from '@/types/soak'
+
+const createStatus = (overrides: Partial<RouterSoakStatus> = {}): RouterSoakStatus => ({
+  readiness: { ready: true, status: 'ready' },
+  reconcile: {
+    hasRun: true,
+    lastRunAt: '2026-07-06T00:00:00Z',
+    summary: {
+      bracketsSwept: 4,
+      entriesChecked: 2,
+      legsResolved: 1,
+      exitLegsUpdated: 3,
+      bracketsClosed: 1,
+      staleReserved: 0,
+      unrepairedLegs: 0,
+      errors: 0,
+    },
+  },
+  checkedAt: '2026-07-06T00:00:05Z',
+  ...overrides,
+})
+
+describe('RouterSoakPanel', () => {
+  it('renders the loading skeleton while loading', () => {
+    render(<RouterSoakPanel status={null} loading />)
+    expect(screen.getByTestId('soak-panel-loading')).toBeInTheDocument()
+  })
+
+  it('renders the full error card only when there is no last-good data', () => {
+    render(<RouterSoakPanel status={null} error="router down" />)
+    expect(screen.getByTestId('soak-panel-error')).toBeInTheDocument()
+    expect(screen.getByText(/router down/)).toBeInTheDocument()
+  })
+
+  it('keeps the last-good snapshot with a stale banner when a refresh fails', () => {
+    render(<RouterSoakPanel status={createStatus()} error="network blip" />)
+    // Data panel still shown, not the error card
+    expect(screen.getByTestId('soak-panel')).toBeInTheDocument()
+    expect(screen.queryByTestId('soak-panel-error')).not.toBeInTheDocument()
+    expect(screen.getByTestId('soak-stale-banner')).toBeInTheDocument()
+    expect(screen.getByText('Ready')).toBeInTheDocument()
+  })
+
+  it('shows a green Ready badge when the router is ready', () => {
+    render(<RouterSoakPanel status={createStatus()} />)
+    expect(screen.getByText('Ready')).toBeInTheDocument()
+    expect(screen.getByTestId('readiness-indicator')).toHaveClass('bg-success')
+  })
+
+  it('shows Reconciling while the readiness gate is held', () => {
+    render(
+      <RouterSoakPanel
+        status={createStatus({ readiness: { ready: false, status: 'reconciling' } })}
+      />,
+    )
+    expect(screen.getByText('Reconciling')).toBeInTheDocument()
+    expect(screen.getByTestId('readiness-indicator')).toHaveClass('bg-warning')
+  })
+
+  it('shows Unreachable when the router cannot be reached', () => {
+    render(
+      <RouterSoakPanel
+        status={createStatus({
+          readiness: { ready: false, status: 'unreachable', error: 'ECONNREFUSED' },
+        })}
+      />,
+    )
+    expect(screen.getByText('Unreachable')).toBeInTheDocument()
+    expect(screen.getByTestId('readiness-indicator')).toHaveClass('bg-destructive')
+    expect(screen.getByTestId('readiness-error')).toHaveTextContent('ECONNREFUSED')
+  })
+
+  it('renders reconcile counters with unrepaired/errors highlighted when non-zero', () => {
+    render(
+      <RouterSoakPanel
+        status={createStatus({
+          reconcile: {
+            hasRun: true,
+            summary: {
+              bracketsSwept: 5,
+              entriesChecked: 0,
+              legsResolved: 0,
+              exitLegsUpdated: 0,
+              bracketsClosed: 0,
+              staleReserved: 0,
+              unrepairedLegs: 2,
+              errors: 1,
+            },
+          },
+        })}
+      />,
+    )
+    expect(screen.getByTestId('counter-value-bracketsSwept')).toHaveTextContent('5')
+    expect(screen.getByTestId('counter-value-unrepairedLegs')).toHaveClass('text-destructive')
+    expect(screen.getByTestId('counter-value-errors')).toHaveClass('text-destructive')
+    // A zero alarm counter is not highlighted
+    expect(screen.getByTestId('counter-value-bracketsSwept')).not.toHaveClass('text-destructive')
+  })
+
+  it('shows a "no reconcile pass yet" note before the first pass', () => {
+    render(<RouterSoakPanel status={createStatus({ reconcile: { hasRun: false } })} />)
+    expect(screen.getByTestId('reconcile-none')).toBeInTheDocument()
+  })
+
+  it('shows an unavailable note when reconcile status could not be fetched', () => {
+    render(
+      <RouterSoakPanel
+        status={createStatus({ reconcile: { hasRun: false, unavailable: true } })}
+      />,
+    )
+    expect(screen.getByTestId('reconcile-unavailable')).toBeInTheDocument()
+  })
+})

--- a/app/ui/src/components/soak/RouterSoakPanel.tsx
+++ b/app/ui/src/components/soak/RouterSoakPanel.tsx
@@ -1,0 +1,206 @@
+import type { RouterSoakStatus, RouterReconcileSummary } from '@/types/soak'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
+import { MaterialIcon } from '@/components/common/MaterialIcon'
+
+type RouterSoakPanelProps = {
+  status: RouterSoakStatus | null
+  loading?: boolean
+  error?: string
+}
+
+function readinessBadge(readiness: RouterSoakStatus['readiness']): string {
+  if (readiness.ready) return 'bg-success/10 text-success border-success/25 shadow-sm'
+  if (readiness.status === 'reconciling') return 'bg-warning/10 text-warning border-warning/25'
+  return 'bg-destructive/10 text-destructive border-destructive/25'
+}
+
+function readinessLabel(readiness: RouterSoakStatus['readiness']): string {
+  if (readiness.ready) return 'Ready'
+  if (readiness.status === 'reconciling') return 'Reconciling'
+  return 'Unreachable'
+}
+
+// Counters whose non-zero value signals unrepaired protection needing an
+// operator's eye — rendered with an alarm colour.
+const ALARM_COUNTERS: (keyof RouterReconcileSummary)[] = ['unrepairedLegs', 'errors']
+
+const COUNTER_LABELS: Record<keyof RouterReconcileSummary, string> = {
+  bracketsSwept: 'Swept',
+  entriesChecked: 'Entries checked',
+  legsResolved: 'Legs resolved',
+  exitLegsUpdated: 'Exit legs updated',
+  bracketsClosed: 'Closed',
+  staleReserved: 'Stale reserved',
+  unrepairedLegs: 'Unrepaired legs',
+  errors: 'Errors',
+}
+
+function formatTimestamp(isoString: string): string {
+  return new Date(isoString).toLocaleTimeString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  })
+}
+
+export function RouterSoakPanel({ status, loading, error }: RouterSoakPanelProps) {
+  if (loading || (!status && !error)) {
+    return (
+      <Card
+        className="bg-white dark:bg-slate-800 rounded-2xl border border-slate-100 dark:border-slate-700 shadow-sm"
+        data-testid="soak-panel-loading"
+      >
+        <CardHeader className="pb-3">
+          <CardTitle className="text-xs font-semibold text-slate-500 uppercase tracking-[0.1em] flex items-center gap-2">
+            <MaterialIcon name="monitor_heart" size="sm" className="text-slate-400" />
+            Router Soak
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Skeleton className="h-5 w-full" />
+          <Skeleton className="h-4 w-3/4" />
+          <Skeleton className="h-4 w-2/3" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  // Only replace the whole panel with an error card when there is no
+  // last-good data to show; otherwise the operational snapshot is what the
+  // operator most wants to keep, with a stale banner over it.
+  if (error && !status) {
+    return (
+      <Card
+        className="bg-white dark:bg-slate-800 rounded-2xl border border-red-100 shadow-sm"
+        data-testid="soak-panel-error"
+      >
+        <CardHeader className="pb-3">
+          <CardTitle className="text-xs font-semibold text-slate-500 uppercase tracking-[0.1em] flex items-center gap-2">
+            <MaterialIcon name="gpp_maybe" size="sm" className="text-destructive" />
+            Router Soak
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-start gap-2 text-sm text-destructive" role="alert">
+            <MaterialIcon name="gpp_maybe" size="sm" className="shrink-0 mt-0.5" />
+            <div>
+              <p className="font-medium">Soak status unavailable</p>
+              <p className="text-xs text-destructive/70 mt-0.5">
+                The BFF could not reach the router. Retrying automatically… ({error})
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (!status) return null
+
+  const { readiness, reconcile } = status
+
+  return (
+    <Card
+      className="bg-white dark:bg-slate-800 rounded-2xl border-l-4 border-l-indigo-500 border border-slate-100 dark:border-slate-700 shadow-sm"
+      data-testid="soak-panel"
+    >
+      <CardHeader className="pb-3 flex flex-row items-center justify-between">
+        <CardTitle className="flex items-center gap-3">
+          <div className="p-2 bg-indigo-50 rounded-lg text-indigo-500">
+            <MaterialIcon name="monitor_heart" size="md" />
+          </div>
+          <div>
+            <span className="text-sm font-bold text-slate-800 dark:text-slate-100">
+              Router Soak
+            </span>
+            <p className="text-[10px] text-slate-400">Reconciler &amp; readiness</p>
+          </div>
+        </CardTitle>
+        <Badge
+          variant="outline"
+          className={`text-xs font-medium ${readinessBadge(readiness)}`}
+          data-testid="readiness-badge"
+        >
+          <span
+            className={`inline-block w-2 h-2 rounded-full mr-1.5 ${
+              readiness.ready
+                ? 'bg-success animate-pulse'
+                : readiness.status === 'reconciling'
+                  ? 'bg-warning animate-pulse'
+                  : 'bg-destructive'
+            }`}
+            data-testid="readiness-indicator"
+          />
+          {readinessLabel(readiness)}
+        </Badge>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {error && (
+          <div
+            className="flex items-center gap-2 text-xs text-warning bg-warning/10 border border-warning/25 rounded-md px-2 py-1.5"
+            role="status"
+            data-testid="soak-stale-banner"
+          >
+            <MaterialIcon name="sync_problem" size="sm" className="shrink-0" />
+            <span>Showing last-known status — refresh failed, retrying…</span>
+          </div>
+        )}
+
+        {readiness.error && (
+          <p className="text-xs text-destructive/80" data-testid="readiness-error">
+            {readiness.error}
+          </p>
+        )}
+
+        {reconcile.unavailable ? (
+          <p className="text-sm text-slate-500" data-testid="reconcile-unavailable">
+            Reconcile status unavailable
+          </p>
+        ) : !reconcile.hasRun ? (
+          <p className="text-sm text-slate-500" data-testid="reconcile-none">
+            No reconcile pass yet
+          </p>
+        ) : (
+          <div className="grid grid-cols-2 gap-2" data-testid="reconcile-summary">
+            {reconcile.summary &&
+              (Object.keys(COUNTER_LABELS) as (keyof RouterReconcileSummary)[]).map(key => {
+                const value = reconcile.summary![key]
+                const alarm = ALARM_COUNTERS.includes(key) && value > 0
+                return (
+                  <div
+                    key={key}
+                    className="flex items-center justify-between px-3 py-2 rounded-md bg-slate-50 dark:bg-slate-700/40"
+                    data-testid={`counter-${key}`}
+                  >
+                    <span className="text-xs text-slate-500">{COUNTER_LABELS[key]}</span>
+                    <span
+                      className={`text-sm font-semibold ${
+                        alarm ? 'text-destructive' : 'text-slate-700 dark:text-slate-200'
+                      }`}
+                      data-testid={`counter-value-${key}`}
+                    >
+                      {value}
+                    </span>
+                  </div>
+                )
+              })}
+          </div>
+        )}
+
+        {reconcile.lastRunAt && (
+          <p
+            className="text-xs text-slate-400 pt-1 border-t border-slate-100"
+            data-testid="last-run"
+          >
+            Last reconcile: {formatTimestamp(reconcile.lastRunAt)}
+          </p>
+        )}
+        <p className="text-xs text-slate-400" data-testid="checked-at">
+          Checked: {formatTimestamp(status.checkedAt)}
+        </p>
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/ui/src/hooks/useSoak.ts
+++ b/app/ui/src/hooks/useSoak.ts
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useState } from 'react'
+import { apiClient } from '@/services/api'
+import type { RouterSoakStatus } from '@/types/soak'
+
+const POLL_INTERVAL_MS = 5000
+
+type UseSoakResult = {
+  status: RouterSoakStatus | null
+  loading: boolean
+  error: string | null
+  refresh: () => void
+}
+
+// Polls the BFF's read-only router soak status. Readiness has no WebSocket
+// event and the reconcile summary is a passive snapshot, so a short REST
+// poll is the right transport.
+export function useSoak(): UseSoakResult {
+  const [status, setStatus] = useState<RouterSoakStatus | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const data = await apiClient.get<RouterSoakStatus>('/soak/status')
+      setStatus(data)
+      setError(null)
+    } catch (err) {
+      // Keep the last-good snapshot in `status`; surface the failure via
+      // `error` so the panel can show a stale banner rather than blanking
+      // the operational view on a single failed poll.
+      setError(err instanceof Error ? err.message : 'Failed to fetch soak status')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchStatus()
+  }, [fetchStatus])
+
+  useEffect(() => {
+    const interval = setInterval(fetchStatus, POLL_INTERVAL_MS)
+    return () => clearInterval(interval)
+  }, [fetchStatus])
+
+  return { status, loading, error, refresh: fetchStatus }
+}

--- a/app/ui/src/types/soak.ts
+++ b/app/ui/src/types/soak.ts
@@ -1,0 +1,32 @@
+// Read-only router soak/health status, mirroring the BFF RouterSoakStatusDto.
+
+export type RouterReadiness = {
+  ready: boolean
+  // 'ready' | 'reconciling' | 'unreachable'
+  status: string
+  error?: string
+}
+
+export type RouterReconcileSummary = {
+  bracketsSwept: number
+  entriesChecked: number
+  legsResolved: number
+  exitLegsUpdated: number
+  bracketsClosed: number
+  staleReserved: number
+  unrepairedLegs: number
+  errors: number
+}
+
+export type RouterReconcile = {
+  hasRun: boolean
+  lastRunAt?: string
+  summary?: RouterReconcileSummary
+  unavailable?: boolean
+}
+
+export type RouterSoakStatus = {
+  readiness: RouterReadiness
+  reconcile: RouterReconcile
+  checkedAt: string
+}


### PR DESCRIPTION
## Summary

Adds a genuinely **read-only** way to watch the router's reconciler + readiness state during a testnet soak, spanning all three services. Previously the reconciler summary was only obtainable via `POST /internal/reconcile`, which *runs* (mutates) a pass — so passive observability didn't exist.

- **Router** — `StartupReconciler` caches its last completed `ReconcileSummary` + timestamp under a mutex and exposes `Status()`. `GET /internal/reconcile` now returns that read-only (no side effects); `POST` still triggers a pass. Same route, same token middleware — no auth change.
- **BFF** — `RouterClientService.getReadiness()` (maps router `/readyz`: 200→ready, 503→reconciling, else unreachable; never throws) + `getReconcileStatus()` (read-only GET, bearer auth). New JWT-guarded `GET /api/soak/status` aggregates both; a reconcile-query failure degrades to `{unavailable:true}` while still returning readiness, so the panel never fully fails.
- **UI** — a `/soak` page with a 5s-polling `RouterSoakPanel`: readiness badge (Ready / Reconciling / Unreachable) and reconcile counters, with `unrepairedLegs` and `errors` highlighted when non-zero. A failed poll keeps the last-good snapshot behind a stale banner rather than blanking the operational view. Nav entry added to the sidebar, topbar, and command palette.

This pairs with the C7 soak wiring (#199): during a soak you now see the reconciler run and the readiness gate lift, live.

## QCHECK

Independent subagent review: **PASS**, no critical/high defects. Verified: Go mutex copy-safety (cache can't be mutated by callers) and no read/write race; the first-pass `nil` cache returns `has_run:false` with no nil-deref; BFF `getReadiness` never lets a throw escape and `getReconcileStatus` is genuinely token-gated; all 11 fields traced Go json-tags → BFF snake interface → `mapSummary` → UI camelCase with no drift; `/api/soak/status` JWT-guarded and leaks only operational counts. Two LOW findings were fixed pre-merge: the panel now retains last-good data with a stale banner on a transient poll failure (the moment you most want it), and `getReadiness` maps non-503 non-2xx to `unreachable` rather than mislabelling it `reconciling`.

## Test evidence

- Router: `gofmt`/`vet` clean; `go test -race ./internal/orders ./internal/api` passes (incl. Status caching, copy-safety, and GET-doesn't-run-a-pass).
- BFF: `tsc --noEmit` clean; 21 soak/router-client tests + full `app.module.spec` module graph pass.
- UI: `next lint` + `tsc` clean for soak files; 9 `RouterSoakPanel` vitest tests (all readiness states, counter highlighting, stale banner, no-pass, unavailable).

## Notes

Design constraint honored: the panel is read-only. Triggering a reconcile pass (`POST /internal/reconcile`) stays an operator action (curl / the forthcoming manual runbook), not a UI button, so viewing the panel can never mutate router state.