### PR TITLE
docs(router): manual testnet C5/C6 sanity runbook + deferred-bracket helper

### DIFF
--- a/docs/testnet-c5-c6-sanity-runbook.md
+++ b/docs/testnet-c5-c6-sanity-runbook.md
@@ -1,0 +1,166 @@
+# Testnet Sanity Runbook — Spot OCO Exits (C5) & Startup Reconciler (C6)
+
+**Date**: 2026-07-06
+**Applies to**: `app/router` order-lifecycle campaign, deliverables C5 (#197) + C6 (#198), flag-wired by C7 (#199)
+**Purpose**: A short, manual, human-in-the-loop walkthrough that proves — against Binance spot **testnet** — that a deferred bracket arms its exits as an OCO pair on entry fill (C5) and that the startup reconciler repairs open brackets and gates readiness across a crash (C6). Run this as a confidence check **before** committing to the 7-day automated soak.
+
+---
+
+## TL;DR
+
+1. Bring up the dev stack against testnet (`make dev`) with `BRACKET_LEGS_ON_FILL=true` (already the default in `docker-compose.dev.yml` after C7).
+2. Place **one deferred spot bracket** with `scripts/place_test_bracket.py` — the UI cannot do this (see "Why not the UI").
+3. Watch the bracket advance `RESERVED → ENTRY_PLACED → ENTRY_FILLED → LEGS_PLACED` and its OCO exits appear — in Postgres and on the `/soak` panel.
+4. Kill the router mid-flight, restart it, and confirm the reconciler settles the bracket and `/readyz` flips `503 → 200`.
+
+Pass criteria are the checklist at the end.
+
+---
+
+## Why not the UI
+
+The UI order form → BFF `POST /trading/orders` path **cannot** exercise C5/C6. The BFF omits `client_order_ids` when it calls the router's `/place_bracket` (`app/bff/src/router-client/router-client.service.ts`), and the router only defers exits and reserves a durable `brackets` row when `client_order_ids.main` is set (`app/router/internal/orders/manager.go` `spotLegsDeferred`). Without it, exits place synchronously and no bracket row is persisted — nothing for the watcher or reconciler to act on. So this runbook drives the router directly, with `client_order_ids` set, via the helper script.
+
+---
+
+## 0. Prerequisites
+
+- Binance **spot testnet** API key/secret (create at <https://testnet.binance.vision>).
+- Docker + the repo's `make` targets.
+- A funded testnet spot balance in the quote asset (USDT) for the symbol you use.
+
+### Environment profile (`.env`)
+
+| Variable                                           | Value          | Why                                                                                          |
+| -------------------------------------------------- | -------------- | -------------------------------------------------------------------------------------------- |
+| `EXECUTION_MODE`                                   | `spot_testnet` | Engine-side execution lock (part of the soak-validated profile; the router does not read it) |
+| `ROUTER_EXECUTION_ENV`                             | `testnet`      | Router forces testnet base URLs in code — its own testnet lock                               |
+| `TRADING_MODE`                                     | `spot`         | Enables the spot client                                                                      |
+| `BRACKET_LEGS_ON_FILL`                             | `true`         | Defers exits → spot OCO on fill (C5). Default in dev compose after C7                        |
+| `SPOT_RECONCILIATION_ENABLED`                      | `true`         | Periodic spot reconciler                                                                     |
+| `I_UNDERSTAND_LIVE_TRADING`                        | _unset_        | Safety interlock — must stay unset                                                           |
+| `BINANCE_SPOT_API_KEY` / `BINANCE_SPOT_SECRET_KEY` | _testnet keys_ | (or the legacy `BINANCE_API_KEY` / `BINANCE_SECRET_KEY`)                                     |
+| `SECURITY_REQUIRED_API_KEY`                        | _a token_      | Router requires it; the router fatals at boot if empty                                       |
+| `ROUTER_API_KEY`                                   | **same token** | The BFF/soak/helper send this; **must equal** `SECURITY_REQUIRED_API_KEY`                    |
+
+> The automated soak (`scripts/run_testnet_soak.py`) validates this whole profile via `validate_soak_environment`; this runbook uses the same variables.
+
+---
+
+## 1. Bring up the stack
+
+```bash
+make dev            # docker compose -f docker-compose.dev.yml up --build (runs in the foreground)
+```
+
+> `make dev` runs in the foreground; open a **second terminal** for the `logs` / `exec` / `kill` / `up -d router` steps below.
+
+Wait until the router is up, then confirm the deferred-legs + reconciler stack booted:
+
+```bash
+docker compose -f docker-compose.dev.yml logs router | grep -E \
+  "Durable bracket reservations enabled|spot exits placed as OCO|Entry fill watcher started|Startup reconciliation complete"
+```
+
+All four lines should be present. On a fresh DB the reconciler sweeps zero brackets — that is expected.
+
+Confirm readiness lifted:
+
+```bash
+curl -s localhost:8001/readyz          # {"status":"ready"} once the startup pass completed
+```
+
+---
+
+## 2. Place a deferred spot bracket (C5)
+
+```bash
+export SECURITY_REQUIRED_API_KEY=<your token>   # or ROUTER_API_KEY
+app/engine/.venv/bin/python scripts/place_test_bracket.py --symbol BTCUSDT --notional-usdt 25
+```
+
+The helper fetches a testnet reference price, builds a resting LIMIT BUY bracket **with `client_order_ids`**, POSTs it, and prints the response plus the leg ids to watch. Expect:
+
+- `status` `200` and **`legs_pending_trigger: true`** in the response (the helper warns loudly if it is not — that means the flag or `DATABASE_URL` is missing).
+- The entry rests below market, so it fills within seconds to minutes depending on testnet flow.
+
+### Observe C5
+
+Watch the bracket row advance (pgAdmin at `localhost:5050`, or psql):
+
+```bash
+docker compose -f docker-compose.dev.yml exec -T postgres \
+  psql -U trading_user -d trading_platform -c \
+  "SELECT status, entry_client_order_id FROM brackets ORDER BY created_at DESC LIMIT 3;"
+
+docker compose -f docker-compose.dev.yml exec -T postgres \
+  psql -U trading_user -d trading_platform -c \
+  "SELECT role, tp_index, client_order_id, status FROM bracket_legs \
+   WHERE bracket_id = (SELECT bracket_id FROM brackets ORDER BY created_at DESC LIMIT 1) \
+   ORDER BY role, tp_index;"
+```
+
+**C5 pass**: the bracket goes `ENTRY_PLACED → ENTRY_FILLED → LEGS_PLACED`, and the TP/SL legs go `PLANNED → PLACED` once the entry fills. On the exchange the two exit orders form one OCO list (the sibling auto-cancels when either fills).
+
+You can also open the **`/soak` panel** in the UI (`localhost:3000/soak`) — readiness shows _Ready_ and the reconcile counters reflect the last startup pass. (The panel is read-only; it does not trigger a pass.)
+
+---
+
+## 3. Simulate a crash and verify the reconciler (C6)
+
+The interesting C6 window is a crash **after the entry fills but before the watcher arms the exits**. With a 2s poll that window is short, so the most reliable manual test is: place the bracket, let the entry fill, kill the router before/while it arms, then restart.
+
+```bash
+docker compose -f docker-compose.dev.yml kill router      # hard stop
+# ... entry may fill on the exchange while the router is down ...
+docker compose -f docker-compose.dev.yml up -d router      # restart
+```
+
+On restart the router holds `/readyz` at `503` while the startup reconciler runs, then flips to `200`:
+
+```bash
+# Immediately after restart, expect 503 "reconciling", then 200 "ready"
+for i in $(seq 1 20); do curl -s -o /dev/null -w "%{http_code} " localhost:8001/readyz; sleep 1; done; echo
+```
+
+Inspect the reconcile result read-only (no side effects), or trigger an on-demand pass:
+
+```bash
+# Read-only: last completed pass (added in the soak/health-panel PR).
+# GET nests the counters under `.summary`: {has_run, last_run_at, summary:{unrepaired_legs, errors, …}}
+curl -s -H "X-API-Key: $SECURITY_REQUIRED_API_KEY" localhost:8001/internal/reconcile | jq
+
+# On-demand: run a pass now (mutating; 409 if one is already in flight).
+# POST returns the summary counters at the top level.
+curl -s -X POST -H "X-API-Key: $SECURITY_REQUIRED_API_KEY" localhost:8001/internal/reconcile | jq
+```
+
+**C6 pass**: after restart the bracket is repaired — its exits are recorded/settled (not left `PLANNED`/`PLACING`), the reconcile summary shows `unrepaired_legs: 0` and `errors: 0`, no duplicate exit orders exist on the exchange, and `/readyz` reached `200`. The `/soak` panel reflects the same counters.
+
+---
+
+## Pass / fail checklist
+
+Carry these into the soak sign-off. **Fail** on any unticked box.
+
+- [ ] All four router startup markers present (durable reservations, spot OCO on fill, watcher started, reconciliation complete).
+- [ ] Helper response had `legs_pending_trigger: true` (exits genuinely deferred).
+- [ ] Bracket advanced `ENTRY_FILLED → LEGS_PLACED`; TP/SL legs reached `PLACED`.
+- [ ] Exactly one OCO list per TP slice on the exchange; sibling auto-cancelled on the other's fill (no orphan, no duplicate).
+- [ ] **`GET /api/v3/orderList` returns a _completed_ list by `origClientOrderId`** — the C5/C6 recovery paths treat a confirmed `-2013` as safe-to-retry, so if a filled list read as "absent" a re-POST could double-sell. Verify once: place OCO, let it complete, query it.
+- [ ] Duplicate `listClientOrderId` and price-relation rejections return `-2010` with the expected messages (the router's matchers depend on the text).
+- [ ] After a mid-flight kill + restart, the reconciler settles the bracket with `unrepaired_legs: 0`, `errors: 0`, and **no double placement**.
+- [ ] `/readyz` observed `503 → 200` across the restart.
+
+---
+
+## Cleanup
+
+```bash
+# Cancel any resting testnet orders for the symbol, then stop the stack
+curl -s -X POST -H "X-API-Key: $SECURITY_REQUIRED_API_KEY" \
+  -d '{"scope":"SPOT","symbols":["BTCUSDT"]}' localhost:8001/cancel_open_orders | jq
+make dev-stop
+```
+
+Testnet balances and orders are disposable; no production data is touched.

--- a/scripts/place_test_bracket.py
+++ b/scripts/place_test_bracket.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Place one deferred spot bracket against the router to exercise C5/C6 by hand.
+
+The UI/BFF path cannot drive the deferred-legs code: the BFF omits
+``client_order_ids`` when calling ``/place_bracket``, and the router only
+defers exits (spot OCO on entry fill) and reserves a durable ``brackets`` row
+when ``client_order_ids.main`` is set. This helper POSTs a bracket **with**
+those ids so the entry-fill watcher (C5) and the startup reconciler (C6) have
+something to act on. See docs/testnet-c5-c6-sanity-runbook.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+from decimal import ROUND_DOWN, Decimal
+import json
+import os
+import sys
+from typing import Any
+import urllib.error
+import urllib.request
+import uuid
+
+
+def _format_decimal(value: Decimal, *, places: int) -> str:
+    quantum = Decimal("1").scaleb(-places)
+    return f"{value.quantize(quantum, rounding=ROUND_DOWN):f}"
+
+
+def build_deferred_bracket_body(
+    symbol: str,
+    reference_price: Decimal,
+    client_order_id: str,
+    *,
+    notional_usdt: Decimal,
+    entry_offset_bps: int = 150,
+) -> dict[str, Any]:
+    """Build a resting-LIMIT BUY spot bracket that defers its exits.
+
+    The entry sits ``entry_offset_bps`` below the reference so it rests then
+    fills; the take-profit is symmetric above and the stop is twice the offset
+    below. ``client_order_ids`` is what makes the router defer the exits.
+    """
+    offset = Decimal(entry_offset_bps) / Decimal("10000")
+    entry_price = reference_price * (Decimal("1") - offset)
+    take_profit_price = reference_price * (Decimal("1") + offset)
+    stop_loss_price = reference_price * (Decimal("1") - offset * Decimal("2"))
+    quantity = notional_usdt / entry_price
+    return {
+        "symbol": symbol,
+        "side": "BUY",
+        "quantity": _format_decimal(quantity, places=6),
+        "entry_price": _format_decimal(entry_price, places=2),
+        "take_profit_prices": [_format_decimal(take_profit_price, places=2)],
+        "stop_loss_price": _format_decimal(stop_loss_price, places=2),
+        "order_type": "LIMIT",
+        "is_futures": False,
+        "client_order_ids": {
+            "main": client_order_id,
+            "take_profits": [f"{client_order_id}-tp1"],
+            "stop_loss": f"{client_order_id}-sl",
+        },
+    }
+
+
+def _require_api_key() -> str:
+    # The router compares the caller's token against SECURITY_REQUIRED_API_KEY;
+    # ROUTER_API_KEY is what the BFF/soak send. They must match.
+    key = os.getenv("SECURITY_REQUIRED_API_KEY") or os.getenv("ROUTER_API_KEY")
+    if not key:
+        print(
+            "error: set SECURITY_REQUIRED_API_KEY (or ROUTER_API_KEY) to the router's token",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    return key
+
+
+def _fetch_reference_price(symbol: str) -> Decimal:
+    base_url = os.getenv("BINANCE_SPOT_BASE_URL", "https://testnet.binance.vision").rstrip("/")
+    url = f"{base_url}/api/v3/ticker/price?symbol={symbol}"
+    with urllib.request.urlopen(url, timeout=10) as response:  # noqa: S310 - trusted testnet URL
+        payload = json.loads(response.read().decode("utf-8"))
+    price = payload.get("price")
+    if not price:
+        raise RuntimeError(f"price lookup response missing price: {payload}")
+    return Decimal(str(price))
+
+
+def _post_bracket(host: str, api_key: str, body: dict[str, Any]) -> tuple[int, Any]:
+    request = urllib.request.Request(
+        f"{host.rstrip('/')}/place_bracket",
+        data=json.dumps(body).encode("utf-8"),
+        headers={"Content-Type": "application/json", "X-API-Key": api_key},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:  # noqa: S310
+            return response.status, json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode("utf-8")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Place one deferred spot bracket (C5/C6 sanity).")
+    parser.add_argument("--symbol", default="BTCUSDT")
+    parser.add_argument("--notional-usdt", default="25", help="Target entry notional in USDT")
+    parser.add_argument("--entry-offset-bps", type=int, default=150)
+    parser.add_argument(
+        "--reference-price",
+        help="Override the reference price instead of fetching the testnet ticker",
+    )
+    parser.add_argument("--host", default=os.getenv("ROUTER_HOST", "http://localhost:8001"))
+    parser.add_argument(
+        "--client-id",
+        default=f"man-{uuid.uuid4().hex[:12]}",
+        help="Client order id for the entry (derives -tp1 / -sl leg ids)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    api_key = _require_api_key()
+
+    reference_price = (
+        Decimal(args.reference_price)
+        if args.reference_price
+        else _fetch_reference_price(args.symbol)
+    )
+    body = build_deferred_bracket_body(
+        args.symbol,
+        reference_price,
+        args.client_id,
+        notional_usdt=Decimal(args.notional_usdt),
+        entry_offset_bps=args.entry_offset_bps,
+    )
+
+    status, response = _post_bracket(args.host, api_key, body)
+    print(json.dumps({"request": body, "status": status, "response": response}, indent=2))
+    if status >= 300:
+        return 1
+
+    print(
+        "\nWatch these client order ids "
+        "(brackets/bracket_legs rows, /soak panel, order_update events):",
+        file=sys.stderr,
+    )
+    print(f"  entry: {args.client_id}", file=sys.stderr)
+    print(f"  tp1:   {args.client_id}-tp1", file=sys.stderr)
+    print(f"  sl:    {args.client_id}-sl", file=sys.stderr)
+    if isinstance(response, dict) and not response.get("legs_pending_trigger"):
+        print(
+            "\nWARNING: legs_pending_trigger was not true — exits were NOT deferred. "
+            "Check BRACKET_LEGS_ON_FILL=true and DATABASE_URL on the router.",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_place_test_bracket.py
+++ b/tests/test_place_test_bracket.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from decimal import Decimal
+import importlib.util
+from pathlib import Path
+import sys
+
+
+def _load_module():
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "place_test_bracket.py"
+    spec = importlib.util.spec_from_file_location("place_test_bracket", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_deferred_bracket_body_includes_client_order_ids():
+    module = _load_module()
+
+    body = module.build_deferred_bracket_body(
+        "BTCUSDT",
+        Decimal("50000"),
+        "man-abc123",
+        notional_usdt=Decimal("25"),
+        entry_offset_bps=150,
+    )
+
+    # client_order_ids is the field that makes the router defer the exits and
+    # reserve a durable bracket row — the whole point of the helper.
+    assert body["client_order_ids"] == {
+        "main": "man-abc123",
+        "take_profits": ["man-abc123-tp1"],
+        "stop_loss": "man-abc123-sl",
+    }
+    assert body["is_futures"] is False
+    assert body["order_type"] == "LIMIT"
+
+
+def test_build_deferred_bracket_body_prices_bracket_the_reference():
+    module = _load_module()
+
+    body = module.build_deferred_bracket_body(
+        "BTCUSDT",
+        Decimal("50000"),
+        "man-x",
+        notional_usdt=Decimal("25"),
+        entry_offset_bps=150,
+    )
+
+    # offset = 150bps = 1.5%. Entry rests below, TP above, SL twice below.
+    assert body["entry_price"] == "49250.00"
+    assert body["take_profit_prices"] == ["50750.00"]
+    assert body["stop_loss_price"] == "48500.00"
+    # quantity = 25 / 49250 floored to 6dp
+    assert body["quantity"] == "0.000507"
+
+
+def test_build_deferred_bracket_body_leg_ids_derive_from_entry_id():
+    module = _load_module()
+
+    body = module.build_deferred_bracket_body(
+        "ETHUSDT",
+        Decimal("3000"),
+        "man-zzz",
+        notional_usdt=Decimal("30"),
+    )
+
+    assert body["client_order_ids"]["take_profits"][0].startswith("man-zzz")
+    assert body["client_order_ids"]["stop_loss"].startswith("man-zzz")


### PR DESCRIPTION
## Summary

The manual half of the testnet validation (deliverable "c"): a human-in-the-loop walkthrough that proves C5 (spot OCO exits arm on entry fill) and C6 (startup reconciler + `/readyz` gate across a crash) on spot **testnet**, as a confidence check before the 7-day automated soak.

- **`scripts/place_test_bracket.py`** — places one deferred spot bracket against the router `/place_bracket` **with `client_order_ids`**. This is the crux: the BFF omits `client_order_ids` (`router-client.service.ts`), and the router only defers exits + reserves a durable `brackets` row when `client_order_ids.main` is set (`manager.go` `spotLegsDeferred`). So the UI order form cannot exercise C5/C6 — this helper can. The pure `build_deferred_bracket_body` is unit-tested; the CLI fetches a testnet reference price, POSTs with `X-API-Key`, prints the leg ids to watch, and warns if `legs_pending_trigger` isn't true.
- **`docs/testnet-c5-c6-sanity-runbook.md`** — the walkthrough: env profile, `make dev`, place a deferred bracket, observe C5 (bracket `RESERVED → ENTRY_FILLED → LEGS_PLACED`, legs `PLANNED → PLACED`) in Postgres and on the `/soak` panel, then kill/restart the router and observe C6 (reconciler settles the bracket, `/readyz` `503 → 200`). Ends with a pass/fail checklist that carries the two blocking soak items (verify `GET /api/v3/orderList` returns *completed* lists; `-2010` message parity).

## QCHECK

Independent subagent verified every command, endpoint, method, status code, payload field, env var, SQL column, log marker, and the price math against the live router code — the accuracy of a runbook is its whole value. **Verdict: PASS**, no critical/high/medium issues. Confirmed: the helper body matches `PlaceBracketRequest`/`ClientOrderIDs` json tags exactly; the deferral gate fires on `client_order_ids.main`; `X-API-Key` auth and the `ROUTER_API_KEY == SECURITY_REQUIRED_API_KEY` requirement; all endpoint paths/methods/codes (`/place_bracket` 200, `/readyz` 503→200, GET/POST `/internal/reconcile`, `/cancel_open_orders` `{scope:"SPOT"}`); the compose `BRACKET_LEGS_ON_FILL` default; the `brackets`/`bracket_legs` columns; and entry/tp/sl/qty = 49250/50750/48500/0.000507. Five LOW cosmetic nits; three fixed pre-merge (EXECUTION_MODE is engine-side not router, the GET-nests-under-`.summary` detail, and the foreground-`make dev` second-terminal note).

## Test evidence

- `ruff` clean; 3 helper unit tests + the 24 soak-runner tests pass.
- Docs/script only — no product code paths changed.