### PR TITLE
feat(backtest): trend-following signal sources (v3) with buy-and-hold benchmark

### DIFF
--- a/app/engine/backtest/metrics.py
+++ b/app/engine/backtest/metrics.py
@@ -103,6 +103,48 @@ class MetricsCalculator:
 
         return metrics
 
+    def apply_benchmark(
+        self,
+        metrics: BacktestMetrics,
+        closes: list[Decimal],
+    ) -> BacktestMetrics:
+        """
+        Fill the buy-and-hold benchmark fields from the run's candle closes.
+
+        Uses the same annualization factor as the strategy Sharpe so the two
+        ratios are directly comparable.
+
+        Args:
+            metrics: Metrics object to update (total_pnl_pct must be set)
+            closes: Close prices of every candle the simulator processed
+
+        Returns:
+            The same metrics object, updated in place
+        """
+        if len(closes) < 2:
+            return metrics
+
+        first = closes[0]
+        metrics.benchmark_return_pct = (closes[-1] / first - 1) * Decimal(100)
+
+        peak = first
+        max_dd = Decimal(0)
+        for close in closes:
+            peak = max(peak, close)
+            max_dd = max(max_dd, (peak - close) / peak)
+        metrics.benchmark_max_drawdown_pct = max_dd * Decimal(100)
+
+        returns_array = np.array(
+            [float(closes[i] / closes[i - 1] - 1) for i in range(1, len(closes))],
+        )
+        if returns_array.std() > 0:
+            metrics.benchmark_sharpe_ratio = Decimal(
+                str(returns_array.mean() / returns_array.std() * self._annualization_factor),
+            )
+
+        metrics.excess_return_pct = metrics.total_pnl_pct - metrics.benchmark_return_pct
+        return metrics
+
     def _calculate_trade_stats(
         self,
         trades: list[BacktestTrade],

--- a/app/engine/backtest/runner.py
+++ b/app/engine/backtest/runner.py
@@ -97,6 +97,10 @@ class BacktestRunner:
                 cooldown_seconds=int(backtest_data.get("cooldown_seconds", 300)),
                 risk_per_trade=Decimal(str(backtest_data.get("risk_per_trade", "0.005"))),
                 warmup_bars=int(backtest_data.get("warmup_bars", 50)),
+                htf_ema_period=int(backtest_data.get("htf_ema_period", 0)),
+                htf_ema_fast=int(backtest_data.get("htf_ema_fast", 0)),
+                min_stop_bps=Decimal(str(backtest_data.get("min_stop_bps", 0))),
+                invert_signals=bool(backtest_data.get("invert_signals", False)),
                 train_days=backtest_data.get("wfo", {}).get("train_days", 90),
                 test_days=backtest_data.get("wfo", {}).get("test_days", 30),
             )

--- a/app/engine/backtest/runner.py
+++ b/app/engine/backtest/runner.py
@@ -101,6 +101,19 @@ class BacktestRunner:
                 htf_ema_fast=int(backtest_data.get("htf_ema_fast", 0)),
                 min_stop_bps=Decimal(str(backtest_data.get("min_stop_bps", 0))),
                 invert_signals=bool(backtest_data.get("invert_signals", False)),
+                signal_source=str(backtest_data.get("signal_source", "smc_retest")),
+                allow_short=bool(backtest_data.get("allow_short", False)),
+                atr_period=int(backtest_data.get("atr_period", 14)),
+                atr_stop_mult=Decimal(str(backtest_data.get("atr_stop_mult", 2))),
+                sma_period=int(backtest_data.get("sma_period", 200)),
+                tsmom_lookback=int(backtest_data.get("tsmom_lookback", 28)),
+                tsmom_deadband_bps=Decimal(str(backtest_data.get("tsmom_deadband_bps", 0))),
+                ema_fast=int(backtest_data.get("ema_fast", 10)),
+                ema_slow=int(backtest_data.get("ema_slow", 40)),
+                donchian_entry=int(backtest_data.get("donchian_entry", 20)),
+                donchian_exit=int(backtest_data.get("donchian_exit", 10)),
+                max_hold_bars=int(backtest_data.get("max_hold_bars", 0)),
+                trend_tp_r=Decimal(str(backtest_data.get("trend_tp_r", 0))),
                 train_days=backtest_data.get("wfo", {}).get("train_days", 90),
                 test_days=backtest_data.get("wfo", {}).get("test_days", 30),
             )
@@ -154,8 +167,10 @@ class BacktestRunner:
         # Start data stream
         streaming_dataset.start_stream(symbol, tf, start_dt, end_dt)
 
-        # Run simulation in a single event loop for the whole stream
-        asyncio.run(self._run_simulation(simulator, streaming_dataset))
+        # Run simulation in a single event loop for the whole stream;
+        # collect closes here so the simulator stays pure
+        closes: list[Decimal] = []
+        asyncio.run(self._run_simulation(simulator, streaming_dataset, closes))
 
         # Calculate metrics
         end_time = time.time()
@@ -168,6 +183,7 @@ class BacktestRunner:
             simulator.drawdown_history,
             runtime_ms,
         )
+        metrics_calc.apply_benchmark(metrics, closes)
 
         # Get git SHA and config hash for reproducibility
         git_sha = self._get_git_sha()
@@ -189,6 +205,11 @@ class BacktestRunner:
         logger.info(f"Total Trades: {metrics.total_trades}")
         logger.info(f"Win Rate: {metrics.hit_rate_pct:.1f}%")
         logger.info(f"Profit Factor: {metrics.profit_factor}")
+        logger.info(
+            f"Buy&Hold: {metrics.benchmark_return_pct:.2f}% "
+            f"(maxDD {metrics.benchmark_max_drawdown_pct:.2f}%) | "
+            f"Excess return: {metrics.excess_return_pct:.2f}%",
+        )
 
         return result
 
@@ -196,12 +217,15 @@ class BacktestRunner:
         self,
         simulator: BacktestSimulator,
         streaming_dataset: StreamingDataset,
+        closes: list[Decimal] | None = None,
     ) -> int:
         candle_count = 0
         while streaming_dataset.has_more():
             candle = streaming_dataset.next_candle()
             if candle:
                 await simulator.process_candle(candle)
+                if closes is not None:
+                    closes.append(candle.close_price)
                 candle_count += 1
 
                 if candle_count % 1000 == 0:
@@ -283,6 +307,8 @@ class BacktestRunner:
                 "slippage_bps": float(result.config.slippage_bps),
                 "funding_model": result.config.funding_model,
                 "tp_ladder": result.config.tp_ladder,
+                "signal_source": result.config.signal_source,
+                "allow_short": result.config.allow_short,
             },
             "metrics": {
                 "total_pnl": float(result.metrics.total_pnl),
@@ -314,6 +340,14 @@ class BacktestRunner:
                 "total_fees": float(result.metrics.total_fees),
                 "total_slippage": float(result.metrics.total_slippage),
                 "total_funding": float(result.metrics.total_funding),
+                "benchmark_return_pct": float(result.metrics.benchmark_return_pct),
+                "benchmark_max_drawdown_pct": float(
+                    result.metrics.benchmark_max_drawdown_pct,
+                ),
+                "benchmark_sharpe_ratio": float(result.metrics.benchmark_sharpe_ratio)
+                if result.metrics.benchmark_sharpe_ratio
+                else None,
+                "excess_return_pct": float(result.metrics.excess_return_pct),
             },
         }
 

--- a/app/engine/backtest/simulator.py
+++ b/app/engine/backtest/simulator.py
@@ -29,6 +29,7 @@ from .capture_bus import CapturingEventBus
 from .costs import CostCalculator
 from .fills import FillEngine
 from .policies import TradingPolicyManager
+from .trend_signals import create_trend_engine
 from .types import (
     BacktestConfig,
     BacktestFill,
@@ -46,6 +47,7 @@ if TYPE_CHECKING:
     from uuid import UUID
 
     from ..bus import EventBus
+    from .trend_signals import TrendEngine, TrendTarget
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +81,7 @@ class _SimClock:
 @dataclass(frozen=True)
 class _BracketSpec:
     stop_loss: Decimal
-    take_profit: Decimal
+    take_profit: Decimal | None
     direction: str
 
 
@@ -89,6 +91,11 @@ class BacktestSimulator:
         config: BacktestConfig,
         initial_balance: Decimal = Decimal(10000),
     ):
+        if config.invert_signals and config.signal_source != "smc_retest":
+            raise ValueError(
+                "invert_signals is an SMC-only diagnostic and cannot be combined "
+                f"with signal_source={config.signal_source!r}",
+            )
         self.config = config
         self.initial_balance = initial_balance
         self.current_balance = initial_balance
@@ -148,8 +155,13 @@ class BacktestSimulator:
         self._htf_ema_fast: Decimal | None = None
         self._pending_brackets: dict[UUID, _BracketSpec] = {}
         self._oco_pairs: dict[UUID, UUID] = {}
+        self._exit_reason_overrides: dict[UUID, ExitReason] = {}
         self._day_start_equity = initial_balance
         self._current_day: date | None = None
+
+        self._trend_engine: TrendEngine | None = (
+            create_trend_engine(config) if config.signal_source != "smc_retest" else None
+        )
 
     async def process_candle(self, candle: Candle) -> None:
         self.current_time = candle.close_time
@@ -162,6 +174,14 @@ class BacktestSimulator:
 
         self._candles.append(candle)
         self._update_htf_ema(candle)
+
+        if self._trend_engine is not None:
+            self._check_max_hold(candle)
+            target = self._trend_engine.on_bar(candle)
+            await self._apply_trend_target(target, candle)
+            self._update_equity_curve()
+            return
+
         features = self._calculate_features()
 
         await self.smc_engine.process_candle(candle, emit_events=True)
@@ -182,6 +202,125 @@ class BacktestSimulator:
                 await self._execute_signal(signal, candle)
 
         self._update_equity_curve()
+
+    async def _apply_trend_target(self, target: TrendTarget, candle: Candle) -> None:
+        """Diff the engine's desired state against the open position.
+
+        Runs every bar, so an entry blocked by a risk gate is retried on the
+        next bar and a missed flip re-arms itself (self-healing desired state).
+        """
+        if not target.ready:
+            return
+        desired = target.desired
+        if desired == "SHORT" and not self.config.allow_short:
+            desired = "FLAT"
+
+        position = self.positions.get(candle.symbol)
+        current = (
+            position.side
+            if position is not None and position.side and position.quantity > 0
+            else None
+        )
+        if current == desired or (current is None and desired == "FLAT"):
+            return
+
+        if current is not None:
+            self._submit_position_close(candle.symbol, ExitReason.FLIP, candle)
+        if desired == "FLAT":
+            return
+
+        signal = self._build_trend_signal(target, desired, candle)
+        await self._execute_signal(signal, candle)
+
+    def _build_trend_signal(
+        self,
+        target: TrendTarget,
+        direction: str,
+        candle: Candle,
+    ) -> dict[str, Any]:
+        entry = target.entry
+        stop = target.stop_loss
+        if entry is None or stop is None:
+            raise ValueError(f"Trend target for {direction} is missing entry/stop: {target}")
+        tp1: Decimal | None = None
+        if self.config.trend_tp_r > 0:
+            risk = abs(entry - stop)
+            sign = Decimal(1) if direction == "LONG" else Decimal(-1)
+            tp1 = entry + sign * risk * self.config.trend_tp_r
+        return {
+            "venue": candle.venue,
+            "symbol": candle.symbol,
+            "timeframe": candle.timeframe.value,
+            "timestamp": candle.close_time,
+            "direction": direction,
+            "zone_id": f"trend-{self.config.signal_source}",
+            "zone_type": "TREND",
+            "bos_level": entry,
+            "entry": entry,
+            "stop_loss": stop,
+            "tp1": tp1,
+            "tp2": None,
+            "tp3": None,
+        }
+
+    def _submit_position_close(
+        self,
+        symbol: str,
+        reason: ExitReason,
+        candle: Candle,
+    ) -> None:
+        position = self.positions.get(symbol)
+        if position is None or not position.side or position.quantity <= 0:
+            return
+        # A close may already be in flight (e.g. max-hold fired before a flip).
+        if any(
+            o.symbol == symbol and o.reduce_only and o.type == OrderType.MARKET
+            for o in self.active_orders
+        ):
+            return
+        # Cancel resting brackets first: a stale stop swept on the next bar
+        # would double-fill the exit and charge a phantom fee.
+        self._cancel_position_brackets(symbol)
+        close_order = BacktestOrder(
+            symbol=symbol,
+            side=OrderSide.SELL if position.side == "LONG" else OrderSide.BUY,
+            type=OrderType.MARKET,
+            quantity=position.quantity,
+            reduce_only=True,
+            order_time=candle.close_time,
+        )
+        self.active_orders.append(close_order)
+        self._exit_reason_overrides[close_order.id] = reason
+
+    def _cancel_position_brackets(self, symbol: str) -> None:
+        brackets = [
+            o
+            for o in self.active_orders
+            if o.symbol == symbol
+            and o.reduce_only
+            and o.type in (OrderType.STOP_MARKET, OrderType.LIMIT)
+        ]
+        for order in brackets:
+            sibling_id = self._oco_pairs.pop(order.id, None)
+            if sibling_id is not None:
+                self._oco_pairs.pop(sibling_id, None)
+            self._cancel_order(order.id)
+
+    def _check_max_hold(self, candle: Candle) -> None:
+        if self.config.max_hold_bars <= 0:
+            return
+        position = self.positions.get(candle.symbol)
+        if (
+            position is None
+            or not position.side
+            or position.quantity <= 0
+            or position.opened_at is None
+        ):
+            return
+        bar_seconds = _BAR_MINUTES.get(candle.timeframe.value, 5) * 60
+        held_bars = (candle.close_time - position.opened_at).total_seconds() / bar_seconds
+        if held_bars >= self.config.max_hold_bars:
+            self._submit_position_close(candle.symbol, ExitReason.TIMEOUT, candle)
 
     @staticmethod
     def _advance_ema(prev: Decimal | None, close: Decimal, period: int) -> Decimal:
@@ -488,7 +627,8 @@ class BacktestSimulator:
             self._cancel_order(sibling_id)
         self._close_position(
             fill,
-            exit_reason=_EXIT_REASONS.get(fill.fill_reason, ExitReason.MANUAL),
+            exit_reason=self._exit_reason_overrides.pop(order.id, None)
+            or _EXIT_REASONS.get(fill.fill_reason, ExitReason.MANUAL),
         )
 
     def _cancel_order(self, order_id: UUID) -> None:
@@ -547,6 +687,9 @@ class BacktestSimulator:
             reduce_only=True,
             order_time=fill.fill_time,
         )
+        self.active_orders.append(stop_order)
+        if bracket.take_profit is None:
+            return
         tp_order = BacktestOrder(
             symbol=fill.symbol,
             side=exit_side,
@@ -556,7 +699,6 @@ class BacktestSimulator:
             reduce_only=True,
             order_time=fill.fill_time,
         )
-        self.active_orders.append(stop_order)
         self.active_orders.append(tp_order)
         self._oco_pairs[stop_order.id] = tp_order.id
         self._oco_pairs[tp_order.id] = stop_order.id

--- a/app/engine/backtest/simulator.py
+++ b/app/engine/backtest/simulator.py
@@ -143,6 +143,9 @@ class BacktestSimulator:
         self._candles: deque[Candle] = deque(maxlen=200)
         self._bos_events: list[dict[str, Any]] = []
         self._prev_macd_hist: Decimal | None = None
+        # Streaming higher-timeframe trend EMAs for the trend-alignment gate.
+        self._htf_ema: Decimal | None = None
+        self._htf_ema_fast: Decimal | None = None
         self._pending_brackets: dict[UUID, _BracketSpec] = {}
         self._oco_pairs: dict[UUID, UUID] = {}
         self._day_start_equity = initial_balance
@@ -158,6 +161,7 @@ class BacktestSimulator:
         self._process_funding(candle)
 
         self._candles.append(candle)
+        self._update_htf_ema(candle)
         features = self._calculate_features()
 
         await self.smc_engine.process_candle(candle, emit_events=True)
@@ -178,6 +182,78 @@ class BacktestSimulator:
                 await self._execute_signal(signal, candle)
 
         self._update_equity_curve()
+
+    @staticmethod
+    def _advance_ema(prev: Decimal | None, close: Decimal, period: int) -> Decimal:
+        if prev is None:
+            return close
+        k = Decimal(2) / Decimal(period + 1)
+        return close * k + prev * (Decimal(1) - k)
+
+    def _update_htf_ema(self, candle: Candle) -> None:
+        """Advance the streaming trend EMA(s) on each closed bar (O(1))."""
+        if self.config.htf_ema_period > 0:
+            self._htf_ema = self._advance_ema(
+                self._htf_ema, candle.close_price, self.config.htf_ema_period
+            )
+        if self.config.htf_ema_fast > 0:
+            self._htf_ema_fast = self._advance_ema(
+                self._htf_ema_fast, candle.close_price, self.config.htf_ema_fast
+            )
+
+    def _trend_allows(self, direction: str, candle: Candle) -> bool:
+        """Trend-alignment gate: only trade with the trend.
+
+        Over 2024-2026 the SMC signal's counter-trend side (shorting a bull
+        market) was its worst performer; this vetoes those. With htf_ema_fast
+        set, the gate is strict EMA stacking (close > fast > slow for longs).
+        """
+        if self.config.htf_ema_period <= 0 or self._htf_ema is None:
+            return True
+        close = candle.close_price
+        strict = self.config.htf_ema_fast > 0 and self._htf_ema_fast is not None
+        if direction == "LONG":
+            if strict:
+                return close > self._htf_ema_fast > self._htf_ema
+            return close > self._htf_ema
+        if strict:
+            return close < self._htf_ema_fast < self._htf_ema
+        return close < self._htf_ema
+
+    @staticmethod
+    def _invert_signal(signal: dict[str, Any]) -> None:
+        """Diagnostic: mirror the trade around its entry (LONG<->SHORT)."""
+        entry = signal["entry"]
+        risk = abs(entry - signal["stop_loss"])
+        if signal["direction"] == "LONG":
+            signal["direction"] = "SHORT"
+            signal["stop_loss"] = entry + risk
+            signal["tp1"] = entry - risk * Decimal("1.5")
+        else:
+            signal["direction"] = "LONG"
+            signal["stop_loss"] = entry - risk
+            signal["tp1"] = entry + risk * Decimal("1.5")
+
+    def _apply_min_stop_floor(self, signal: dict[str, Any]) -> None:
+        """Widen too-tight structure stops to a fee-aware minimum distance.
+
+        A tight stop forces a huge notional (risk = notional * stop_dist), so
+        fixed fees become a large fraction of the risked amount. Flooring the
+        stop distance shrinks notional and restores the fee/risk ratio.
+        """
+        min_bps = self.config.min_stop_bps
+        if min_bps <= 0:
+            return
+        entry = signal["entry"]
+        stop = signal["stop_loss"]
+        min_dist = entry * min_bps / Decimal(10000)
+        if abs(entry - stop) >= min_dist:
+            return
+        # Widen the stop away from entry on the loss side.
+        if stop < entry:  # LONG: stop below entry
+            signal["stop_loss"] = entry - min_dist
+        else:  # SHORT: stop above entry
+            signal["stop_loss"] = entry + min_dist
 
     def _calculate_features(self) -> dict[str, Decimal] | None:
         if len(self._candles) < self.config.warmup_bars:
@@ -265,7 +341,17 @@ class BacktestSimulator:
         }
 
     async def _execute_signal(self, signal: dict[str, Any], candle: Candle) -> None:
+        if self.config.invert_signals:
+            self._invert_signal(signal)
         direction = signal["direction"]
+
+        if not self._trend_allows(direction, candle):
+            logger.debug(f"Signal vetoed by trend gate: {direction} {candle.symbol}")
+            return
+
+        # Fee-aware stop floor must run before sizing and bracket placement so
+        # the widened stop feeds both.
+        self._apply_min_stop_floor(signal)
 
         allowed, reasons = self.policy_manager.is_trading_allowed(
             candle.close_time,

--- a/app/engine/backtest/trend_signals.py
+++ b/app/engine/backtest/trend_signals.py
@@ -1,0 +1,221 @@
+"""
+Streaming trend-following signal engines for the backtest simulator.
+
+Each engine is a self-contained state machine over closed bars: it owns its
+lookback buffers (bounded deques) and an O(1) Wilder ATR, and emits a desired
+position state every bar. The simulator diffs that desired state against the
+open position, so a blocked entry self-heals on the next bar.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..models import Candle
+    from .types import BacktestConfig
+
+LONG = "LONG"
+SHORT = "SHORT"
+FLAT = "FLAT"
+
+
+@dataclass(frozen=True)
+class TrendTarget:
+    """Desired position state for the current bar."""
+
+    desired: str
+    entry: Decimal | None = None
+    stop_loss: Decimal | None = None
+    ready: bool = False
+
+
+class _StreamingAtr:
+    """O(1) Wilder ATR; arithmetic mirrors TechnicalIndicatorsCalculator.atr
+    (simple mean of the first N true ranges, then Wilder smoothing) so the
+    streaming and batch values match exactly."""
+
+    def __init__(self, period: int):
+        self._period = period
+        self._prev_close: Decimal | None = None
+        self._seed_trs: deque[Decimal] = deque(maxlen=period)
+        self._atr: Decimal | None = None
+
+    def update(self, candle: Candle) -> Decimal | None:
+        if self._prev_close is None:
+            true_range = candle.high_price - candle.low_price
+        else:
+            true_range = max(
+                candle.high_price - candle.low_price,
+                abs(candle.high_price - self._prev_close),
+                abs(candle.low_price - self._prev_close),
+            )
+        self._prev_close = candle.close_price
+
+        if self._atr is None:
+            self._seed_trs.append(true_range)
+            if len(self._seed_trs) == self._period:
+                self._atr = sum(self._seed_trs, Decimal(0)) / self._period
+        else:
+            self._atr = (self._atr * (self._period - 1) + true_range) / self._period
+        return self._atr
+
+
+class _TrendEngineBase:
+    """Shared ATR stop construction; subclasses implement the desired-state rule."""
+
+    def __init__(self, config: BacktestConfig):
+        self._atr = _StreamingAtr(config.atr_period)
+        self._stop_mult = config.atr_stop_mult
+
+    def _target(self, desired: str, close: Decimal, atr: Decimal) -> TrendTarget:
+        if desired == FLAT:
+            return TrendTarget(desired=FLAT, ready=True)
+        offset = self._stop_mult * atr
+        stop = close - offset if desired == LONG else close + offset
+        return TrendTarget(desired=desired, entry=close, stop_loss=stop, ready=True)
+
+    @staticmethod
+    def _warming_up() -> TrendTarget:
+        return TrendTarget(desired=FLAT, ready=False)
+
+
+class PriceSmaEngine(_TrendEngineBase):
+    """Long/cash rule: hold while close > SMA(sma_period), else cash. Never short."""
+
+    def __init__(self, config: BacktestConfig):
+        super().__init__(config)
+        self._period = config.sma_period
+        self._closes: deque[Decimal] = deque(maxlen=config.sma_period)
+
+    def on_bar(self, candle: Candle) -> TrendTarget:
+        atr = self._atr.update(candle)
+        self._closes.append(candle.close_price)
+        if len(self._closes) < self._period or atr is None:
+            return self._warming_up()
+        sma = sum(self._closes, Decimal(0)) / self._period
+        desired = LONG if candle.close_price > sma else FLAT
+        return self._target(desired, candle.close_price, atr)
+
+
+class TsmomEngine(_TrendEngineBase):
+    """Time-series momentum: sign of the trailing lookback-bar return, with a
+    dead-band inside which the previous state is held (hysteresis)."""
+
+    def __init__(self, config: BacktestConfig):
+        super().__init__(config)
+        self._lookback = config.tsmom_lookback
+        self._threshold = config.tsmom_deadband_bps / Decimal(10000)
+        self._closes: deque[Decimal] = deque(maxlen=config.tsmom_lookback + 1)
+        self._state = FLAT
+
+    def on_bar(self, candle: Candle) -> TrendTarget:
+        atr = self._atr.update(candle)
+        self._closes.append(candle.close_price)
+        if len(self._closes) <= self._lookback or atr is None:
+            return self._warming_up()
+        trailing_return = candle.close_price / self._closes[0] - 1
+        if trailing_return > self._threshold:
+            self._state = LONG
+        elif trailing_return < -self._threshold:
+            self._state = SHORT
+        return self._target(self._state, candle.close_price, atr)
+
+
+class EmaCrossEngine(_TrendEngineBase):
+    """Streaming fast/slow EMA cross: LONG while fast > slow, SHORT while below."""
+
+    def __init__(self, config: BacktestConfig):
+        super().__init__(config)
+        self._fast_period = config.ema_fast
+        self._slow_period = config.ema_slow
+        self._fast: Decimal | None = None
+        self._slow: Decimal | None = None
+        self._bars_seen = 0
+
+    @staticmethod
+    def _advance(prev: Decimal | None, close: Decimal, period: int) -> Decimal:
+        if prev is None:
+            return close
+        k = Decimal(2) / Decimal(period + 1)
+        return close * k + prev * (Decimal(1) - k)
+
+    def on_bar(self, candle: Candle) -> TrendTarget:
+        atr = self._atr.update(candle)
+        close = candle.close_price
+        self._fast = self._advance(self._fast, close, self._fast_period)
+        self._slow = self._advance(self._slow, close, self._slow_period)
+        self._bars_seen += 1
+        if self._bars_seen < self._slow_period or atr is None:
+            return self._warming_up()
+        if self._fast > self._slow:
+            desired = LONG
+        elif self._fast < self._slow:
+            desired = SHORT
+        else:
+            desired = FLAT
+        return self._target(desired, close, atr)
+
+
+class DonchianEngine(_TrendEngineBase):
+    """Turtle channels: enter on a break of the prior donchian_entry-bar
+    extreme, exit on a break of the (shorter) prior donchian_exit-bar extreme.
+    Channels exclude the current bar. SHORT states are emitted; the simulator
+    enforces allow_short."""
+
+    def __init__(self, config: BacktestConfig):
+        super().__init__(config)
+        self._entry_n = config.donchian_entry
+        self._exit_n = config.donchian_exit
+        window = max(config.donchian_entry, config.donchian_exit)
+        self._highs: deque[Decimal] = deque(maxlen=window)
+        self._lows: deque[Decimal] = deque(maxlen=window)
+        self._state = FLAT
+
+    def on_bar(self, candle: Candle) -> TrendTarget:
+        atr = self._atr.update(candle)
+        close = candle.close_price
+        ready = len(self._highs) >= self._entry_n and atr is not None
+
+        if ready:
+            highs = list(self._highs)
+            lows = list(self._lows)
+            if self._state == LONG and close < min(lows[-self._exit_n :]):
+                self._state = FLAT
+            elif self._state == SHORT and close > max(highs[-self._exit_n :]):
+                self._state = FLAT
+            if self._state == FLAT:
+                if close > max(highs[-self._entry_n :]):
+                    self._state = LONG
+                elif close < min(lows[-self._entry_n :]):
+                    self._state = SHORT
+
+        self._highs.append(candle.high_price)
+        self._lows.append(candle.low_price)
+        if not ready:
+            return self._warming_up()
+        assert atr is not None
+        return self._target(self._state, close, atr)
+
+
+TrendEngine = PriceSmaEngine | TsmomEngine | EmaCrossEngine | DonchianEngine
+
+_ENGINES: dict[str, type] = {
+    "price_sma": PriceSmaEngine,
+    "tsmom": TsmomEngine,
+    "ema_cross": EmaCrossEngine,
+    "donchian": DonchianEngine,
+}
+
+
+def create_trend_engine(config: BacktestConfig) -> TrendEngine:
+    engine_cls = _ENGINES.get(config.signal_source)
+    if engine_cls is None:
+        raise ValueError(
+            f"Unknown trend signal_source {config.signal_source!r}; "
+            f"expected one of {sorted(_ENGINES)}",
+        )
+    return engine_cls(config)

--- a/app/engine/backtest/types.py
+++ b/app/engine/backtest/types.py
@@ -189,6 +189,22 @@ class BacktestConfig:
     risk_per_trade: Decimal = Decimal("0.005")
     warmup_bars: int = 50
 
+    # Strategy variant knobs (0 = disabled)
+    # htf_ema_period: trend-alignment gate — veto signals against a slow EMA
+    #   (long only when close > EMA, short only when close < EMA).
+    # min_stop_bps: fee-aware minimum stop distance in bps of entry price;
+    #   widens too-tight structure stops so notional (and thus fee/risk) drops.
+    htf_ema_period: int = 0
+    # htf_ema_fast: when >0 alongside htf_ema_period, require strict EMA stacking
+    #   (long: close > fast EMA > slow EMA; short mirrored) — a stricter, more
+    #   selective trend gate than the single-EMA version.
+    htf_ema_fast: int = 0
+    min_stop_bps: Decimal = Decimal(0)
+    # Diagnostic only: mirror every trade around its entry (LONG<->SHORT,
+    # stop/target swapped). If inverting turns a loser profitable, the signal
+    # has negative directional edge, not merely zero edge.
+    invert_signals: bool = False
+
     # WFO settings
     train_days: int = 90
     test_days: int = 30

--- a/app/engine/backtest/types.py
+++ b/app/engine/backtest/types.py
@@ -52,6 +52,7 @@ class ExitReason(Enum):
     SL = "sl"  # Stop loss
     MANUAL = "manual"
     TIMEOUT = "timeout"
+    FLIP = "flip"  # Desired-state reversal closed the position
 
 
 @dataclass
@@ -205,6 +206,25 @@ class BacktestConfig:
     # has negative directional edge, not merely zero edge.
     invert_signals: bool = False
 
+    # Trend-following signal source (lookbacks are in BARS; defaults are
+    # oriented to the primary daily arm — 1h configs must scale them x24).
+    # "smc_retest" keeps the existing SMC pipeline byte-identical.
+    signal_source: str = "smc_retest"  # smc_retest|price_sma|tsmom|ema_cross|donchian
+    # Long/cash is the evidenced form of crypto trend-following; long/short
+    # runs are a diagnostic arm, so SHORT targets degrade to FLAT by default.
+    allow_short: bool = False
+    atr_period: int = 14
+    atr_stop_mult: Decimal = Decimal(2)
+    sma_period: int = 200
+    tsmom_lookback: int = 28
+    tsmom_deadband_bps: Decimal = Decimal(0)
+    ema_fast: int = 10
+    ema_slow: int = 40
+    donchian_entry: int = 20
+    donchian_exit: int = 10
+    max_hold_bars: int = 0  # 0 = no timeout exit
+    trend_tp_r: Decimal = Decimal(0)  # 0 = no TP leg; let winners run
+
     # WFO settings
     train_days: int = 90
     test_days: int = 30
@@ -239,6 +259,12 @@ class BacktestMetrics:
     total_fees: Decimal = Decimal(0)
     total_slippage: Decimal = Decimal(0)
     total_funding: Decimal = Decimal(0)
+
+    # Buy-and-hold benchmark over the identical candle window
+    benchmark_return_pct: Decimal = Decimal(0)
+    benchmark_max_drawdown_pct: Decimal = Decimal(0)
+    benchmark_sharpe_ratio: Decimal | None = None
+    excess_return_pct: Decimal = Decimal(0)
 
     # Runtime
     runtime_ms: int = 0

--- a/app/engine/tests/unit/backtest/test_metrics_benchmark.py
+++ b/app/engine/tests/unit/backtest/test_metrics_benchmark.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from decimal import Decimal
+import math
+
+import pytest
+
+from app.engine.backtest.metrics import MetricsCalculator, bars_per_year
+from app.engine.backtest.types import BacktestMetrics
+from app.engine.models import TimeFrame
+
+
+def _closes(values: list[str]) -> list[Decimal]:
+    return [Decimal(v) for v in values]
+
+
+class TestApplyBenchmark:
+    def test_benchmark_return_matches_first_to_last_close(self) -> None:
+        metrics = MetricsCalculator(timeframe=TimeFrame.D1).apply_benchmark(
+            BacktestMetrics(),
+            _closes(["100", "104", "96", "130"]),
+        )
+        assert metrics.benchmark_return_pct == Decimal(30)
+
+    def test_benchmark_max_drawdown_from_peak(self) -> None:
+        # Peak 120 -> trough 90 is a 25% drawdown; the later recovery to 110
+        # must not shrink it.
+        metrics = MetricsCalculator(timeframe=TimeFrame.D1).apply_benchmark(
+            BacktestMetrics(),
+            _closes(["100", "120", "90", "110"]),
+        )
+        assert metrics.benchmark_max_drawdown_pct == Decimal(25)
+
+    def test_benchmark_sharpe_uses_timeframe_annualization(self) -> None:
+        # Bar returns +10%, -10%, +10%: Sharpe must scale by sqrt(bars/year)
+        # of the DAILY crypto calendar (365), same as the strategy Sharpe.
+        closes = _closes(["100", "110", "99", "108.9"])
+        metrics = MetricsCalculator(timeframe=TimeFrame.D1).apply_benchmark(
+            BacktestMetrics(),
+            closes,
+        )
+        returns = [0.1, -0.1, 0.1]
+        mean = sum(returns) / len(returns)
+        std = math.sqrt(sum((r - mean) ** 2 for r in returns) / len(returns))
+        expected = mean / std * math.sqrt(bars_per_year(TimeFrame.D1))
+        assert metrics.benchmark_sharpe_ratio is not None
+        assert float(metrics.benchmark_sharpe_ratio) == pytest.approx(expected)
+
+    def test_excess_return_is_strategy_minus_benchmark(self) -> None:
+        metrics = BacktestMetrics(total_pnl_pct=Decimal(12))
+        MetricsCalculator(timeframe=TimeFrame.D1).apply_benchmark(
+            metrics,
+            _closes(["100", "130"]),
+        )
+        assert metrics.excess_return_pct == Decimal(-18)

--- a/app/engine/tests/unit/backtest/test_runner_trend_config.py
+++ b/app/engine/tests/unit/backtest/test_runner_trend_config.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from decimal import Decimal
+import json
+from pathlib import Path
+
+from app.engine.backtest.runner import BacktestRunner
+from app.engine.backtest.types import BacktestConfig, BacktestMetrics, BacktestResult
+
+
+def _config_path(tmp_path: Path, text: str) -> str:
+    path = tmp_path / "config.yaml"
+    path.write_text(text)
+    return str(path)
+
+
+def test_yaml_loads_trend_knobs_into_config(tmp_path: Path) -> None:
+    runner = BacktestRunner(
+        _config_path(
+            tmp_path,
+            "backtest:\n"
+            "  signal_source: price_sma\n"
+            "  allow_short: true\n"
+            "  atr_period: 20\n"
+            "  atr_stop_mult: 2.5\n"
+            "  sma_period: 65\n"
+            "  tsmom_lookback: 14\n"
+            "  tsmom_deadband_bps: 25\n"
+            "  ema_fast: 5\n"
+            "  ema_slow: 20\n"
+            "  donchian_entry: 10\n"
+            "  donchian_exit: 5\n"
+            "  max_hold_bars: 30\n"
+            "  trend_tp_r: 1.5\n",
+        ),
+    )
+
+    config = runner.config
+    loaded = (
+        config.signal_source,
+        config.allow_short,
+        config.atr_period,
+        config.atr_stop_mult,
+        config.sma_period,
+        config.tsmom_lookback,
+        config.tsmom_deadband_bps,
+        config.ema_fast,
+        config.ema_slow,
+        config.donchian_entry,
+        config.donchian_exit,
+        config.max_hold_bars,
+        config.trend_tp_r,
+    )
+    assert loaded == (
+        "price_sma",
+        True,
+        20,
+        Decimal("2.5"),
+        65,
+        14,
+        Decimal(25),
+        5,
+        20,
+        10,
+        5,
+        30,
+        Decimal("1.5"),
+    )
+
+
+def test_missing_trend_keys_default_to_smc_path(tmp_path: Path) -> None:
+    runner = BacktestRunner(
+        _config_path(tmp_path, "backtest:\n  warmup_bars: 50\n"),
+    )
+
+    defaults = BacktestConfig()
+    config = runner.config
+    assert (config.signal_source, config.allow_short) == ("smc_retest", False)
+    assert (config.sma_period, config.tsmom_lookback, config.trend_tp_r) == (
+        defaults.sma_period,
+        defaults.tsmom_lookback,
+        defaults.trend_tp_r,
+    )
+
+
+def test_report_json_includes_benchmark_and_signal_source(tmp_path: Path) -> None:
+    runner = BacktestRunner(
+        _config_path(tmp_path, "backtest:\n  signal_source: tsmom\n"),
+    )
+    result = BacktestResult(
+        config=runner.config,
+        metrics=BacktestMetrics(
+            total_pnl_pct=Decimal(12),
+            benchmark_return_pct=Decimal(30),
+            benchmark_max_drawdown_pct=Decimal(25),
+            benchmark_sharpe_ratio=Decimal("1.1"),
+            excess_return_pct=Decimal(-18),
+        ),
+    )
+    report_path = tmp_path / "report.json"
+
+    runner._save_json_report(result, report_path)
+    report = json.loads(report_path.read_text())
+
+    assert report["config"]["signal_source"] == "tsmom"
+    assert report["metrics"]["benchmark_return_pct"] == 30.0
+    assert report["metrics"]["benchmark_max_drawdown_pct"] == 25.0
+    assert report["metrics"]["benchmark_sharpe_ratio"] == 1.1
+    assert report["metrics"]["excess_return_pct"] == -18.0

--- a/app/engine/tests/unit/backtest/test_simulator_strategy_knobs.py
+++ b/app/engine/tests/unit/backtest/test_simulator_strategy_knobs.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+import app.engine.backtest.simulator as simulator_module
+from app.engine.backtest.simulator import BacktestSimulator
+from app.engine.backtest.types import BacktestConfig, OrderType
+
+from .series import make_candle
+
+
+def _signal(timestamp: datetime, *, entry: str, stop: str, direction: str = "LONG") -> dict[str, Any]:
+    e = Decimal(entry)
+    s = Decimal(stop)
+    risk = abs(e - s)
+    sign = Decimal(1) if direction == "LONG" else Decimal(-1)
+    return {
+        "venue": "SPOT",
+        "symbol": "BTCUSDT",
+        "timeframe": "15m",
+        "timestamp": timestamp,
+        "direction": direction,
+        "zone_id": "zone-1",
+        "zone_type": "OB_BULL",
+        "bos_level": e,
+        "entry": e,
+        "stop_loss": s,
+        "tp1": e + sign * risk * Decimal("1.5"),
+        "tp2": e + sign * risk * Decimal(2),
+        "tp3": e + sign * risk * Decimal(3),
+    }
+
+
+def _install_signal(monkeypatch: pytest.MonkeyPatch, sig: dict[str, Any], fire_at: datetime) -> None:
+    async def fake_analyze(**kwargs: Any) -> dict[str, Any] | None:
+        if kwargs["candles"][-1]["open_time"] == fire_at:
+            return dict(sig)  # fresh copy; sim mutates stop_loss in place
+        return None
+
+    monkeypatch.setattr(simulator_module, "analyze_retest", fake_analyze)
+
+
+def _ramp_candles(count: int, start: str, end: str) -> list:
+    """Linear price ramp so a slow EMA lags the last close in a known direction."""
+    s = Decimal(start)
+    e = Decimal(end)
+    out = []
+    for i in range(count):
+        px = s + (e - s) * Decimal(i) / Decimal(count - 1)
+        p = f"{px:.2f}"
+        out.append(make_candle(i, p, f"{px + 1:.2f}", f"{px - 1:.2f}", p))
+    return out
+
+
+class TestHtfTrendGate:
+    @pytest.mark.asyncio
+    async def test_downtrend_vetoes_long(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Falling prices → slow EMA sits ABOVE the last close → long is counter-trend.
+        candles = _ramp_candles(60, "130", "100")
+        _install_signal(monkeypatch, _signal(candles[-1].open_time, entry="100", stop="98"), candles[-1].open_time)
+        sim = BacktestSimulator(BacktestConfig(htf_ema_period=10, warmup_bars=50))
+
+        for c in candles:
+            await sim.process_candle(c)
+
+        market_orders = [o for o in sim.active_orders if o.type == OrderType.MARKET]
+        assert market_orders == [], "long against a downtrend must be vetoed by the HTF gate"
+
+    @pytest.mark.asyncio
+    async def test_uptrend_allows_long(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Rising prices → slow EMA sits BELOW the last close → long is trend-aligned.
+        candles = _ramp_candles(60, "70", "100")
+        _install_signal(monkeypatch, _signal(candles[-1].open_time, entry="100", stop="98"), candles[-1].open_time)
+        sim = BacktestSimulator(BacktestConfig(htf_ema_period=10, warmup_bars=50))
+
+        for c in candles:
+            await sim.process_candle(c)
+
+        market_orders = [o for o in sim.active_orders if o.type == OrderType.MARKET]
+        assert len(market_orders) == 1, "a trend-aligned long must pass the HTF gate"
+
+    @pytest.mark.asyncio
+    async def test_disabled_gate_allows_counter_trend(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        candles = _ramp_candles(60, "130", "100")
+        _install_signal(monkeypatch, _signal(candles[-1].open_time, entry="100", stop="98"), candles[-1].open_time)
+        sim = BacktestSimulator(BacktestConfig(htf_ema_period=0, warmup_bars=50))  # gate off
+
+        for c in candles:
+            await sim.process_candle(c)
+
+        assert len([o for o in sim.active_orders if o.type == OrderType.MARKET]) == 1
+
+    @pytest.mark.asyncio
+    async def test_strict_dual_ema_allows_when_stacked(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Rising ramp → close > fast EMA > slow EMA → strict long allowed.
+        candles = _ramp_candles(70, "70", "100")
+        _install_signal(monkeypatch, _signal(candles[-1].open_time, entry="100", stop="98"), candles[-1].open_time)
+        sim = BacktestSimulator(BacktestConfig(htf_ema_period=50, htf_ema_fast=10, warmup_bars=50))
+
+        for c in candles:
+            await sim.process_candle(c)
+
+        assert len([o for o in sim.active_orders if o.type == OrderType.MARKET]) == 1
+
+    @pytest.mark.asyncio
+    async def test_strict_dual_ema_vetoes_when_not_stacked(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Falling ramp → close < fast < slow → strict long vetoed.
+        candles = _ramp_candles(70, "130", "100")
+        _install_signal(monkeypatch, _signal(candles[-1].open_time, entry="100", stop="98"), candles[-1].open_time)
+        sim = BacktestSimulator(BacktestConfig(htf_ema_period=50, htf_ema_fast=10, warmup_bars=50))
+
+        for c in candles:
+            await sim.process_candle(c)
+
+        assert [o for o in sim.active_orders if o.type == OrderType.MARKET] == []
+
+
+class TestMinStopFloor:
+    @pytest.mark.asyncio
+    async def test_tight_stop_is_widened_to_floor(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Entry 100, structure stop only 10bps away; floor at 100bps (1%) must widen it to 99.0.
+        # Fire one bar before the end so the market entry fills and a position opens.
+        candles = _ramp_candles(56, "97", "100")
+        _install_signal(monkeypatch, _signal(candles[-2].open_time, entry="100", stop="99.9"), candles[-2].open_time)
+        sim = BacktestSimulator(BacktestConfig(min_stop_bps=Decimal(100), warmup_bars=50))
+
+        for c in candles:
+            await sim.process_candle(c)
+
+        assert sim.positions["BTCUSDT"].stop_loss == Decimal("99.0")
+
+    @pytest.mark.asyncio
+    async def test_wide_stop_is_untouched(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Structure stop already 2% away; a 1% floor must not move it.
+        candles = _ramp_candles(56, "97", "100")
+        _install_signal(monkeypatch, _signal(candles[-2].open_time, entry="100", stop="98"), candles[-2].open_time)
+        sim = BacktestSimulator(BacktestConfig(min_stop_bps=Decimal(100), warmup_bars=50))
+
+        for c in candles:
+            await sim.process_candle(c)
+
+        assert sim.positions["BTCUSDT"].stop_loss == Decimal("98")
+
+    @pytest.mark.asyncio
+    async def test_floor_improves_fee_to_risk(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # With the 10% notional cap binding in both cases the notional (and thus
+        # fee) is identical, but the floor's wider stop makes the trade RISK more
+        # per dollar of fees — the whole point. Assert risked_amount rises.
+        candles = _ramp_candles(56, "97", "100")
+
+        _install_signal(monkeypatch, _signal(candles[-2].open_time, entry="100", stop="99.9"), candles[-2].open_time)
+        floored = BacktestSimulator(BacktestConfig(min_stop_bps=Decimal(100), warmup_bars=50))
+        for c in candles:
+            await floored.process_candle(c)
+
+        _install_signal(monkeypatch, _signal(candles[-2].open_time, entry="100", stop="99.9"), candles[-2].open_time)
+        unfloored = BacktestSimulator(BacktestConfig(min_stop_bps=Decimal(0), warmup_bars=50))
+        for c in candles:
+            await unfloored.process_candle(c)
+
+        assert floored.positions["BTCUSDT"].risked_amount > unfloored.positions["BTCUSDT"].risked_amount

--- a/app/engine/tests/unit/backtest/test_simulator_trend_wiring.py
+++ b/app/engine/tests/unit/backtest/test_simulator_trend_wiring.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+import app.engine.backtest.simulator as simulator_module
+from app.engine.backtest.simulator import BacktestSimulator
+from app.engine.backtest.trend_signals import TrendTarget
+from app.engine.backtest.types import BacktestConfig, ExitReason, OrderType
+
+from .series import flat_candles, make_candle
+
+
+def _long(entry: str = "100", stop: str = "98") -> TrendTarget:
+    return TrendTarget(
+        desired="LONG",
+        entry=Decimal(entry),
+        stop_loss=Decimal(stop),
+        ready=True,
+    )
+
+
+def _short(entry: str = "100", stop: str = "102") -> TrendTarget:
+    return TrendTarget(
+        desired="SHORT",
+        entry=Decimal(entry),
+        stop_loss=Decimal(stop),
+        ready=True,
+    )
+
+
+def _flat() -> TrendTarget:
+    return TrendTarget(desired="FLAT", ready=True)
+
+
+class _ScriptedEngine:
+    """Replays a fixed target per bar; holds the last target once exhausted."""
+
+    def __init__(self, targets: list[TrendTarget]):
+        self._targets = list(targets)
+        self._index = 0
+
+    def on_bar(self, candle: Any) -> TrendTarget:
+        target = self._targets[min(self._index, len(self._targets) - 1)]
+        self._index += 1
+        return target
+
+
+def _install_engine(monkeypatch: pytest.MonkeyPatch, targets: list[TrendTarget]) -> None:
+    monkeypatch.setattr(
+        simulator_module,
+        "create_trend_engine",
+        lambda config: _ScriptedEngine(targets),
+    )
+
+
+def _trend_config(**overrides: Any) -> BacktestConfig:
+    defaults: dict[str, Any] = {
+        "signal_source": "price_sma",
+        "slippage_bps": Decimal(0),
+    }
+    defaults.update(overrides)
+    return BacktestConfig(**defaults)
+
+
+async def _run(sim: BacktestSimulator, candles: list) -> None:
+    for candle in candles:
+        await sim.process_candle(candle)
+
+
+class TestTrendEntry:
+    @pytest.mark.asyncio
+    async def test_trend_source_places_market_entry_with_stop_only_bracket(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _install_engine(monkeypatch, [_long()])
+        sim = BacktestSimulator(_trend_config())
+
+        await _run(sim, flat_candles(3))
+
+        position = sim.positions["BTCUSDT"]
+        assert position.side == "LONG"
+        assert position.quantity > 0
+        assert position.stop_loss == Decimal(98)
+        assert position.take_profit is None
+        resting = [(o.type, o.reduce_only) for o in sim.active_orders]
+        assert resting == [(OrderType.STOP_MARKET, True)]
+
+    @pytest.mark.asyncio
+    async def test_trend_source_skips_smc_engine_and_analyze_retest(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _install_engine(monkeypatch, [_long()])
+        calls = {"retest": 0, "smc": 0}
+
+        async def counting_retest(**kwargs: Any) -> None:
+            calls["retest"] += 1
+            return None
+
+        monkeypatch.setattr(simulator_module, "analyze_retest", counting_retest)
+        sim = BacktestSimulator(_trend_config(warmup_bars=1))
+
+        async def counting_smc(candle: Any, emit_events: bool = True) -> None:
+            calls["smc"] += 1
+
+        sim.smc_engine.process_candle = counting_smc  # type: ignore[method-assign]
+
+        await _run(sim, flat_candles(60))
+
+        assert calls == {"retest": 0, "smc": 0}
+
+    @pytest.mark.asyncio
+    async def test_trend_tp_r_positive_places_limit_tp_with_oco(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # risk = 2, trend_tp_r = 1.5 -> TP at 103; TP and stop are OCO-paired.
+        _install_engine(monkeypatch, [_long()])
+        sim = BacktestSimulator(_trend_config(trend_tp_r=Decimal("1.5")))
+
+        await _run(sim, flat_candles(3))
+
+        stop = next(o for o in sim.active_orders if o.type == OrderType.STOP_MARKET)
+        tp = next(o for o in sim.active_orders if o.type == OrderType.LIMIT)
+        assert stop.stop_price == Decimal(98)
+        assert tp.price == Decimal(103)
+        assert sim._oco_pairs[stop.id] == tp.id
+        assert sim._oco_pairs[tp.id] == stop.id
+        assert sim.positions["BTCUSDT"].take_profit == Decimal(103)
+
+    @pytest.mark.asyncio
+    async def test_htf_gate_still_vetoes_counter_trend_entries(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Falling prices keep the slow EMA above the close, so the scripted
+        # LONG target must be vetoed by the reused trend-alignment gate.
+        _install_engine(monkeypatch, [_long()])
+        sim = BacktestSimulator(_trend_config(htf_ema_period=10))
+        candles = []
+        for i in range(40):
+            px = Decimal(130) - Decimal(i)
+            candles.append(
+                make_candle(i, str(px), str(px + 1), str(px - 1), str(px)),
+            )
+
+        await _run(sim, candles)
+
+        assert sim.positions == {}
+        assert sim.active_orders == []
+
+
+class TestFlipAndClose:
+    @pytest.mark.asyncio
+    async def test_flip_cancels_brackets_closes_then_reverses_next_bar(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _install_engine(monkeypatch, [_long(), _long(), _short(), _short(), _short()])
+        sim = BacktestSimulator(_trend_config(allow_short=True))
+        candles = flat_candles(5)
+
+        await _run(sim, candles[:3])
+        # At the flip bar the close order must be queued BEFORE the reverse
+        # entry, or the entry hits the netting-unsupported branch on fill.
+        market_orders = [o for o in sim.active_orders if o.type == OrderType.MARKET]
+        assert [(o.reduce_only, o.side.value) for o in market_orders] == [
+            (True, "SELL"),
+            (False, "SELL"),
+        ]
+        assert all(o.type != OrderType.STOP_MARKET for o in sim.active_orders)
+
+        await _run(sim, candles[3:])
+        assert sim.positions["BTCUSDT"].side == "SHORT"
+        assert [t.side for t in sim.completed_trades] == ["long"]
+
+    @pytest.mark.asyncio
+    async def test_flip_close_records_exit_reason_flip(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _install_engine(monkeypatch, [_long(), _long(), _short(), _short()])
+        sim = BacktestSimulator(_trend_config(allow_short=True))
+
+        await _run(sim, flat_candles(4))
+
+        assert [t.exit_reason for t in sim.completed_trades] == [ExitReason.FLIP]
+
+    @pytest.mark.asyncio
+    async def test_allow_short_false_closes_long_without_reversing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Default long/cash mode: a SHORT target degrades to FLAT — the long
+        # is closed but no short entry may ever be placed.
+        _install_engine(monkeypatch, [_long(), _long(), _short(), _short()])
+        sim = BacktestSimulator(_trend_config())
+
+        await _run(sim, flat_candles(5))
+
+        assert [t.exit_reason for t in sim.completed_trades] == [ExitReason.FLIP]
+        assert sim.positions["BTCUSDT"].side is None
+        assert sim.active_orders == []
+        assert all(t.side == "long" for t in sim.completed_trades)
+
+    @pytest.mark.asyncio
+    async def test_stale_stop_cannot_double_fill_after_flip_close(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # After the flip-close cancels the brackets, a bar sweeping the old
+        # stop level (98) must not produce a second exit fill: the phantom fee
+        # would show up as sim.total_fees > the single trade's fees.
+        _install_engine(monkeypatch, [_long(), _long(), _flat(), _flat()])
+        sim = BacktestSimulator(_trend_config())
+        candles = flat_candles(3)
+        candles.append(make_candle(3, "100", "100.5", "97", "100"))
+
+        await _run(sim, candles)
+
+        assert len(sim.completed_trades) == 1
+        assert sim.total_fees == sim.completed_trades[0].fees
+        assert sim.active_orders == []
+
+    @pytest.mark.asyncio
+    async def test_max_hold_bars_closes_position_with_timeout_reason(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _install_engine(monkeypatch, [_long()])
+        sim = BacktestSimulator(_trend_config(max_hold_bars=2))
+
+        await _run(sim, flat_candles(5))
+
+        assert sim.completed_trades, "the timeout must have closed the position"
+        assert sim.completed_trades[0].exit_reason == ExitReason.TIMEOUT
+
+
+class TestGuardsAndDefaults:
+    @pytest.mark.asyncio
+    async def test_default_config_still_runs_smc_retest_path(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        calls = {"retest": 0}
+
+        async def counting_retest(**kwargs: Any) -> None:
+            calls["retest"] += 1
+            return None
+
+        monkeypatch.setattr(simulator_module, "analyze_retest", counting_retest)
+        sim = BacktestSimulator(BacktestConfig())
+
+        await _run(sim, flat_candles(55))
+
+        assert sim._trend_engine is None
+        assert calls["retest"] > 0
+
+    def test_invert_signals_with_trend_source_raises(self) -> None:
+        with pytest.raises(ValueError, match="invert_signals"):
+            BacktestSimulator(
+                BacktestConfig(signal_source="price_sma", invert_signals=True),
+            )

--- a/app/engine/tests/unit/backtest/test_trend_signal_engine.py
+++ b/app/engine/tests/unit/backtest/test_trend_signal_engine.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+from collections import deque
+from decimal import Decimal
+
+import pytest
+
+from app.engine.backtest.trend_signals import (
+    TrendTarget,
+    _StreamingAtr,
+    create_trend_engine,
+)
+from app.engine.backtest.types import BacktestConfig
+from app.engine.features.indicators import TechnicalIndicatorsCalculator
+
+from .series import make_candle
+
+# high = close+2, low = close-2 with |close step| <= 2 keeps every Wilder TR
+# pinned at 4, so ATR stays exactly 4 and stop math is exact in assertions.
+_PINNED_ATR = Decimal(4)
+
+
+def _banded_candles(closes: list[str]) -> list:
+    out = []
+    for i, close in enumerate(closes):
+        c = Decimal(close)
+        out.append(make_candle(i, str(c), str(c + 2), str(c - 2), str(c)))
+    return out
+
+
+def _ramp(start: int, step: int, count: int) -> list[str]:
+    return [str(start + step * i) for i in range(count)]
+
+
+def _run(engine, candles) -> list[TrendTarget]:
+    return [engine.on_bar(c) for c in candles]
+
+
+class TestPriceSmaEngine:
+    def _engine(self):
+        return create_trend_engine(
+            BacktestConfig(
+                signal_source="price_sma",
+                sma_period=4,
+                atr_period=3,
+                atr_stop_mult=Decimal(2),
+            ),
+        )
+
+    def test_price_sma_long_when_close_above_sma(self) -> None:
+        # Rising ramp: last close 108 > SMA4(105..108) = 106.5 -> long/cash rule fires.
+        targets = _run(self._engine(), _banded_candles(_ramp(100, 1, 9)))
+        assert targets[-1] == TrendTarget(
+            desired="LONG",
+            entry=Decimal(108),
+            stop_loss=Decimal(108) - Decimal(2) * _PINNED_ATR,
+            ready=True,
+        )
+
+    def test_price_sma_flat_when_close_below_sma(self) -> None:
+        # Falling ramp: close < SMA -> exit to cash; the engine must never
+        # emit SHORT (the evidenced form is long/cash).
+        targets = _run(self._engine(), _banded_candles(_ramp(110, -1, 9)))
+        assert targets[-1] == TrendTarget(
+            desired="FLAT",
+            entry=None,
+            stop_loss=None,
+            ready=True,
+        )
+        assert all(t.desired in {"LONG", "FLAT"} for t in targets)
+
+
+class TestTsmomEngine:
+    def _engine(self, deadband_bps: int = 0):
+        return create_trend_engine(
+            BacktestConfig(
+                signal_source="tsmom",
+                tsmom_lookback=4,
+                tsmom_deadband_bps=Decimal(deadband_bps),
+                atr_period=3,
+                atr_stop_mult=Decimal(2),
+            ),
+        )
+
+    def test_tsmom_goes_long_after_positive_trailing_return(self) -> None:
+        targets = _run(self._engine(), _banded_candles(_ramp(100, 1, 8)))
+        assert targets[-1] == TrendTarget(
+            desired="LONG",
+            entry=Decimal(107),
+            stop_loss=Decimal(107) - Decimal(2) * _PINNED_ATR,
+            ready=True,
+        )
+
+    def test_tsmom_deadband_holds_previous_state_in_chop(self) -> None:
+        # Strong rise establishes LONG, then a flat stretch puts the trailing
+        # return inside the 1% dead-band: hysteresis keeps the LONG state.
+        closes = _ramp(100, 2, 6) + ["110"] * 4
+        targets = _run(self._engine(deadband_bps=100), _banded_candles(closes))
+        assert targets[-1].desired == "LONG"
+
+    def test_tsmom_not_ready_before_lookback_filled(self) -> None:
+        # A trailing 4-bar return needs 5 closes; the first 4 bars must stay silent.
+        targets = _run(self._engine(), _banded_candles(_ramp(100, 1, 4)))
+        assert all(
+            t == TrendTarget(desired="FLAT", entry=None, stop_loss=None, ready=False)
+            for t in targets
+        )
+
+
+class TestEmaCrossEngine:
+    def _engine(self):
+        return create_trend_engine(
+            BacktestConfig(
+                signal_source="ema_cross",
+                ema_fast=3,
+                ema_slow=6,
+                atr_period=3,
+                atr_stop_mult=Decimal(2),
+            ),
+        )
+
+    def test_ema_cross_flips_short_when_fast_crosses_below(self) -> None:
+        # Rise then a hard fall: the fast EMA crosses below the slow EMA.
+        closes = _ramp(100, 2, 8) + _ramp(112, -2, 8)
+        targets = _run(self._engine(), _banded_candles(closes))
+        last_close = Decimal(closes[-1])
+        assert targets[-1] == TrendTarget(
+            desired="SHORT",
+            entry=last_close,
+            stop_loss=last_close + Decimal(2) * _PINNED_ATR,
+            ready=True,
+        )
+
+    def test_ema_cross_stop_is_k_atr_below_entry(self) -> None:
+        targets = _run(self._engine(), _banded_candles(_ramp(100, 2, 10)))
+        last_close = Decimal("118")
+        assert targets[-1] == TrendTarget(
+            desired="LONG",
+            entry=last_close,
+            stop_loss=last_close - Decimal(2) * _PINNED_ATR,
+            ready=True,
+        )
+
+
+class TestDonchianEngine:
+    def _engine(self):
+        return create_trend_engine(
+            BacktestConfig(
+                signal_source="donchian",
+                donchian_entry=4,
+                donchian_exit=2,
+                atr_period=3,
+                atr_stop_mult=Decimal(2),
+            ),
+        )
+
+    def test_donchian_breaks_prior_n_bar_high_excluding_current(self) -> None:
+        # Six flat bars pin the prior 4-bar high at 102; the breakout close
+        # 102.5 clears it. Were the current bar's own high (104.5) wrongly
+        # included in the channel, no breakout would register.
+        candles = _banded_candles(["100"] * 6 + ["102.5"])
+        engine = self._engine()
+        targets = _run(engine, candles)
+        breakout_tr = max(
+            Decimal(4),  # high-low of the breakout bar
+            abs(Decimal("104.5") - Decimal(100)),
+            abs(Decimal("100.5") - Decimal(100)),
+        )
+        expected_atr = (_PINNED_ATR * 2 + breakout_tr) / 3
+        assert targets[-1] == TrendTarget(
+            desired="LONG",
+            entry=Decimal("102.5"),
+            stop_loss=Decimal("102.5") - Decimal(2) * expected_atr,
+            ready=True,
+        )
+        assert all(t.desired == "FLAT" for t in targets[:-1])
+
+    def test_donchian_exits_on_exit_channel_break_not_entry_channel(self) -> None:
+        # Turtle asymmetry: the LONG exits when close breaks the prior 2-bar
+        # low (98) even though it stays above the prior 4-bar low (90). The
+        # exit must not flip to SHORT (95 is above the entry channel's low).
+        bars = [
+            ("100", "102", "90", "100"),
+            ("100", "102", "90", "100"),
+            ("100", "102", "98", "100"),
+            ("100", "102", "98", "100"),
+            ("103", "104", "101", "103"),  # close > prior 4-bar high 102 -> LONG
+            ("95", "96", "94", "95"),  # close < prior 2-bar low 98 -> FLAT
+        ]
+        candles = [make_candle(i, *bar) for i, bar in enumerate(bars)]
+        engine = self._engine()
+        targets = _run(engine, candles)
+        assert targets[-2].desired == "LONG"
+        assert targets[-1].desired == "FLAT"
+
+
+class TestStreamingAtr:
+    def test_streaming_atr_matches_indicators_batch_atr(self) -> None:
+        # Parity invariant against the batch Wilder ATR on an irregular walk.
+        closes = [
+            "100",
+            "103",
+            "99",
+            "104",
+            "101",
+            "108",
+            "107",
+            "95",
+            "102",
+            "110",
+            "109",
+            "111",
+            "104",
+            "106",
+            "113",
+            "112",
+            "108",
+            "115",
+            "114",
+            "118",
+        ]
+        candles = []
+        for i, close in enumerate(closes):
+            c = Decimal(close)
+            candles.append(
+                make_candle(i, str(c), str(c + 3 + (i % 4)), str(c - 2 - (i % 3)), str(c)),
+            )
+        period = 14
+        batch = TechnicalIndicatorsCalculator.atr(candles, period=period)
+        streaming_atr = _StreamingAtr(period)
+        streamed = [streaming_atr.update(c) for c in candles]
+        assert streamed == batch
+
+
+class TestEngineHousekeeping:
+    @pytest.mark.parametrize(
+        "source",
+        ["price_sma", "tsmom", "ema_cross", "donchian"],
+    )
+    def test_engine_memory_stays_bounded_at_lookback(self, source: str) -> None:
+        # Every internal buffer must be a bounded deque; 300 bars through a
+        # <=6-bar-lookback engine cannot grow state.
+        engine = create_trend_engine(
+            BacktestConfig(
+                signal_source=source,
+                sma_period=5,
+                tsmom_lookback=5,
+                ema_fast=3,
+                ema_slow=6,
+                donchian_entry=5,
+                donchian_exit=3,
+                atr_period=3,
+            ),
+        )
+        for c in _banded_candles(["100"] * 300):
+            engine.on_bar(c)
+        buffers = [
+            value
+            for holder in (engine, *vars(engine).values())
+            if hasattr(holder, "__dict__")
+            for value in vars(holder).values()
+            if isinstance(value, deque)
+        ]
+        assert buffers, "expected at least one internal deque buffer"
+        assert all(b.maxlen is not None and len(b) <= b.maxlen for b in buffers)
+
+    def test_factory_raises_on_unknown_signal_source(self) -> None:
+        with pytest.raises(ValueError, match="signal_source"):
+            create_trend_engine(BacktestConfig(signal_source="astrology"))

--- a/docs/plans/2026-07-09-signal-family-v3-trend-experiment.md
+++ b/docs/plans/2026-07-09-signal-family-v3-trend-experiment.md
@@ -1,0 +1,197 @@
+# Signal Family v3 — Trend-Continuation Experiment Plan
+
+**Date:** 2026-07-09 (rev 2, post-research) · **Status:** PLANNED (not implemented)
+**Branch (when implemented):** `exp/trend-signals-v3`
+**Synthesis of:** Claude plan + independent architect counter-plan (verified mechanics against actual code; Codex quota-blocked) + crypto signal-family deep-research (`docs/reviews/2026-07-09-crypto-signal-families-research.md`, 20 claims verified 3-0).
+
+---
+
+## 1. Overview
+
+Add a config-selectable **trend-following signal source** to the backtest engine beside the existing SMC retest signal. `signal_source` selects one of: `"smc_retest"` (default — **SMC stays as the control arm and remains fully selectable**), `"price_sma"`, `"tsmom"`, `"ema_cross"`, `"donchian"`. The trend engines are self-contained streaming state machines in a new `app/engine/backtest/trend_signals.py`; the simulator diffs each engine's _desired state_ against the open position (flip-close via reduce-only MARKET order, then reverse where allowed), while the entire existing gate/size/bracket chain (`_trend_allows` → min-stop floor → policies → `size_with_exposure_caps` → pretrade risk → cooldown → brackets) is reused untouched. Every run reports **buy-and-hold benchmark metrics + excess return**.
+
+**Research-driven framing (rev 2):** the evidenced configuration is **long-only (long/cash), DAILY bars, multi-week lookbacks**. Its realistic payoff is _drawdown reduction at roughly buy-and-hold returns_ (OOS template: Sharpe 1.11 vs 1.13, maxDD 52% vs 62%), net Sharpe plausibly 0.5–1.0. The short side of crypto momentum loses in 19/20 studied combos pre-cost, so long/short runs are a **diagnostic, not the GO bar**. No verified evidence supports 15m-class trend rules; 1h has partial support only.
+
+Why the pivot: the SMC retest arm has measured negative gross edge (−23%/2yr baseline; −5% with execution fixes; audit: strategy-not-code). Trend-following is the one family with top-journal, net-of-cost-surviving support on BTC/ETH (Liu & Tsyvinski RFS 2021; Hudson & Urquhart breakeven costs 57–66 bps vs our ~10 bps fees).
+
+## 2. Key design decisions (with rationale)
+
+1. **Desired-state, not edge-triggered**: engines emit `TrendTarget {desired: LONG|SHORT|FLAT, entry, stop_loss, ready}` **every bar**; the simulator diffs against the actual position. Self-healing when a risk gate blocks an entry.
+2. **No fills.py changes** (verified by code trace): a reduce-only MARKET order already fills at next-bar open + slippage, takes the no-bracket fall-through in `_execute_fill`, and lands in side-agnostic `_close_position`.
+3. **Cancel resting brackets at flip-submission time** — else a bar touching the old stop double-fills and charges a **phantom fee** (fee is unconditional at the top of `_execute_fill`). New `_cancel_position_brackets(symbol)`.
+4. **Ordering invariant**: on flip-and-reverse, the close order must be appended **before** the reverse entry, or the entry hits the "netting unsupported" branch (fees charged, brackets orphaned). Regression-tested.
+5. **Optional TP leg** (~6 lines): `_BracketSpec.take_profit: Decimal | None`; skip LIMIT leg + OCO registration when None. Default `trend_tp_r = 0` — let winners run.
+6. **Own streaming state per engine** — bounded deques + O(1) Wilder ATR (parity-tested vs batch calculator). The shared 200-candle deque is too short and `_calculate_features`/SMCEngine are skipped on the trend path.
+7. **Exits**: flip-close (`ExitReason.FLIP` via `_exit_reason_overrides` consulted in `_execute_fill`) + optional `max_hold_bars` timeout. Donchian uses turtle asymmetric entry/exit channels. **ATR trailing deferred to phase 2.**
+8. **Regime gate reused**: existing `htf_ema_period`/`htf_ema_fast` EMA-stack gate applies for free. ADX/HMM deferred — zero verified claims survived for regime filters (open question, not disproof).
+9. **Guard**: `invert_signals=True` + trend source → `ValueError` (SMC-only diagnostic; `tp1` may be None on trend arm).
+10. **Ex-ante parameters from the verified literature** (no tuning): price-vs-SMA 20d/65d/200d; SMA/EMA cross 10/40d; TSMOM 28d; Donchian 20d/10d (turtle); 2×ATR stops. ±50% sensitivity is robustness _reporting_ only. Low turnover + maker fees explicitly favored (short lookbacks bleed the most Sharpe to costs).
+11. **Inverse-vol sizing falls out free**: fixed-fractional risk + ATR stop ⇒ qty ∝ 1/ATR. (Vol-managed literature: helps in-sample, doesn't fix power-law tails — reported, not oversold.)
+
+## 3. Config knobs (`BacktestConfig`, flat; defaults preserve SMC behavior; lookbacks in BARS, defaults oriented to the primary 1d arm — 1h configs must scale ×24)
+
+```python
+signal_source: str = "smc_retest"   # "smc_retest" | "price_sma" | "tsmom" | "ema_cross" | "donchian"
+allow_short: bool = False           # long/cash is the evidenced form; long/short is a diagnostic
+atr_period: int = 14
+atr_stop_mult: Decimal = Decimal(2) # turtle 2N initial stop
+sma_period: int = 200               # price-vs-SMA long/cash rule (20/65/200d menu)
+tsmom_lookback: int = 28            # 28d TSM (Han et al. — flagged in-sample-optimal; report honestly)
+tsmom_deadband_bps: Decimal = Decimal(0)  # hysteresis inside dead-band
+ema_fast: int = 10                  # 10/40d cross (consistent gross performer)
+ema_slow: int = 40
+donchian_entry: int = 20            # 20d/10d turtle channels
+donchian_exit: int = 10
+max_hold_bars: int = 0              # 0 = off
+trend_tp_r: Decimal = Decimal(0)    # 0 = no TP; let winners run
+```
+
+Plus `ExitReason.FLIP = "flip"`, and on `BacktestMetrics`: `benchmark_return_pct`, `benchmark_max_drawdown_pct`, `benchmark_sharpe_ratio`, `excess_return_pct` (defaulted → serializer-safe). `bars_per_year(D1)=365` already correct for 24/7 crypto.
+
+## 4. Data prep (new step, research-driven)
+
+- **Fetch ~7 years of daily klines** via the existing Binance downloader (`download.py`): `btcusdt_1d.csv`, `ethusdt_1d.csv`, 2019-01-01 → 2026-06-30. Rationale: resampling our 2-yr 1h data leaves only ~530 tradable daily bars after a 200d warmup and **contains no full bear market** — the drawdown-protection claim (the whole point of the family) is only testable across 2021–22.
+- Keep existing 2-yr 1h CSVs for the secondary arm. 15m dropped (no supporting evidence at retail fees).
+
+## 5. Files to change
+
+| File                                                            | Change                                                                                                                                                                                                                                             |
+| --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `app/engine/backtest/trend_signals.py`                          | **NEW** — `TrendTarget`, `_StreamingAtr`, `PriceSmaEngine`, `TsmomEngine`, `EmaCrossEngine`, `DonchianEngine`, `create_trend_engine` (ValueError on unknown source)                                                                                |
+| `app/engine/backtest/types.py`                                  | knobs above, `ExitReason.FLIP`, 4 benchmark metric fields                                                                                                                                                                                          |
+| `app/engine/backtest/simulator.py`                              | trend branch in `process_candle` (SMC branch byte-identical), `_apply_trend_target`, `_build_trend_signal`, `_submit_position_close`, `_cancel_position_brackets`, `_check_max_hold`, optional-TP bracket, exit-reason override, constructor guard |
+| `app/engine/backtest/metrics.py`                                | `MetricsCalculator.apply_benchmark(metrics, closes)`                                                                                                                                                                                               |
+| `app/engine/backtest/runner.py`                                 | knob parsing, collect closes in `_run_simulation`, apply benchmark, serialize + log excess                                                                                                                                                         |
+| `app/engine/tests/unit/backtest/test_trend_signal_engine.py`    | **NEW** — pure engine tests                                                                                                                                                                                                                        |
+| `app/engine/tests/unit/backtest/test_simulator_trend_wiring.py` | **NEW** — simulator integration                                                                                                                                                                                                                    |
+| `app/engine/tests/unit/backtest/test_metrics_benchmark.py`      | **NEW**                                                                                                                                                                                                                                            |
+| `app/engine/tests/unit/backtest/test_runner_trend_config.py`    | **NEW**                                                                                                                                                                                                                                            |
+| `reports/backtest/strategies/v3-*.yaml`                         | **NEW** ex-ante configs (see matrix)                                                                                                                                                                                                               |
+| `scripts/analyze_strategy_runs.py`                              | read benchmark fields when present (same B&H convention)                                                                                                                                                                                           |
+
+## 6. Functions
+
+**trend_signals.py**
+
+- `TrendTarget` — frozen dataclass: `desired`, `entry`, `stop_loss`, `ready`.
+- `_StreamingAtr.update(candle) -> Decimal | None` — O(1) Wilder ATR, seeded with simple mean of first N TRs (parity with `TechnicalIndicatorsCalculator`).
+- `PriceSmaEngine.on_bar(candle) -> TrendTarget` — rolling SMA over `sma_period` closes; desired LONG when close > SMA else FLAT (never SHORT — the evidenced long/cash rule).
+- `TsmomEngine.on_bar` — trailing `tsmom_lookback`-bar return vs dead-band with hysteresis.
+- `EmaCrossEngine.on_bar` — streaming fast/slow EMAs; LONG when fast>slow; ready after `ema_slow` bars.
+- `DonchianEngine.on_bar` — entry/exit channels from bounded deques, current bar excluded; turtle asymmetric exits; SHORT states allowed (simulator enforces `allow_short`).
+- `create_trend_engine(config)` — factory keyed on `signal_source`.
+
+**simulator.py**
+
+- `process_candle` — SMC branch verbatim when `signal_source == "smc_retest"`; else `_check_max_hold` → `engine.on_bar` → `_apply_trend_target` (SMCEngine + `analyze_retest` skipped).
+- `_apply_trend_target(target, candle)` — SHORT degrades to FLAT when `allow_short=False`; side mismatch → `_submit_position_close(FLIP)`; then `_build_trend_signal` → existing `_execute_signal`.
+- `_build_trend_signal(target, candle) -> dict` — retest-shaped dict; `zone_id=f"trend-{signal_source}"`; `tp1=None` when `trend_tp_r==0`.
+- `_submit_position_close(symbol, reason, candle)` — duplicate-pending-close guard; `_cancel_position_brackets`; reduce-only MARKET sized to position; record exit-reason override.
+- `_cancel_position_brackets(symbol)` — cancel resting STOP/LIMIT legs, clean `_oco_pairs`.
+- `_check_max_hold(candle)` — timeout close from `position.opened_at` + `_BAR_MINUTES`.
+- `_execute_fill` — `reason = self._exit_reason_overrides.pop(order.id, None) or _EXIT_REASONS.get(...)`.
+
+**metrics.py / runner.py**
+
+- `apply_benchmark(metrics, closes)` — B&H equity `initial × close_i/close_0`; sets 4 fields incl. `excess_return_pct`; same annualization factor as strategy Sharpe.
+- Runner: collect `(close_time, close_price)` during `_run_simulation` (runner sees every raw candle; simulator stays pure), apply benchmark, serialize, log.
+
+## 7. Test coverage (TDD — failing tests first)
+
+**test_trend_signal_engine.py** (pure)
+
+- `test_price_sma_long_when_close_above_sma` — long/cash rule fires
+- `test_price_sma_flat_when_close_below_sma` — exits to cash, never SHORT
+- `test_tsmom_goes_long_after_positive_trailing_return`
+- `test_tsmom_deadband_holds_previous_state_in_chop` — hysteresis
+- `test_tsmom_not_ready_before_lookback_filled` — warmup silence
+- `test_ema_cross_flips_short_when_fast_crosses_below`
+- `test_ema_cross_stop_is_k_atr_below_entry` — exact stop math
+- `test_donchian_breaks_prior_n_bar_high_excluding_current`
+- `test_donchian_exits_on_exit_channel_break_not_entry_channel` — turtle asymmetry
+- `test_streaming_atr_matches_indicators_batch_atr` — parity invariant
+- `test_engine_memory_stays_bounded_at_lookback`
+- `test_factory_raises_on_unknown_signal_source`
+
+**test_simulator_trend_wiring.py** (idioms from `test_simulator_strategy_knobs.py`)
+
+- `test_trend_source_places_market_entry_with_stop_only_bracket`
+- `test_trend_source_skips_smc_engine_and_analyze_retest`
+- `test_flip_cancels_brackets_closes_then_reverses_next_bar` — ordering invariant
+- `test_flip_close_records_exit_reason_flip`
+- `test_allow_short_false_closes_long_without_reversing` — long/cash degrade
+- `test_stale_stop_cannot_double_fill_after_flip_close` — phantom-fee regression
+- `test_max_hold_bars_closes_position_with_timeout_reason`
+- `test_trend_tp_r_positive_places_limit_tp_with_oco`
+- `test_htf_gate_still_vetoes_counter_trend_entries`
+- `test_default_config_still_runs_smc_retest_path` — SMC regression guard
+- `test_invert_signals_with_trend_source_raises`
+
+**test_metrics_benchmark.py**
+
+- `test_benchmark_return_matches_first_to_last_close` · `test_benchmark_max_drawdown_from_peak` · `test_benchmark_sharpe_uses_timeframe_annualization` · `test_excess_return_is_strategy_minus_benchmark`
+
+**test_runner_trend_config.py**
+
+- `test_yaml_loads_trend_knobs_into_config` · `test_missing_trend_keys_default_to_smc_path` · `test_report_json_includes_benchmark_and_signal_source`
+
+## 8. Wiring verification
+
+| New export                                             | Imported by                                                                  | Called from (runtime)                                      |
+| ------------------------------------------------------ | ---------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `create_trend_engine`                                  | `simulator.py`                                                               | `__init__` when `signal_source != "smc_retest"`            |
+| `*Engine.on_bar`                                       | via factory                                                                  | `process_candle` trend branch, every closed bar            |
+| `TrendTarget`                                          | `simulator.py`, tests                                                        | consumed by `_apply_trend_target`                          |
+| `_apply_trend_target` / `_build_trend_signal`          | internal                                                                     | `process_candle` → existing `_execute_signal`              |
+| `_submit_position_close` / `_cancel_position_brackets` | internal                                                                     | flip + `_check_max_hold`                                   |
+| `ExitReason.FLIP`                                      | `simulator.py`                                                               | override dict → `_execute_fill` → trades.csv `exit_reason` |
+| `_BracketSpec.take_profit: Decimal \| None`            | internal                                                                     | `_place_bracket_orders` skips TP leg                       |
+| `apply_benchmark`                                      | `runner.py`                                                                  | `run_backtest` after `calculate_metrics`                   |
+| benchmark fields                                       | `runner.py`, `serializers.py` (attr-by-name, additive-safe), analysis script | JSON report + CLI log                                      |
+| new knobs                                              | `runner.py` `_load_config` → constructors                                    | engines/branches                                           |
+
+Dead-end check: every new export has a runtime caller; `trail_*` fields deliberately stay dead (phase 2).
+
+## 9. Experiment matrix + GO/NO-GO (rev 2 — research-aligned)
+
+**Primary arm — daily bars, long/cash (`allow_short: false`), 2019→2026 (covers the 2021–22 bear):**
+
+| Config         | Rule                  | Lookback                                |
+| -------------- | --------------------- | --------------------------------------- |
+| v3-sma200      | price > SMA else cash | 200d                                    |
+| v3-sma65       | 〃                    | 65d                                     |
+| v3-sma20       | 〃                    | 20d (cost-fragile — expected worst net) |
+| v3-cross-10-40 | EMA cross             | 10/40d                                  |
+| v3-tsmom28     | trailing-return sign  | 28d                                     |
+| v3-donch-20-10 | turtle channels       | 20d/10d                                 |
+
+× {BTCUSDT, ETHUSDT} × costs {taker 10 bps, maker 4 bps} → 24 runs (fast: ~2.7k daily bars each).
+
+**Diagnostic arm:** best daily config with `allow_short: true` — literature predicts the short leg _loses_; if it profits, suspect an implementation bug before celebrating.
+**Secondary arm:** best 2 configs on 1h (2024→2026, lookbacks ×24) — partial evidence only (Borgards, ≤2019).
+**Control arm:** rerun s3/s4 SMC configs over the identical windows.
+**Sensitivity:** ±50% primary lookback per family — robustness reporting only, never selection.
+
+**GO** (per symbol, primary arm): net Sharpe ≥ 0.9 × B&H Sharpe **AND** maxDD ≤ 0.8 × B&H maxDD **AND** net total return ≥ 0.75 × B&H **AND** result does not flip sign across ±50% sensitivity. Report trade count N prominently (daily trend rules trade rarely; expect wide CIs).
+**NO-GO**: fails the above on either symbol, or only the cost-fragile short lookbacks pass (cost artifact), or the 2021–22 bear segment shows no drawdown protection (the family's entire value proposition).
+**Expectation set ex-ante** (so we can't move goalposts): net Sharpe 0.5–1.0, return ≈ B&H, maxDD materially lower, ≥1 losing year, decay risk — no verified academic sample extends past Aug 2023, so our 2024–26 segment is novel evidence either way.
+
+## 10. Risks + rollback
+
+1. **Stale-bracket double fill / phantom fee** — brackets cancelled synchronously at flip submission; regression test.
+2. **Flip ordering** — close before reverse entry; regression test.
+3. **Re-entry churn after stop-out** — desired-state re-enters next bar if the engine still says LONG; honest but fee-heavy in chop; dead-band + fee reporting surface it; no tuning knob added ex-ante.
+4. **Lookback/timeframe confusion** — knobs in bars, defaults for 1d; 1h configs must scale ×24 (YAML comments; absurd trade counts caught in report sanity checks).
+5. **SMC default regression** — SMC branch byte-identical; 65 existing tests + explicit default-path test.
+6. **Data risk** — 1d download needs Binance history depth (BTC/ETH fine from 2019); verify row counts + gap scan before running.
+7. **Uncommitted main work** — strategy-knob work is load-bearing; branch `exp/trend-signals-v3`, commit those knobs first on the branch.
+8. **Rollback** — dark-launch (`signal_source` unset = SMC); no schema/DB changes; JSON additions additive; revert = drop branch.
+
+## 11. Estimate & phases
+
+~2–2.5 focused days: types/config 1h · data download/validation 1–2h · trend_signals + engine tests 4–5h (5 engines) · simulator wiring + tests 4–5h · metrics/runner + tests 2h · quality gates 1h · ~30 runs + report 3–4h.
+**Phase 2 (only if GO):** ATR trailing (`trail_atr_mult`), regime-filter study (ADX/HMM — open question in the literature), walk-forward via existing `wfo.py`, funding-carry/on-chain research if desired.
+
+## 12. SMC status
+
+SMC retest remains the default `signal_source` and the experiment's control arm. Nothing is removed. The separately-documented SMC cleanups (dead CHOCH-OB code, `candles[-2]` OB pick, smoke-test pin) stay optional hygiene PRs — audited as not affecting profitability.

--- a/docs/reviews/2026-07-07-smc-efficacy-research.md
+++ b/docs/reviews/2026-07-07-smc-efficacy-research.md
@@ -1,0 +1,94 @@
+# Does SMC Actually Work? — Evidence Review & Improvement Recommendations
+
+**Date:** 2026-07-07
+**Method:** Deep-research harness — 6 search angles, 23 sources fetched, 105 claims extracted, top 25 adversarially verified (3-vote, 2/3 refutes to kill). 18 confirmed, 7 refuted.
+**Trigger:** Our SMC retest/mean-reversion backtest returns −23%/2yr; execution fixes (trend filter, cheaper fees, right-sized stops) only shrink the loss to −5% without creating positive edge. Question: is the "ride institutional order flow" hype real, and can SMC be improved substantially?
+
+---
+
+## Bottom line
+
+The independent evidence **contradicts SMC's core selling proposition** and **confirms our internal "strategy not code" verdict**. The −23%→−5% pattern is exactly what the literature predicts: execution/cost tuning cannot manufacture an edge that structurally isn't there. The single evidence-backed direction to explore is a **reframe from single-bar mean-reversion entries to regime-conditioned trend-continuation with multi-bar holds** — and even that was demonstrated only on non-SMC signals on one instrument, so it is a hypothesis to backtest, not a fix to adopt.
+
+The specific "improvements" most commonly recommended online (order-flow/volume overlays, session/kill-zone timing) **failed verification** — they trace back to uncited self-run backtests, not evidence.
+
+---
+
+## Finding 1 — SMC-style price patterns carry no measured predictive edge (confidence: HIGH, 3-0)
+
+- **Candlesticks (peer-reviewed):** Marshall, Young & Rose (2006, _Journal of Banking & Finance_ 30(8)) — transaction-cost-aware bootstrap on DJIA components: candlestick strategies "do not have value"; neither bullish nor bearish signals beat buy-and-hold.
+- **Walk-forward quant (2026 preprint):** Mesfin, arXiv:2605.04004 — 947 RTH days of 5-min MNQ futures, 2-pt round-trip cost, walk-forward OOS with positive controls. **None of 14 OHLCV single-bar signal families** (breakouts, gaps, volume, liquidity grabs) survives out-of-sample. Gross edge is **structurally capped at ~0.07–1.50 pts/trade — below the 2-pt cost.** Liquidity-sweep reversals (a core SMC idea) are **significantly negative in BOTH directions** (fade −2.20 pts, T=−14.12; continuation −1.80 pts, T=−13.24) across 6,442 events.
+- Corroborated by Bajgrowicz & Scaillet (2012, _JFE_): technical rules have no value after costs + data-snooping control.
+
+**Why this maps to us:** the structural edge ceiling is the direct explanation for why trend-filter/fee/stop fixes shrank our loss but never crossed into positive edge. You cannot cost-tune your way into an edge that isn't in the signal.
+
+_Caveat:_ candlesticks are an analogy — order blocks/FVG/CHOCH/BOS have essentially no direct peer-reviewed test. The MNQ paper is a single-author, non-peer-reviewed preprint on one instrument at bar resolution (it flags that true sweeps may need tick/order-book data).
+
+## Finding 2 — "Ride institutional order flow" is a retrospective narrative, not observable data (confidence: MEDIUM)
+
+- An order block is "the last opposing candle before an impulsive move" — markable only _after_ the move. It is a guess from past price, not the order book.
+- BIS 2022: only ~28% of institutional spot-FX volume hits visible venues; the rest is internalized/bilateral. Attributing a visible wick to hidden institutional intent is unverifiable.
+- Barber–Odean and "Resolving a Paradox": retail order flow's informational value is captured by sophisticated intermediaries, not retail. Retail is more plausibly _exploited by_ professional flow than riding alongside it.
+
+_Caveat:_ the specific "retail surge = head-fake, pros fade it" mechanism is overstated lore — Boehmer, Jones, Zhang & Zhang (_J. Finance_ 2021) find aggregate retail imbalance positively predicts next-week returns (~10 bps). The load-bearing point (retail can't observe/ride institutional flow from a chart) survives; the causal head-fake story does not.
+
+## Finding 3 — What separates winners is regime + holds + skill, not better entries (confidence: HIGH/MEDIUM)
+
+- **Skill is real and persists OOS** (Barber, Lee, Liu & Odean 2014, full Taiwan Stock Exchange, 3.7B txns): top-500 day traders earn +49.5 bps/day before fees (+28.1 after); bottom lose −17.5 (−34.2 after); next-year spread >60 bps/day, monotonic. Past performance is "by a large margin the best predictor of future performance," then experience, past volume, **willingness to short**, and **concentration**.
+- **The mechanism that beat costs was structural, not entry-level:** in arXiv:2605.04004, the only two signals clearing all validation criteria used **GMM regime-state classification** and held **12–15 bars (60–75 min), not 1–6 bars** — capturing structural state transitions, not single-bar patterns.
+
+**Why this maps to us:** our losing setup is a single-entry mean-reversion retest. This is the one evidence-backed direction — condition on regime/trend state and hold for the structural move.
+
+_Caveat (caps confidence at MEDIUM):_ those two "validated" signals are the author's own positive controls, are NOT SMC, were NOT discovered among the 14 tested families, and London Signal B's edge is destroyed (T=−3.56) by a mere 1-bar execution delay. "Regime detection works" is a research direction, not a turnkey retail recipe.
+
+## Finding 4 — Realistic expectation: SMC-patterns-alone are very unlikely to be net-profitable after fees (confidence: HIGH, 3-0)
+
+- > 80% of day traders lose in a typical six-month period (Barber–Odean).
+- Heavy day traders earn gross NT$36.4M/day but net **−NT$68.9M/day after costs** — costs are decisive.
+- Only ~15% of ~360,000 annual Taiwanese day traders beat fees in a year; **<1% do so predictably the next year.**
+- 70–89% of retail CFD accounts lose (ESMA/FCA disclosures); Chague & De-Losso (Brazil): ~97% of persistent day traders lose.
+- Anecdotal SMC "millionaires" are consistent with pure survivorship: a 5M-path Monte Carlo of a **zero-edge breakeven** system produced 15 paths >$1M (best $3.7M).
+
+---
+
+## Refuted claims — do NOT treat these as improvements (verified 0-3)
+
+| Refuted claim                                                                                                 | Why it failed                                          |
+| ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| Combining SMC zones with order-flow/volume confirmation (CVD, Volume Profile POC/VAL, OBI) is a validated fix | Untested assertion from a vendor blog; no OOS evidence |
+| Session/"kill-zone" timing flips a losing system to profitable (68% vs 41% win rate)                          | Uncited self-run backtest, not reproducible            |
+| Trader psychology, not analysis, is the primary loss driver                                                   | Not supported; costs + absent edge dominate            |
+
+**Implication:** multi-timeframe confluence, higher-timeframe bias, session timing, and volume/order-flow overlays are **UNVERIFIED hypotheses to backtest** — not evidence-backed recommendations. Test each with proper out-of-sample / walk-forward validation and realistic costs before believing it.
+
+---
+
+## Recommendations (ranked by evidence, for our engine)
+
+1. **Reframe the signal family, not the execution.** Stop tuning stops/fees/filters on a mean-reversion retest. The evidence says the shape is wrong. Prototype a **regime-conditioned trend-continuation** entry (break-and-go in an aligned regime) that lets winners run over a multi-bar structural move — the only mechanism in the literature that cleared costs.
+2. **Add an explicit regime classifier** (trend vs range vs transition) as a hard gate — e.g. ADX/Hurst/rolling-slope now, GMM/HMM on our feature set later. Only take continuation trades in trend regimes; suppress mean-reversion outside balance.
+3. **Validate by out-of-sample persistence, not in-sample fit.** Walk-forward with realistic round-trip costs, positive controls, and a data-snooping guard. If an idea doesn't survive OOS, discard it — most won't.
+4. **Treat MTF confluence / HTF bias / session timing / volume overlays as experiments**, each isolated and cost-aware. Expect most to fail (they did in verification).
+5. **Do not go live** on the current signal. Do not force positive returns via more parameter tuning — that is curve-fitting.
+
+---
+
+## Open questions worth a direct, cost-aware backtest
+
+1. Does regime/trend conditioning + longer structural holds convert our SMC retest edge from negative to positive on _our_ instrument/timeframe, and does it transfer from MNQ futures to crypto?
+2. Does genuine order-flow/volume data (CVD, POC/VAL, order-book imbalance, aggregated exchange flow) added to zone entries create measurable OOS edge? (Refuted at the citation level → unresolved, not disproven.)
+3. Is the persistent skill of the profitable ~1% replicable by a systematic strategy, or is it discretionary judgment / proprietary-data / execution advantages "unavailable to retail"? If the latter, no rule-tuning reaches positive expectancy.
+
+---
+
+## Source quality note
+
+The **null/deflationary side is very well supported** (peer-reviewed candlestick + Taiwan day-trader studies, ESMA/FCA regulatory data, a rigorous 2026 walk-forward preprint). The **positive "how to improve SMC" side is thin** — the strongest quant result is a single-author preprint on one instrument whose two "validated" signals are non-SMC positive controls, one of which dies from a 1-bar delay. Base-rate/skill evidence is Taiwan equities 1992–2006, generalized cross-market by extension.
+
+### Key sources
+
+- Marshall, Young & Rose (2006), _J. Banking & Finance_ — https://www.sciencedirect.com/science/article/abs/pii/S0378426605002116
+- Mesfin (2026), walk-forward OOS on MNQ — https://arxiv.org/pdf/2605.04004
+- Barber, Lee, Liu & Odean, "Cross-Section of Speculator Skill" — https://faculty.haas.berkeley.edu/odean/papers/day%20traders/Day%20Trading%20Skill%20110523.pdf
+- Barber & Odean, "Do Individual Day Traders Make Money?" — https://faculty.haas.berkeley.edu/odean/papers/Day%20Traders/Day%20Trade%20040330.pdf
+- "The Illusion of Edge: SMC, Survivorship Bias, and Market Reality" (InsiderFinance) — https://wire.insiderfinance.io/the-illusion-of-edge-smc-survivorship-bias-and-market-reality-ae7873ef154d

--- a/docs/reviews/2026-07-09-crypto-signal-families-research.md
+++ b/docs/reviews/2026-07-09-crypto-signal-families-research.md
@@ -1,0 +1,48 @@
+# Which Signal Families Actually Work on BTC/ETH? — Evidence Review
+
+**Date:** 2026-07-09 · **Method:** deep-research harness, 25 claims adversarially verified (3-vote): 20 confirmed, 1 refuted, 4 unverified (infra errors).
+**Companion to:** `2026-07-07-smc-efficacy-research.md` (SMC null result) and `docs/plans/2026-07-09-signal-family-v3-trend-experiment.md`.
+
+## Bottom line
+
+The best-evidenced family for a retail BTC/ETH spot trader is **long-only (long/cash), daily-bar trend-following** — price-vs-SMA rules or time-series momentum with **~10–65-day lookbacks** (150/200-day for cost robustness). Top-journal support (Liu & Tsyvinski, _RFS_ 2021), documented breakeven costs (57–66 bps) comfortably above ~10 bps retail fees, and repeated net-of-cost survival. Its realistic payoff is **drawdown reduction at roughly buy-and-hold returns — not return outperformance** — with net Sharpe plausibly **0.5–1.0** (the documented 1.5 is an in-sample-selected optimistic ceiling) and material decay risk.
+
+## Confirmed findings (all 3-0 unless noted)
+
+1. **TSMOM is the best-documented crypto-specific predictor** — Liu & Tsyvinski (_RFS_ 2021): past returns predict 1–8 weeks ahead for BTC/XRP/ETH (weaker for ETH; sample ends ~2018; gross of costs).
+2. **The beta trap is real and quantified** — Han, Kang & Ryu (2013–2023 sample incl. the 2022 bear): the short side of crypto TSM loses in **19 of 20** lookback/holding combos _pre-cost_; momentum is insignificant in bear regimes; a market-neutral long-short crypto momentum strategy is judged "unattainable." Reported crypto momentum performance is largely _timed long-BTC beta_.
+3. **Decay since 2020–21 is corroborated by 3 independent studies** — cross-sectional momentum significant only pre-July-2020 (Grobys et al., _FMPM_ 2025); large-cap momentum flat after early 2021 (Han et al.); BTC technical rules already negative out-of-sample in H1 2018 (Hudson & Urquhart, _Annals of OR_). **No verified sample extends past Aug 2023.**
+4. **Daily long/cash SMA rules worked net of costs** — hold when price > 20/65/150/200-day SMA else cash: gross Sharpe up to 1.89 (BTC-65d) / 2.64 (ETH-20d); all four still beat B&H on Sharpe even at 0.5%/trade. Short lookbacks earn more but bleed most to costs (BTC-20d: −0.43 Sharpe at 0.5% vs −0.06/−0.07 for 150/200d) → **low turnover + maker fees favored** (Le & Ruthbah, Monash WP).
+5. **Headline crypto trend numbers are often zero-friction artifacts** — the widely-cited 73,700% SMA-crossover backtest assumed _no_ fees/spread/slippage; its useful residue: ~10/40-day SMA windows consistent (gross Sharpe 0.5–1.5, one losing year), performance already fading pre-2020, and no profitable intraday windows.
+6. **Large-scale in-sample rule evidence doesn't survive OOS on BTC** — 14,919 rules (Hudson & Urquhart): all families significant in-sample with breakeven costs 57–66 bps (filter/channel-breakout best); outperformance vs B&H shows up mainly on **Calmar/Sortino (drawdown avoidance)**, not raw return; H1-2018 OOS turned negative.
+7. **Vol-managed sizing helps in-sample but doesn't fix tails** — Barroso–Santa-Clara-style scaling raises average payoffs >200% with significant alphas (Grobys et al. 2025), but the power-law tail exponent (~3, undefined variance) is unchanged — Sharpe alone is misleading. Gross-of-cost, cross-sectional, equal-weighted; transfer to single-asset spot TSM is plausible but unproven.
+8. **Net-of-cost Sharpe ceiling ≈ 1.5, explicitly optimistic** — best combo (28d/5d, long-only TSM, 15 bps/trade incl. measured slippage) selected in-sample; authors call it a best-case.
+9. **Cross-sectional altcoin momentum is a poor retail candidate** — 5 of 21 portfolios liquidated in-sample; only 6 beat market; profits from the long leg; post-2020 decay.
+10. **The most honest OOS test is the template for expectations** — walk-forward-optimized EMA cross on BTC, run once on unseen Nov 2019–Aug 2021 with 0.1% fees (Mroziewicz & Ślepaczuk 2026): ~matched B&H (Sharpe 1.11 vs 1.13) with **maxDD 52% vs 62%** and higher Information Ratio. _Drawdown reduction, not return outperformance._ (Companion claim that it "survives fees with 0.4% breakeven" was REFUTED 0-3.)
+11. **Timeframe: daily-to-multi-day bars only** (2-0 + corroboration) — Borgards (_NAJEF_ 2021): TSM profitable net of 0.2% fees at 1-day and 1-hour frequencies, but at 5-min fees consume all gross profit. No verified support for 15m-class trend rules.
+
+## Refuted / unverified
+
+- ❌ REFUTED (0-3): "Warsaw EMA strategy survives retail taker fees with ~0.4% breakeven."
+- ❓ Unverified (verifier infra errors, not disproven): no-profitable-intraday finding's details; walk-forward fragility pre-2021; Han et al.'s headline net Sharpe 1.51 decomposition.
+- **Zero surviving claims** for: regime filters (ADX/HMM/GMM), perp funding carry, on-chain (MVRV/SOPR/flows), sentiment, seasonality, short-horizon mean reversion — open questions, not disproofs.
+
+## What this changes for the v3 experiment
+
+1. **Primary arm = daily bars, long/cash** (`allow_short: false`). The GO bar must NOT require a winning long/short arm — the short side is documented to lose; long/short runs become a _diagnostic_ expected to underperform.
+2. **Success = risk-adjusted**: Sharpe ≥ B&H with maxDD materially lower (template: 62%→52%) at roughly comparable return. Requiring return outperformance would fail strategies the literature calls successful.
+3. **Add the price-vs-SMA family** (the most-evidenced rule shape) alongside TSMOM/EMA-cross/Donchian; ex-ante lookbacks 20d/65d/200d + 10/40d cross + 28d TSM.
+4. **Get longer daily history** — resampling our 2-yr 1h data yields only ~530 tradable daily bars after a 200d warmup and contains no full bear; fetch ~7 years of 1d klines via the existing Binance downloader so the drawdown-protection claim is actually testable (2022 bear).
+5. **1h becomes the secondary arm** (partial support: Borgards net-positive at 1h through 2019); **15m dropped** (no supporting evidence at retail fees).
+6. Expectation setting: net Sharpe 0.5–1.0, at least one losing year, decay risk — post-2023 samples don't exist, so our 2024–26 result is itself novel evidence.
+
+## Key sources
+
+- Liu & Tsyvinski, _Risks and Returns of Cryptocurrency_, RFS 2021 — ssrn.com/abstract=3226952
+- Han, Kang & Ryu, _TS & CS Momentum in Crypto_ (incl. internet appendix) — SSRN 4675565
+- Grobys et al., _FMPM_ 2025 — doi 10.1007/s11408-025-00474-9
+- Hudson & Urquhart, _Technical Trading and Cryptocurrencies_, Annals of OR — doi 10.1007/s10479-019-03357-1
+- Le & Ruthbah (Monash), _Trend-following Strategies for Crypto Investors_ — monash.edu WP
+- Mroziewicz & Ślepaczuk (Warsaw 2026), OOS EMA-cross on BTC — arXiv 2602.10785
+- Borgards, _NAJEF_ 2021 — doi 10.1016/j.najef.2021.101385
+- arXiv 2009.12155 (zero-friction SMA-cross caveats)

--- a/reports/backtest/strategies/inverted.yaml
+++ b/reports/backtest/strategies/inverted.yaml
@@ -1,0 +1,14 @@
+backtest:
+  fee_bps_spot: 10
+  slippage_bps: 2
+  funding_model: disabled
+  pivot_n: 3
+  retest_max_wait_bars: 8
+  cooldown_seconds: 300
+  risk_per_trade: 0.005
+  warmup_bars: 50
+  invert_signals: true
+  rr:
+    tp_ladder: [{r: 1.5, size: 0.4}, {r: 2.0, size: 0.3}, {r: 3.0, size: 0.3}]
+    move_to_breakeven_on: TP1
+    trail_after: TP2

--- a/reports/backtest/strategies/s1-trend.yaml
+++ b/reports/backtest/strategies/s1-trend.yaml
@@ -1,0 +1,15 @@
+backtest:
+  fee_bps_spot: 10
+  slippage_bps: 2
+  funding_model: disabled
+  pivot_n: 3
+  retest_max_wait_bars: 8
+  cooldown_seconds: 300
+  risk_per_trade: 0.005
+  warmup_bars: 50
+  htf_ema_period: 200
+  min_stop_bps: 0
+  rr:
+    tp_ladder: [{r: 1.5, size: 0.4}, {r: 2.0, size: 0.3}, {r: 3.0, size: 0.3}]
+    move_to_breakeven_on: TP1
+    trail_after: TP2

--- a/reports/backtest/strategies/s2-cost.yaml
+++ b/reports/backtest/strategies/s2-cost.yaml
@@ -1,0 +1,15 @@
+backtest:
+  fee_bps_spot: 4
+  slippage_bps: 2
+  funding_model: constant
+  pivot_n: 3
+  retest_max_wait_bars: 8
+  cooldown_seconds: 300
+  risk_per_trade: 0.005
+  warmup_bars: 50
+  htf_ema_period: 0
+  min_stop_bps: 50
+  rr:
+    tp_ladder: [{r: 1.5, size: 0.4}, {r: 2.0, size: 0.3}, {r: 3.0, size: 0.3}]
+    move_to_breakeven_on: TP1
+    trail_after: TP2

--- a/reports/backtest/strategies/s3-combined.yaml
+++ b/reports/backtest/strategies/s3-combined.yaml
@@ -1,0 +1,15 @@
+backtest:
+  fee_bps_spot: 4
+  slippage_bps: 2
+  funding_model: constant
+  pivot_n: 3
+  retest_max_wait_bars: 8
+  cooldown_seconds: 300
+  risk_per_trade: 0.005
+  warmup_bars: 50
+  htf_ema_period: 200
+  min_stop_bps: 50
+  rr:
+    tp_ladder: [{r: 1.5, size: 0.4}, {r: 2.0, size: 0.3}, {r: 3.0, size: 0.3}]
+    move_to_breakeven_on: TP1
+    trail_after: TP2

--- a/reports/backtest/strategies/s4-fee3.yaml
+++ b/reports/backtest/strategies/s4-fee3.yaml
@@ -1,0 +1,16 @@
+backtest:
+  fee_bps_spot: 3
+  slippage_bps: 2
+  funding_model: constant
+  pivot_n: 3
+  retest_max_wait_bars: 8
+  cooldown_seconds: 300
+  risk_per_trade: 0.005
+  warmup_bars: 50
+  htf_ema_period: 200
+  htf_ema_fast: 50
+  min_stop_bps: 0
+  rr:
+    tp_ladder: [{r: 1.5, size: 0.4}, {r: 2.0, size: 0.3}, {r: 3.0, size: 0.3}]
+    move_to_breakeven_on: TP1
+    trail_after: TP2

--- a/reports/backtest/strategies/s4-fee4.yaml
+++ b/reports/backtest/strategies/s4-fee4.yaml
@@ -1,0 +1,16 @@
+backtest:
+  fee_bps_spot: 4
+  slippage_bps: 2
+  funding_model: constant
+  pivot_n: 3
+  retest_max_wait_bars: 8
+  cooldown_seconds: 300
+  risk_per_trade: 0.005
+  warmup_bars: 50
+  htf_ema_period: 200
+  htf_ema_fast: 50
+  min_stop_bps: 0
+  rr:
+    tp_ladder: [{r: 1.5, size: 0.4}, {r: 2.0, size: 0.3}, {r: 3.0, size: 0.3}]
+    move_to_breakeven_on: TP1
+    trail_after: TP2

--- a/reports/backtest/strategies/v3-cross-10-40-maker.yaml
+++ b/reports/backtest/strategies/v3-cross-10-40-maker.yaml
@@ -1,0 +1,13 @@
+# v3 trend experiment — primary arm: DAILY bars, long/cash (maker fees).
+# Lookbacks are in BARS sized for 1d candles; a 1h secondary run must scale x24.
+backtest:
+  fee_bps_spot: 4
+  slippage_bps: 2
+  funding_model: disabled
+  risk_per_trade: 0.005
+  signal_source: ema_cross
+  allow_short: false
+  atr_period: 14
+  atr_stop_mult: 2
+  ema_fast: 10
+  ema_slow: 40

--- a/reports/backtest/strategies/v3-cross-10-40-taker.yaml
+++ b/reports/backtest/strategies/v3-cross-10-40-taker.yaml
@@ -1,0 +1,13 @@
+# v3 trend experiment — primary arm: DAILY bars, long/cash (taker fees).
+# Lookbacks are in BARS sized for 1d candles; a 1h secondary run must scale x24.
+backtest:
+  fee_bps_spot: 10
+  slippage_bps: 2
+  funding_model: disabled
+  risk_per_trade: 0.005
+  signal_source: ema_cross
+  allow_short: false
+  atr_period: 14
+  atr_stop_mult: 2
+  ema_fast: 10
+  ema_slow: 40

--- a/reports/backtest/strategies/v3-donch-20-10-maker.yaml
+++ b/reports/backtest/strategies/v3-donch-20-10-maker.yaml
@@ -1,0 +1,13 @@
+# v3 trend experiment — primary arm: DAILY bars, long/cash (maker fees).
+# Lookbacks are in BARS sized for 1d candles; a 1h secondary run must scale x24.
+backtest:
+  fee_bps_spot: 4
+  slippage_bps: 2
+  funding_model: disabled
+  risk_per_trade: 0.005
+  signal_source: donchian
+  allow_short: false
+  atr_period: 14
+  atr_stop_mult: 2
+  donchian_entry: 20
+  donchian_exit: 10

--- a/reports/backtest/strategies/v3-donch-20-10-taker.yaml
+++ b/reports/backtest/strategies/v3-donch-20-10-taker.yaml
@@ -1,0 +1,13 @@
+# v3 trend experiment — primary arm: DAILY bars, long/cash (taker fees).
+# Lookbacks are in BARS sized for 1d candles; a 1h secondary run must scale x24.
+backtest:
+  fee_bps_spot: 10
+  slippage_bps: 2
+  funding_model: disabled
+  risk_per_trade: 0.005
+  signal_source: donchian
+  allow_short: false
+  atr_period: 14
+  atr_stop_mult: 2
+  donchian_entry: 20
+  donchian_exit: 10

--- a/reports/backtest/strategies/v3-sma20-maker.yaml
+++ b/reports/backtest/strategies/v3-sma20-maker.yaml
@@ -1,0 +1,12 @@
+# v3 trend experiment — primary arm: DAILY bars, long/cash (maker fees).
+# Lookbacks are in BARS sized for 1d candles; a 1h secondary run must scale x24.
+backtest:
+  fee_bps_spot: 4
+  slippage_bps: 2
+  funding_model: disabled
+  risk_per_trade: 0.005
+  signal_source: price_sma
+  allow_short: false
+  atr_period: 14
+  atr_stop_mult: 2
+  sma_period: 20

--- a/reports/backtest/strategies/v3-sma20-taker.yaml
+++ b/reports/backtest/strategies/v3-sma20-taker.yaml
@@ -1,0 +1,12 @@
+# v3 trend experiment — primary arm: DAILY bars, long/cash (taker fees).
+# Lookbacks are in BARS sized for 1d candles; a 1h secondary run must scale x24.
+backtest:
+  fee_bps_spot: 10
+  slippage_bps: 2
+  funding_model: disabled
+  risk_per_trade: 0.005
+  signal_source: price_sma
+  allow_short: false
+  atr_period: 14
+  atr_stop_mult: 2
+  sma_period: 20

--- a/reports/backtest/strategies/v3-sma200-maker.yaml
+++ b/reports/backtest/strategies/v3-sma200-maker.yaml
@@ -1,0 +1,12 @@
+# v3 trend experiment — primary arm: DAILY bars, long/cash (maker fees).
+# Lookbacks are in BARS sized for 1d candles; a 1h secondary run must scale x24.
+backtest:
+  fee_bps_spot: 4
+  slippage_bps: 2
+  funding_model: disabled
+  risk_per_trade: 0.005
+  signal_source: price_sma
+  allow_short: false
+  atr_period: 14
+  atr_stop_mult: 2
+  sma_period: 200

--- a/reports/backtest/strategies/v3-sma200-taker.yaml
+++ b/reports/backtest/strategies/v3-sma200-taker.yaml
@@ -1,0 +1,12 @@
+# v3 trend experiment — primary arm: DAILY bars, long/cash (taker fees).
+# Lookbacks are in BARS sized for 1d candles; a 1h secondary run must scale x24.
+backtest:
+  fee_bps_spot: 10
+  slippage_bps: 2
+  funding_model: disabled
+  risk_per_trade: 0.005
+  signal_source: price_sma
+  allow_short: false
+  atr_period: 14
+  atr_stop_mult: 2
+  sma_period: 200

--- a/reports/backtest/strategies/v3-sma65-maker.yaml
+++ b/reports/backtest/strategies/v3-sma65-maker.yaml
@@ -1,0 +1,12 @@
+# v3 trend experiment — primary arm: DAILY bars, long/cash (maker fees).
+# Lookbacks are in BARS sized for 1d candles; a 1h secondary run must scale x24.
+backtest:
+  fee_bps_spot: 4
+  slippage_bps: 2
+  funding_model: disabled
+  risk_per_trade: 0.005
+  signal_source: price_sma
+  allow_short: false
+  atr_period: 14
+  atr_stop_mult: 2
+  sma_period: 65

--- a/reports/backtest/strategies/v3-sma65-taker.yaml
+++ b/reports/backtest/strategies/v3-sma65-taker.yaml
@@ -1,0 +1,12 @@
+# v3 trend experiment — primary arm: DAILY bars, long/cash (taker fees).
+# Lookbacks are in BARS sized for 1d candles; a 1h secondary run must scale x24.
+backtest:
+  fee_bps_spot: 10
+  slippage_bps: 2
+  funding_model: disabled
+  risk_per_trade: 0.005
+  signal_source: price_sma
+  allow_short: false
+  atr_period: 14
+  atr_stop_mult: 2
+  sma_period: 65

--- a/reports/backtest/strategies/v3-tsmom28-maker.yaml
+++ b/reports/backtest/strategies/v3-tsmom28-maker.yaml
@@ -1,0 +1,13 @@
+# v3 trend experiment — primary arm: DAILY bars, long/cash (maker fees).
+# Lookbacks are in BARS sized for 1d candles; a 1h secondary run must scale x24.
+backtest:
+  fee_bps_spot: 4
+  slippage_bps: 2
+  funding_model: disabled
+  risk_per_trade: 0.005
+  signal_source: tsmom
+  allow_short: false
+  atr_period: 14
+  atr_stop_mult: 2
+  tsmom_lookback: 28
+  tsmom_deadband_bps: 0

--- a/reports/backtest/strategies/v3-tsmom28-taker.yaml
+++ b/reports/backtest/strategies/v3-tsmom28-taker.yaml
@@ -1,0 +1,13 @@
+# v3 trend experiment — primary arm: DAILY bars, long/cash (taker fees).
+# Lookbacks are in BARS sized for 1d candles; a 1h secondary run must scale x24.
+backtest:
+  fee_bps_spot: 10
+  slippage_bps: 2
+  funding_model: disabled
+  risk_per_trade: 0.005
+  signal_source: tsmom
+  allow_short: false
+  atr_period: 14
+  atr_stop_mult: 2
+  tsmom_lookback: 28
+  tsmom_deadband_bps: 0

--- a/scripts/analyze_strategy_runs.py
+++ b/scripts/analyze_strategy_runs.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Summarize strategy backtest runs: period returns, trade stats, costs, vs buy-and-hold.
+
+Reads artifacts/strategy-runs/<strategy>/<SYMBOL>_<tf>_<range>/{trades.csv,report.json},
+reconstructs the realized equity curve from the trade ledger (initial + cumulative
+net_pnl by exit time — the ledger already embeds fixed-fractional compounding), and
+reports cumulative returns at 1/3/6/12/24-month horizons from inception.
+
+When report.json carries the benchmark fields (v3 runs onward) the buy-and-hold
+comparison comes straight from the report — computed over the exact candle window
+the simulator processed — instead of being re-derived from the raw CSV.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from datetime import datetime, timedelta, timezone
+import json
+from pathlib import Path
+
+ROOT = Path("/Users/subhajlimanond/dev/online trader")
+INITIAL = 10000.0
+HORIZONS = [("1m", 30), ("3m", 91), ("6m", 182), ("12m", 365), ("24m", 730)]
+
+
+def f(x: str) -> float:
+    try:
+        return float(x)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def load_trades(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    return list(csv.DictReader(open(path)))
+
+
+def load_benchmark(path: Path) -> dict | None:
+    """Benchmark fields from report.json, when the run produced them."""
+    if not path.exists():
+        return None
+    try:
+        metrics = json.loads(path.read_text()).get("metrics", {})
+    except (json.JSONDecodeError, OSError):
+        return None
+    if metrics.get("benchmark_return_pct") is None:
+        return None
+    return {
+        "return_pct": metrics["benchmark_return_pct"],
+        "max_dd_pct": metrics.get("benchmark_max_drawdown_pct"),
+        "sharpe": metrics.get("benchmark_sharpe_ratio"),
+        "excess_pct": metrics.get("excess_return_pct"),
+    }
+
+
+def equity_at(trades: list[dict], when: datetime) -> float:
+    eq = INITIAL
+    for t in trades:
+        xt = t.get("exit_time") or ""
+        if not xt:
+            continue
+        try:
+            et = datetime.fromisoformat(xt.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        if et <= when:
+            eq += f(t["net_pnl"])
+    return eq
+
+
+def buy_hold_return(symbol: str, tf: str, start: datetime, when: datetime) -> float | None:
+    path = ROOT / "data" / "backtest" / f"{symbol.lower()}_{tf}.csv"
+    if not path.exists():
+        return None
+    start_px = end_px = None
+    for r in csv.DictReader(open(path)):
+        try:
+            ts = datetime.fromisoformat(r["timestamp"].replace("Z", "+00:00"))
+        except (ValueError, KeyError):
+            continue
+        if start_px is None and ts >= start:
+            start_px = f(r["close"])
+        if ts <= when:
+            end_px = f(r["close"])
+    if start_px and end_px:
+        return (end_px / start_px - 1) * 100
+    return None
+
+
+def trade_stats(trades: list[dict]) -> dict:
+    n = len(trades)
+    if n == 0:
+        return {"n": 0}
+    nets = [f(t["net_pnl_r"]) for t in trades if abs(f(t["net_pnl_r"])) < 50]
+    wins = [x for x in nets if x > 0]
+    losses = [x for x in nets if x <= 0]
+    gross_win = sum(f(t["net_pnl"]) for t in trades if f(t["net_pnl"]) > 0)
+    gross_loss = -sum(f(t["net_pnl"]) for t in trades if f(t["net_pnl"]) < 0)
+    fees = sum(f(t["fees"]) for t in trades)
+    slip = sum(f(t["slippage"]) for t in trades)
+    fund = sum(f(t["funding"]) for t in trades)
+    longs = [f(t["net_pnl_r"]) for t in trades if t["side"] == "long" and abs(f(t["net_pnl_r"])) < 50]
+    shorts = [f(t["net_pnl_r"]) for t in trades if t["side"] == "short" and abs(f(t["net_pnl_r"])) < 50]
+    return {
+        "n": n,
+        "hit": len(wins) / len(nets) * 100 if nets else 0,
+        "avg_r": sum(nets) / len(nets) if nets else 0,
+        "avg_win_r": sum(wins) / len(wins) if wins else 0,
+        "avg_loss_r": sum(losses) / len(losses) if losses else 0,
+        "pf": gross_win / gross_loss if gross_loss else float("inf"),
+        "fees": fees,
+        "slip": slip,
+        "fund": fund,
+        "n_long": len(longs),
+        "n_short": len(shorts),
+        "long_r": sum(longs) / len(longs) if longs else 0,
+        "short_r": sum(shorts) / len(shorts) if shorts else 0,
+    }
+
+
+def max_drawdown(trades: list[dict]) -> float:
+    eq = INITIAL
+    peak = INITIAL
+    mdd = 0.0
+    for t in sorted(trades, key=lambda r: r.get("exit_time") or ""):
+        eq += f(t["net_pnl"])
+        peak = max(peak, eq)
+        if peak > 0:
+            mdd = max(mdd, (peak - eq) / peak)
+    return mdd * 100
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--strats",
+        default="baseline,s1,s2,s3",
+        help="Comma-separated strategy run names under artifacts/strategy-runs/",
+    )
+    parser.add_argument("--symbols", default="BTCUSDT,ETHUSDT")
+    parser.add_argument("--tf", default="1h", help="Timeframe segment of the run dirs")
+    parser.add_argument("--range", dest="range_", default="20240701_20260630")
+    parser.add_argument("--start", default="2024-07-01", help="Inception date (UTC)")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    strats = [s for s in args.strats.split(",") if s]
+    symbols = [s for s in args.symbols.split(",") if s]
+    start = datetime.fromisoformat(args.start).replace(tzinfo=timezone.utc)
+
+    for symbol in symbols:
+        print(f"\n{'=' * 100}\n{symbol} — {args.tf} — {args.range_}\n{'=' * 100}")
+        bh = {h: buy_hold_return(symbol, args.tf, start, start + timedelta(days=d)) for h, d in HORIZONS}
+        if all(v is not None for v in bh.values()):
+            print(f"{'Buy & Hold':16} | " + " ".join(f"{h}:{bh[h]:+7.1f}%" for h, _ in HORIZONS))
+        print("-" * 100)
+        header = f"{'Strategy':16} | " + " ".join(f"{h:>10}" for h, _ in HORIZONS)
+        print(header)
+        for strat in strats:
+            d = ROOT / "artifacts" / "strategy-runs" / strat / f"{symbol}_{args.tf}_{args.range_}"
+            trades = load_trades(d / "trades.csv")
+            if not trades:
+                print(f"{strat:16} | (no data — run may be incomplete)")
+                continue
+            rets = []
+            for h, days in HORIZONS:
+                eq = equity_at(trades, start + timedelta(days=days))
+                rets.append((eq / INITIAL - 1) * 100)
+            print(f"{strat:16} | " + " ".join(f"{r:+9.1f}%" for r in rets))
+        print("-" * 100)
+        print(f"{'Strategy':16} | {'trades':>7} {'hit%':>6} {'PF':>5} {'avgR':>6} {'winR':>6} {'lossR':>7} {'maxDD%':>7} {'fees$':>8} {'slip$':>7} {'fund$':>7} | long/short R")
+        for strat in strats:
+            d = ROOT / "artifacts" / "strategy-runs" / strat / f"{symbol}_{args.tf}_{args.range_}"
+            trades = load_trades(d / "trades.csv")
+            if not trades:
+                continue
+            s = trade_stats(trades)
+            mdd = max_drawdown(trades)
+            pf = s["pf"]
+            pfs = f"{pf:.2f}" if pf != float("inf") else "inf"
+            print(
+                f"{strat:16} | {s['n']:7d} {s['hit']:5.1f} {pfs:>5} {s['avg_r']:+6.2f} "
+                f"{s['avg_win_r']:+6.2f} {s['avg_loss_r']:+7.2f} {mdd:7.1f} "
+                f"{s['fees']:8.0f} {s['slip']:7.0f} {s['fund']:7.0f} | "
+                f"L {s['long_r']:+.2f}({s['n_long']}) S {s['short_r']:+.2f}({s['n_short']})"
+            )
+        print("-" * 100)
+        print(f"{'Strategy':16} | {'B&H ret%':>9} {'B&H maxDD%':>11} {'B&H Sharpe':>11} {'excess%':>9}  (from report.json)")
+        for strat in strats:
+            d = ROOT / "artifacts" / "strategy-runs" / strat / f"{symbol}_{args.tf}_{args.range_}"
+            bench = load_benchmark(d / "report.json")
+            if bench is None:
+                print(f"{strat:16} | (no benchmark fields in report)")
+                continue
+            sharpe = f"{bench['sharpe']:11.2f}" if bench["sharpe"] is not None else f"{'—':>11}"
+            print(
+                f"{strat:16} | {bench['return_pct']:+9.1f} {bench['max_dd_pct']:11.1f} "
+                f"{sharpe} {bench['excess_pct']:+9.1f}"
+            )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Implements `docs/plans/2026-07-09-signal-family-v3-trend-experiment.md` (rev 2, research-aligned): a config-selectable **trend-following signal source** beside the existing SMC retest pipeline, plus buy-and-hold benchmark metrics on every run.

- **`trend_signals.py` (new)** — self-contained streaming engines: `PriceSmaEngine` (long/cash, never SHORT), `TsmomEngine` (trailing return with dead-band hysteresis), `EmaCrossEngine`, `DonchianEngine` (turtle asymmetric entry/exit channels), all sharing an O(1) Wilder `_StreamingAtr` that is parity-tested against the batch calculator; `create_trend_engine` factory raises on unknown sources.
- **Simulator** — desired-state diffing per bar (self-heals when a risk gate blocks an entry). Flip-close cancels resting brackets synchronously (no stale-stop double fill / phantom fee) and queues the reduce-only MARKET close **before** any reverse entry (ordering invariant, regression-tested). `SHORT` degrades to `FLAT` unless `allow_short`. Optional TP leg (`trend_tp_r=0` → stop-only bracket, no OCO). `max_hold_bars` timeout. `ExitReason.FLIP`/`TIMEOUT` land in trades.csv via exit-reason overrides. The whole gate/size/bracket chain (HTF EMA gate → min-stop floor → policies → exposure caps → pretrade risk → cooldown) is reused untouched. **SMC default path is byte-identical** and guarded by an explicit regression test; `invert_signals` + trend source raises.
- **Metrics/runner** — `apply_benchmark` fills B&H return/maxDD/Sharpe + excess return with the same annualization factor as the strategy Sharpe; runner parses the new knobs, collects closes, serializes benchmark fields + `signal_source` into report.json.
- **Configs** — 12 ex-ante `v3-*.yaml` (6 daily rule families × taker/maker fees), lookbacks from the verified literature, no tuning. `analyze_strategy_runs.py` reads benchmark fields and takes run parameters.
- Also lands the load-bearing strategy-variant knobs (HTF EMA gate, min-stop floor, invert diagnostic) that the v3 arms depend on, plus the plan/research docs.

## Test evidence

- TDD: engine tests (15), simulator wiring (11), metrics benchmark (4), runner config (3) all written first and confirmed RED before implementation.
- `pytest tests/unit/` 3× consecutive: **1446 passed** each run; the single failure (`test_redis_adapter_syntax`) reproduces identically on pristine `main` (redis-py stubs, unrelated).
- ruff + ruff format + mypy clean on all changed modules.
- End-to-end smoke (real runner, daily BTC 2024-07→2026-06, `v3-sma20-taker`): 36 trades, all long, exits 35 flip/1 sl, +1.65% vs B&H −6.80% (excess +8.45%), maxDD 2.73% vs 52.97% — the drawdown-protection profile the research predicts.
- Wiring verification: every new export has a non-test runtime caller.
- QCHECK: skeptical pass over the assembled diff — no CRITICAL/HIGH findings. Codex MCP review attempted but unavailable (no response in 40 min; known quota block).

## Next (separate from this PR)

Download 7y daily klines (2019→2026), run the 24-run primary matrix + diagnostic/secondary/control arms, evaluate the ex-ante GO/NO-GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)