### PR TITLE
feat(paper): zero-TP brackets and bracket-scoped close_position

### DIFF
--- a/app/engine/backtest/position_sizing.py
+++ b/app/engine/backtest/position_sizing.py
@@ -36,6 +36,8 @@ def annualized_volatility(
     convention as MetricsCalculator's Sharpe, so target and measurement agree."""
     if len(closes) < 2:
         return None
+    if any(close <= 0 for close in closes):
+        return None
     returns = [float(closes[i] / closes[i - 1]) - 1.0 for i in range(1, len(closes))]
     return Decimal(str(statistics.pstdev(returns) * math.sqrt(bars_per_year)))
 

--- a/app/engine/backtest/position_sizing.py
+++ b/app/engine/backtest/position_sizing.py
@@ -1,0 +1,55 @@
+"""
+Pure position-sizing functions for the simulator's non-risk sizing modes.
+
+"notional" sizes a fixed fraction of equity; "vol_target" scales that fraction
+so the position's annualized volatility approximates a target. Both return a
+target quantity that the caller must still clamp with the exposure caps.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+import math
+import statistics
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def notional_quantity(
+    *,
+    equity: Decimal,
+    entry_price: Decimal,
+    notional_pct: Decimal,
+) -> Decimal | None:
+    if equity <= 0 or entry_price <= 0 or notional_pct <= 0:
+        return None
+    return equity * notional_pct / entry_price
+
+
+def annualized_volatility(
+    closes: Sequence[Decimal],
+    bars_per_year: float,
+) -> Decimal | None:
+    """Population std of simple per-bar returns, sqrt-annualized — the same
+    convention as MetricsCalculator's Sharpe, so target and measurement agree."""
+    if len(closes) < 2:
+        return None
+    returns = [float(closes[i] / closes[i - 1]) - 1.0 for i in range(1, len(closes))]
+    return Decimal(str(statistics.pstdev(returns) * math.sqrt(bars_per_year)))
+
+
+def vol_target_quantity(
+    *,
+    equity: Decimal,
+    entry_price: Decimal,
+    vol_target_annual_pct: Decimal,
+    annualized_vol: Decimal | None,
+) -> Decimal | None:
+    if equity <= 0 or entry_price <= 0 or vol_target_annual_pct <= 0:
+        return None
+    if annualized_vol is None or annualized_vol <= 0:
+        return None
+    weight = vol_target_annual_pct / Decimal(100) / annualized_vol
+    return equity * weight / entry_price

--- a/app/engine/backtest/runner.py
+++ b/app/engine/backtest/runner.py
@@ -114,6 +114,21 @@ class BacktestRunner:
                 donchian_exit=int(backtest_data.get("donchian_exit", 10)),
                 max_hold_bars=int(backtest_data.get("max_hold_bars", 0)),
                 trend_tp_r=Decimal(str(backtest_data.get("trend_tp_r", 0))),
+                sizing_mode=str(backtest_data.get("sizing_mode", "risk")),
+                notional_pct=Decimal(str(backtest_data.get("notional_pct", 1))),
+                vol_target_annual_pct=Decimal(
+                    str(backtest_data.get("vol_target_annual_pct", 0)),
+                ),
+                vol_lookback_bars=int(backtest_data.get("vol_lookback_bars", 20)),
+                max_position_notional_pct=Decimal(
+                    str(backtest_data.get("max_position_notional_pct", "0.10")),
+                ),
+                max_symbol_exposure_pct=Decimal(
+                    str(backtest_data.get("max_symbol_exposure_pct", "0.25")),
+                ),
+                max_total_exposure_leverage=Decimal(
+                    str(backtest_data.get("max_total_exposure_leverage", 3)),
+                ),
                 train_days=backtest_data.get("wfo", {}).get("train_days", 90),
                 test_days=backtest_data.get("wfo", {}).get("test_days", 30),
             )
@@ -309,6 +324,13 @@ class BacktestRunner:
                 "tp_ladder": result.config.tp_ladder,
                 "signal_source": result.config.signal_source,
                 "allow_short": result.config.allow_short,
+                "sizing_mode": result.config.sizing_mode,
+                "notional_pct": float(result.config.notional_pct),
+                "vol_target_annual_pct": float(result.config.vol_target_annual_pct),
+                "vol_lookback_bars": result.config.vol_lookback_bars,
+                "max_position_notional_pct": float(result.config.max_position_notional_pct),
+                "max_symbol_exposure_pct": float(result.config.max_symbol_exposure_pct),
+                "max_total_exposure_leverage": float(result.config.max_total_exposure_leverage),
             },
             "metrics": {
                 "total_pnl": float(result.metrics.total_pnl),

--- a/app/engine/backtest/simulator.py
+++ b/app/engine/backtest/simulator.py
@@ -19,7 +19,11 @@ from ..bus import set_event_bus
 from ..core.signal_cooldown import SignalCooldown
 from ..decision.pretrade_risk import evaluate_pretrade_risk
 from ..decision.risk_state import RiskSnapshot
-from ..decision.sizing import size_with_exposure_caps
+from ..decision.sizing import (
+    RiskCappedSize,
+    cap_quantity_with_exposure_caps,
+    size_with_exposure_caps,
+)
 from ..features.indicators import TechnicalIndicatorsCalculator
 from ..models import Candle, RiskParameters, TimeFrame, TradingDecision
 from ..retest.engine import analyze_retest
@@ -28,7 +32,13 @@ from ..smc_types import StructureBreakEvent
 from .capture_bus import CapturingEventBus
 from .costs import CostCalculator
 from .fills import FillEngine
+from .metrics import bars_per_year
 from .policies import TradingPolicyManager
+from .position_sizing import (
+    annualized_volatility,
+    notional_quantity,
+    vol_target_quantity,
+)
 from .trend_signals import create_trend_engine
 from .types import (
     BacktestConfig,
@@ -50,6 +60,8 @@ if TYPE_CHECKING:
     from .trend_signals import TrendEngine, TrendTarget
 
 logger = logging.getLogger(__name__)
+
+_CANDLE_BUFFER_BARS = 200
 
 _BAR_MINUTES: dict[str, int] = {
     "1m": 1,
@@ -96,6 +108,29 @@ class BacktestSimulator:
                 "invert_signals is an SMC-only diagnostic and cannot be combined "
                 f"with signal_source={config.signal_source!r}",
             )
+        if config.sizing_mode not in {"risk", "notional", "vol_target"}:
+            raise ValueError(
+                f"Unknown sizing_mode {config.sizing_mode!r}; "
+                "expected one of ['notional', 'risk', 'vol_target']",
+            )
+        if config.sizing_mode != "risk" and config.signal_source == "smc_retest":
+            raise ValueError(
+                f"sizing_mode={config.sizing_mode!r} is a trend-source arm; "
+                "smc_retest keeps fixed-fractional risk sizing",
+            )
+        if config.sizing_mode == "vol_target" and config.vol_target_annual_pct <= 0:
+            raise ValueError(
+                "sizing_mode='vol_target' requires a positive vol_target_annual_pct",
+            )
+        if config.sizing_mode == "vol_target" and not (
+            2 <= config.vol_lookback_bars <= _CANDLE_BUFFER_BARS - 1
+        ):
+            raise ValueError(
+                f"vol_lookback_bars must be in [2, {_CANDLE_BUFFER_BARS - 1}]: the "
+                f"candle buffer holds {_CANDLE_BUFFER_BARS} bars and volatility "
+                "needs lookback+1 closes, so values outside that range would "
+                "silently never trade",
+            )
         self.config = config
         self.initial_balance = initial_balance
         self.current_balance = initial_balance
@@ -118,9 +153,10 @@ class BacktestSimulator:
             cooldown_seconds=config.cooldown_seconds,
             clock=self._clock,
         )
-        # Notional/symbol-exposure/open-position caps mirror the live engine
-        # defaults (main.py risk_parameters); daily-loss/drawdown gates and
-        # max_position_size deliberately stay disabled here.
+        # Notional/symbol-exposure/leverage caps default to the live engine
+        # values (main.py risk_parameters) but are config knobs so sizing arms
+        # can lift them; daily-loss/drawdown gates and max_position_size
+        # deliberately stay disabled here.
         self._risk = RiskParameters(
             max_position_size=Decimal(1_000_000_000),
             max_daily_loss=Decimal(1),
@@ -128,9 +164,9 @@ class BacktestSimulator:
             risk_per_trade=config.risk_per_trade,
             max_correlation=Decimal(1),
             max_open_positions=5,
-            max_total_exposure_leverage=Decimal(3),
-            max_symbol_exposure_pct=Decimal("0.25"),
-            max_position_notional_pct=Decimal("0.10"),
+            max_total_exposure_leverage=config.max_total_exposure_leverage,
+            max_symbol_exposure_pct=config.max_symbol_exposure_pct,
+            max_position_notional_pct=config.max_position_notional_pct,
             risk_data_max_age_seconds=86400,
             drawdown_lookback_days=30,
         )
@@ -147,7 +183,7 @@ class BacktestSimulator:
         self.total_slippage = Decimal(0)
         self.total_funding = Decimal(0)
 
-        self._candles: deque[Candle] = deque(maxlen=200)
+        self._candles: deque[Candle] = deque(maxlen=_CANDLE_BUFFER_BARS)
         self._bos_events: list[dict[str, Any]] = []
         self._prev_macd_hist: Decimal | None = None
         # Streaming higher-timeframe trend EMAs for the trend-alignment gate.
@@ -507,11 +543,10 @@ class BacktestSimulator:
         symbol_exposure = self._symbol_exposure_usd()
         total_exposure = sum(symbol_exposure.values(), Decimal(0))
 
-        sized = size_with_exposure_caps(
+        sized = self._size_signal(
+            signal,
+            candle,
             equity=equity,
-            entry_price=signal["entry"],
-            stop_loss=signal["stop_loss"],
-            risk=self._risk,
             existing_symbol_exposure_usd=symbol_exposure.get(candle.symbol, Decimal(0)),
             existing_total_exposure_usd=total_exposure,
         )
@@ -575,6 +610,56 @@ class BacktestSimulator:
         logger.info(
             f"Signal executed: {direction} {candle.symbol} size={sized.quantity}",
         )
+
+    def _size_signal(
+        self,
+        signal: dict[str, Any],
+        candle: Candle,
+        *,
+        equity: Decimal,
+        existing_symbol_exposure_usd: Decimal,
+        existing_total_exposure_usd: Decimal,
+    ) -> RiskCappedSize | None:
+        if self.config.sizing_mode == "risk":
+            return size_with_exposure_caps(
+                equity=equity,
+                entry_price=signal["entry"],
+                stop_loss=signal["stop_loss"],
+                risk=self._risk,
+                existing_symbol_exposure_usd=existing_symbol_exposure_usd,
+                existing_total_exposure_usd=existing_total_exposure_usd,
+            )
+
+        if self.config.sizing_mode == "notional":
+            target = notional_quantity(
+                equity=equity,
+                entry_price=signal["entry"],
+                notional_pct=self.config.notional_pct,
+            )
+        else:
+            target = vol_target_quantity(
+                equity=equity,
+                entry_price=signal["entry"],
+                vol_target_annual_pct=self.config.vol_target_annual_pct,
+                annualized_vol=self._realized_annual_vol(candle),
+            )
+        if target is None or target <= 0:
+            return None
+        return cap_quantity_with_exposure_caps(
+            quantity=target,
+            equity=equity,
+            entry_price=signal["entry"],
+            risk=self._risk,
+            existing_symbol_exposure_usd=existing_symbol_exposure_usd,
+            existing_total_exposure_usd=existing_total_exposure_usd,
+        )
+
+    def _realized_annual_vol(self, candle: Candle) -> Decimal | None:
+        lookback = self.config.vol_lookback_bars
+        if len(self._candles) < lookback + 1:
+            return None
+        closes = [c.close_price for c in self._candles][-(lookback + 1) :]
+        return annualized_volatility(closes, bars_per_year(candle.timeframe))
 
     def _process_order_fills(self, candle: Candle) -> None:
         fills = self.fill_engine.process_order_fills(self.active_orders, candle)

--- a/app/engine/backtest/simulator.py
+++ b/app/engine/backtest/simulator.py
@@ -118,6 +118,10 @@ class BacktestSimulator:
                 f"sizing_mode={config.sizing_mode!r} is a trend-source arm; "
                 "smc_retest keeps fixed-fractional risk sizing",
             )
+        if config.sizing_mode == "notional" and config.notional_pct <= 0:
+            raise ValueError(
+                "sizing_mode='notional' requires a positive notional_pct",
+            )
         if config.sizing_mode == "vol_target" and config.vol_target_annual_pct <= 0:
             raise ValueError(
                 "sizing_mode='vol_target' requires a positive vol_target_annual_pct",

--- a/app/engine/backtest/types.py
+++ b/app/engine/backtest/types.py
@@ -225,6 +225,24 @@ class BacktestConfig:
     max_hold_bars: int = 0  # 0 = no timeout exit
     trend_tp_r: Decimal = Decimal(0)  # 0 = no TP leg; let winners run
 
+    # Position sizing (trend sources only; "risk" reproduces every historical
+    # result byte-for-byte). "notional": qty = equity * notional_pct / entry.
+    # "vol_target": the notional fraction becomes vol_target_annual_pct /
+    # realized annualized close-to-close vol over vol_lookback_bars, so the
+    # position's vol approximates the target. The 2xATR stop stays as the
+    # protective exit in both modes but no longer drives sizing.
+    sizing_mode: str = "risk"  # risk|notional|vol_target
+    notional_pct: Decimal = Decimal(1)
+    vol_target_annual_pct: Decimal = Decimal(0)
+    vol_lookback_bars: int = 20
+
+    # Exposure caps, previously hardcoded to the live-engine defaults
+    # (main.py risk_parameters). Raising them is what makes notional_pct
+    # above 0.10 actually reachable.
+    max_position_notional_pct: Decimal = Decimal("0.10")
+    max_symbol_exposure_pct: Decimal = Decimal("0.25")
+    max_total_exposure_leverage: Decimal = Decimal(3)
+
     # WFO settings
     train_days: int = 90
     test_days: int = 30

--- a/app/engine/decision/sizing.py
+++ b/app/engine/decision/sizing.py
@@ -35,11 +35,29 @@ def size_with_exposure_caps(
         return None
 
     risk_amount = equity * risk.risk_per_trade
-    quantity = risk_amount / stop_distance
+    return cap_quantity_with_exposure_caps(
+        quantity=risk_amount / stop_distance,
+        equity=equity,
+        entry_price=entry_price,
+        risk=risk,
+        existing_symbol_exposure_usd=existing_symbol_exposure_usd,
+        existing_total_exposure_usd=existing_total_exposure_usd,
+    )
+
+
+def cap_quantity_with_exposure_caps(
+    *,
+    quantity: Decimal,
+    equity: Decimal,
+    entry_price: Decimal,
+    risk: RiskParameters,
+    existing_symbol_exposure_usd: Decimal = Decimal(0),
+    existing_total_exposure_usd: Decimal = Decimal(0),
+) -> RiskCappedSize:
     original_quantity = quantity
 
     # Cap sizing to notional/exposure limits instead of rejecting outright.
-    # This intentionally risks *less* than risk_per_trade when stops are too tight.
+    # This intentionally risks *less* than the target when caps bind.
     if entry_price and entry_price > 0 and quantity > 0:
         max_qty_candidates = []
 

--- a/app/engine/paper/broker.py
+++ b/app/engine/paper/broker.py
@@ -36,6 +36,7 @@ from .schema import (
     build_insert_paper_fill,
     build_insert_paper_order,
     build_upsert_paper_position,
+    cancel_bracket_orders_sql,
     cancel_oco_siblings_sql,
     status_from_db,
     status_to_db,
@@ -103,6 +104,12 @@ class CancelRequest(BaseModel):
 class CloseAllRequest(BaseModel):
     symbol: str | None = None
     is_futures: bool = False
+
+
+class ClosePositionRequest(BaseModel):
+    symbol: str
+    paper_session_id: UUID
+    client_order_id: str | None = None
 
 
 class OrderUpdate(BaseModel):
@@ -628,8 +635,8 @@ class PaperBroker:
         All orders in a bracket share the same paper_session_id for OCO tracking.
         TP/SL orders are marked reduce_only=True per schema.
         """
-        if len(request.take_profit_prices) != 1:
-            _raise_http(400, "Exactly one take profit price is required")
+        if len(request.take_profit_prices) > 1:
+            _raise_http(400, "At most one take profit price is supported")
 
         now = datetime.now(UTC)
         bracket_id = uuid4()
@@ -640,7 +647,7 @@ class PaperBroker:
         else:
             client_order_ids = ClientOrderIDs(
                 main=f"paper_{uuid4().hex[:8]}",
-                take_profits=[f"paper_tp_{uuid4().hex[:8]}"],
+                take_profits=[f"paper_tp_{uuid4().hex[:8]}" for _ in request.take_profit_prices],
                 stop_loss=f"paper_sl_{uuid4().hex[:8]}",
             )
         venue = "USD_M" if request.is_futures else "SPOT"
@@ -669,20 +676,22 @@ class PaperBroker:
             )
             orders.append(entry_order)
 
-            # 2. Take profit orders (OCO, reduce_only=True)
-            tp_side = OrderSide.SELL if request.side == "BUY" else OrderSide.BUY
-            tp_order = BacktestOrder(
-                symbol=request.symbol,
-                side=tp_side,
-                type=OrderType.LIMIT,
-                quantity=request.quantity,
-                price=request.take_profit_prices[0],
-                client_order_id=client_order_ids.take_profits[0],
-                status=OrderStatus.NEW,
-                reduce_only=True,
-                order_time=now,
-            )
-            orders.append(tp_order)
+            # 2. Take profit orders (OCO, reduce_only=True); zero-TP brackets
+            # (trend co-primaries: exit on flip/stop) place entry + stop only
+            if request.take_profit_prices:
+                tp_side = OrderSide.SELL if request.side == "BUY" else OrderSide.BUY
+                tp_order = BacktestOrder(
+                    symbol=request.symbol,
+                    side=tp_side,
+                    type=OrderType.LIMIT,
+                    quantity=request.quantity,
+                    price=request.take_profit_prices[0],
+                    client_order_id=client_order_ids.take_profits[0],
+                    status=OrderStatus.NEW,
+                    reduce_only=True,
+                    order_time=now,
+                )
+                orders.append(tp_order)
 
             # 3. Stop loss order (OCO, reduce_only=True)
             sl_side = OrderSide.SELL if request.side == "BUY" else OrderSide.BUY
@@ -775,6 +784,92 @@ class PaperBroker:
         else:
             return {"status": "success"}
 
+    async def _cancel_bracket_resting_orders(self, symbol: str, bracket_id: UUID) -> int:
+        """Cancel every resting NEW order for one (symbol, bracket) in DB and memory."""
+        sql, params = cancel_bracket_orders_sql(bracket_id, symbol=symbol)
+        async with self.db_pool.acquire() as conn:
+            await conn.execute(sql, *params)
+
+        cancelled = 0
+        for client_order_id, order in list(self.active_orders.items()):
+            if (
+                self._order_bracket_ids.get(client_order_id) == bracket_id
+                and order.symbol == symbol
+                and order.status == OrderStatus.NEW
+            ):
+                order.status = OrderStatus.CANCELLED
+                del self.active_orders[client_order_id]
+                del self._order_bracket_ids[client_order_id]
+                self._order_venues.pop(client_order_id, None)
+                await self._publish_order_update(order, "CANCELLED")
+                cancelled += 1
+        return cancelled
+
+    async def close_position(
+        self,
+        symbol: str,
+        bracket_id: UUID,
+        client_order_id: str | None = None,
+    ) -> dict[str, str]:
+        """Close a single bracket's position without touching other brackets.
+
+        Cancels the bracket's resting orders (notably the stop) BEFORE placing
+        the market close, so the same candle cannot fill both exits.
+        """
+        if client_order_id is not None and client_order_id in self.active_orders:
+            return {"status": "duplicate", "client_order_id": client_order_id}
+
+        try:
+            cancelled = await self._cancel_bracket_resting_orders(symbol, bracket_id)
+
+            position = self.positions.get((symbol, bracket_id))
+            if position is None or position.net_quantity.is_zero():
+                return {
+                    "status": "success",
+                    "closed": "false",
+                    "cancelled_orders": str(cancelled),
+                }
+
+            close_side = OrderSide.SELL if position.net_quantity > 0 else OrderSide.BUY
+            close_order = BacktestOrder(
+                symbol=symbol,
+                side=close_side,
+                type=OrderType.MARKET,
+                quantity=abs(position.net_quantity),
+                client_order_id=client_order_id or f"paper_close_{uuid4().hex[:8]}",
+                status=OrderStatus.NEW,
+                reduce_only=True,
+                order_time=datetime.now(UTC),
+            )
+
+            await self._insert_paper_order(close_order, bracket_id)
+            self.active_orders[close_order.client_order_id] = close_order
+            self._order_bracket_ids[close_order.client_order_id] = bracket_id
+            self._order_venues[close_order.client_order_id] = (
+                "USD_M" if position.is_futures else "SPOT"
+            )
+
+            if symbol in self.latest_candles:
+                await self._process_pending_fills(self.latest_candles[symbol])
+
+            logger.info(
+                "Initiated bracket-scoped close for %s (bracket=%s)",
+                symbol,
+                bracket_id,
+            )
+
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.exception("Error closing bracket position")
+            raise HTTPException(status_code=400, detail=str(e)) from e
+        else:
+            return {
+                "status": "success",
+                "closed": "true",
+                "cancelled_orders": str(cancelled),
+            }
+
     async def close_all_positions(self, request: CloseAllRequest) -> dict[str, str]:
         """Close all positions"""
         try:
@@ -844,6 +939,14 @@ def create_paper_broker_app(broker: PaperBroker) -> FastAPI:
     @app.post("/close_all")
     async def close_all_endpoint(request: CloseAllRequest) -> dict[str, str]:
         return await broker.close_all_positions(request)
+
+    @app.post("/close_position")
+    async def close_position_endpoint(request: ClosePositionRequest) -> dict[str, str]:
+        return await broker.close_position(
+            request.symbol,
+            request.paper_session_id,
+            client_order_id=request.client_order_id,
+        )
 
     @app.get("/healthz")
     async def healthz() -> dict[str, str]:

--- a/app/engine/paper/schema.py
+++ b/app/engine/paper/schema.py
@@ -249,6 +249,40 @@ def build_upsert_paper_position(
     return sql, params
 
 
+def cancel_bracket_orders_sql(
+    paper_session_id: UUID,
+    *,
+    symbol: str,
+    now: datetime | None = None,
+) -> tuple[str, list[object]]:
+    """Build SQL to cancel all resting orders in one bracket.
+
+    Cancels every NEW order (entry and exits) for the symbol and
+    paper_session_id, used by the bracket-scoped close so the resting stop
+    cannot fill alongside the close order.
+    """
+    sql = """
+        UPDATE paper_orders
+        SET status = $1, updated_at = $2
+        WHERE paper_session_id = $3
+          AND symbol = $4
+          AND status = $5
+    """
+
+    if now is None:
+        now = datetime.now(UTC)
+
+    params: list[object] = [
+        status_to_db(OrderStatus.CANCELLED),
+        now,
+        paper_session_id,
+        symbol,
+        status_to_db(OrderStatus.NEW),
+    ]
+
+    return sql, params
+
+
 def cancel_oco_siblings_sql(
     paper_session_id: UUID,
     filled_order_id: UUID,

--- a/app/engine/tests/unit/backtest/test_position_sizing.py
+++ b/app/engine/tests/unit/backtest/test_position_sizing.py
@@ -68,6 +68,18 @@ class TestAnnualizedVolatility:
     def test_fewer_than_two_closes_returns_none(self) -> None:
         assert annualized_volatility([Decimal(100)], bars_per_year=10_000.0) is None
 
+    @pytest.mark.parametrize(
+        "closes",
+        [
+            [Decimal(100), Decimal(0), Decimal(100)],
+            [Decimal(100), Decimal("-5"), Decimal(100)],
+        ],
+    )
+    def test_non_positive_close_returns_none(self, closes: list[Decimal]) -> None:
+        # A zero/negative close would make the ratio undefined; return None
+        # rather than raising DivisionByZero mid-sizing.
+        assert annualized_volatility(closes, bars_per_year=10_000.0) is None
+
 
 class TestVolTargetQuantity:
     def test_quantity_scales_equity_by_target_over_realized_vol(self) -> None:

--- a/app/engine/tests/unit/backtest/test_position_sizing.py
+++ b/app/engine/tests/unit/backtest/test_position_sizing.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.engine.backtest.position_sizing import (
+    annualized_volatility,
+    notional_quantity,
+    vol_target_quantity,
+)
+
+
+class TestNotionalQuantity:
+    def test_quantity_is_equity_fraction_over_entry(self) -> None:
+        qty = notional_quantity(
+            equity=Decimal(10_000),
+            entry_price=Decimal(100),
+            notional_pct=Decimal("0.5"),
+        )
+
+        assert qty == Decimal(50)
+
+    @pytest.mark.parametrize(
+        ("equity", "entry_price", "notional_pct"),
+        [
+            (Decimal(10_000), Decimal(0), Decimal("0.5")),
+            (Decimal(10_000), Decimal(100), Decimal(0)),
+            (Decimal(0), Decimal(100), Decimal("0.5")),
+        ],
+    )
+    def test_non_positive_inputs_return_none(
+        self,
+        equity: Decimal,
+        entry_price: Decimal,
+        notional_pct: Decimal,
+    ) -> None:
+        qty = notional_quantity(
+            equity=equity,
+            entry_price=entry_price,
+            notional_pct=notional_pct,
+        )
+
+        assert qty is None
+
+
+class TestAnnualizedVolatility:
+    def test_known_return_series_scales_by_sqrt_bars_per_year(self) -> None:
+        # Per-bar returns [2%, 0%, 2%, 0%] -> population std 1% -> x sqrt(10000) = 100%
+        closes = [
+            Decimal(100),
+            Decimal(102),
+            Decimal(102),
+            Decimal("104.04"),
+            Decimal("104.04"),
+        ]
+
+        vol = annualized_volatility(closes, bars_per_year=10_000.0)
+
+        assert vol is not None
+        assert float(vol) == pytest.approx(1.0, abs=1e-12)
+
+    def test_flat_series_returns_zero(self) -> None:
+        closes = [Decimal(100)] * 5
+
+        assert annualized_volatility(closes, bars_per_year=10_000.0) == Decimal(0)
+
+    def test_fewer_than_two_closes_returns_none(self) -> None:
+        assert annualized_volatility([Decimal(100)], bars_per_year=10_000.0) is None
+
+
+class TestVolTargetQuantity:
+    def test_quantity_scales_equity_by_target_over_realized_vol(self) -> None:
+        # 40% annual target / 100% realized vol -> 0.4 weight -> 10000 * 0.4 / 100
+        qty = vol_target_quantity(
+            equity=Decimal(10_000),
+            entry_price=Decimal(100),
+            vol_target_annual_pct=Decimal(40),
+            annualized_vol=Decimal(1),
+        )
+
+        assert qty == Decimal(40)
+
+    def test_low_realized_vol_levers_weight_up(self) -> None:
+        # 40% target / 50% realized -> 0.8 weight -> 10000 * 0.8 / 100
+        qty = vol_target_quantity(
+            equity=Decimal(10_000),
+            entry_price=Decimal(100),
+            vol_target_annual_pct=Decimal(40),
+            annualized_vol=Decimal("0.5"),
+        )
+
+        assert qty == Decimal(80)
+
+    @pytest.mark.parametrize("annualized_vol", [None, Decimal(0)])
+    def test_missing_or_zero_vol_returns_none(self, annualized_vol: Decimal | None) -> None:
+        qty = vol_target_quantity(
+            equity=Decimal(10_000),
+            entry_price=Decimal(100),
+            vol_target_annual_pct=Decimal(40),
+            annualized_vol=annualized_vol,
+        )
+
+        assert qty is None
+
+    def test_zero_target_returns_none(self) -> None:
+        qty = vol_target_quantity(
+            equity=Decimal(10_000),
+            entry_price=Decimal(100),
+            vol_target_annual_pct=Decimal(0),
+            annualized_vol=Decimal(1),
+        )
+
+        assert qty is None

--- a/app/engine/tests/unit/backtest/test_runner_sizing_config.py
+++ b/app/engine/tests/unit/backtest/test_runner_sizing_config.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from decimal import Decimal
+import json
+from pathlib import Path
+
+from app.engine.backtest.runner import BacktestRunner
+from app.engine.backtest.types import BacktestConfig, BacktestMetrics, BacktestResult
+
+
+def _config_path(tmp_path: Path, text: str) -> str:
+    path = tmp_path / "config.yaml"
+    path.write_text(text)
+    return str(path)
+
+
+def test_yaml_loads_sizing_knobs_into_config(tmp_path: Path) -> None:
+    runner = BacktestRunner(
+        _config_path(
+            tmp_path,
+            "backtest:\n"
+            "  sizing_mode: notional\n"
+            "  notional_pct: 0.5\n"
+            "  vol_target_annual_pct: 40\n"
+            "  vol_lookback_bars: 30\n"
+            "  max_position_notional_pct: 1.0\n"
+            "  max_symbol_exposure_pct: 1.0\n"
+            "  max_total_exposure_leverage: 2\n",
+        ),
+    )
+
+    config = runner.config
+    loaded = (
+        config.sizing_mode,
+        config.notional_pct,
+        config.vol_target_annual_pct,
+        config.vol_lookback_bars,
+        config.max_position_notional_pct,
+        config.max_symbol_exposure_pct,
+        config.max_total_exposure_leverage,
+    )
+    assert loaded == (
+        "notional",
+        Decimal("0.5"),
+        Decimal(40),
+        30,
+        Decimal("1.0"),
+        Decimal("1.0"),
+        Decimal(2),
+    )
+
+
+def test_missing_sizing_keys_default_to_risk_mode_and_live_caps(tmp_path: Path) -> None:
+    runner = BacktestRunner(
+        _config_path(tmp_path, "backtest:\n  warmup_bars: 50\n"),
+    )
+
+    defaults = BacktestConfig()
+    config = runner.config
+    assert (config.sizing_mode, config.notional_pct) == ("risk", defaults.notional_pct)
+    assert (
+        config.vol_target_annual_pct,
+        config.vol_lookback_bars,
+        config.max_position_notional_pct,
+        config.max_symbol_exposure_pct,
+        config.max_total_exposure_leverage,
+    ) == (
+        defaults.vol_target_annual_pct,
+        defaults.vol_lookback_bars,
+        Decimal("0.10"),
+        Decimal("0.25"),
+        Decimal(3),
+    )
+
+
+def test_report_json_includes_sizing_fields(tmp_path: Path) -> None:
+    runner = BacktestRunner(
+        _config_path(
+            tmp_path,
+            "backtest:\n"
+            "  signal_source: tsmom\n"
+            "  sizing_mode: notional\n"
+            "  notional_pct: 0.25\n"
+            "  max_position_notional_pct: 1.0\n",
+        ),
+    )
+    result = BacktestResult(
+        config=runner.config,
+        metrics=BacktestMetrics(),
+    )
+    report_path = tmp_path / "report.json"
+
+    runner._save_json_report(result, report_path)
+    report = json.loads(report_path.read_text())
+
+    assert report["config"]["sizing_mode"] == "notional"
+    assert report["config"]["notional_pct"] == 0.25
+    assert report["config"]["vol_target_annual_pct"] == 0.0
+    assert report["config"]["max_position_notional_pct"] == 1.0
+    assert report["config"]["max_symbol_exposure_pct"] == 0.25
+    assert report["config"]["max_total_exposure_leverage"] == 3.0

--- a/app/engine/tests/unit/backtest/test_simulator_sizing_modes.py
+++ b/app/engine/tests/unit/backtest/test_simulator_sizing_modes.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+import app.engine.backtest.simulator as simulator_module
+from app.engine.backtest.simulator import BacktestSimulator
+from app.engine.backtest.trend_signals import TrendTarget
+from app.engine.backtest.types import BacktestConfig
+
+from .series import flat_candles
+
+
+def _long(entry: str = "100", stop: str = "98") -> TrendTarget:
+    return TrendTarget(
+        desired="LONG",
+        entry=Decimal(entry),
+        stop_loss=Decimal(stop),
+        ready=True,
+    )
+
+
+class _ScriptedEngine:
+    """Replays a fixed target per bar; holds the last target once exhausted."""
+
+    def __init__(self, targets: list[TrendTarget]):
+        self._targets = list(targets)
+        self._index = 0
+
+    def on_bar(self, candle: Any) -> TrendTarget:
+        target = self._targets[min(self._index, len(self._targets) - 1)]
+        self._index += 1
+        return target
+
+
+def _install_engine(monkeypatch: pytest.MonkeyPatch, targets: list[TrendTarget]) -> None:
+    monkeypatch.setattr(
+        simulator_module,
+        "create_trend_engine",
+        lambda config: _ScriptedEngine(targets),
+    )
+
+
+def _trend_config(**overrides: Any) -> BacktestConfig:
+    defaults: dict[str, Any] = {
+        "signal_source": "price_sma",
+        "slippage_bps": Decimal(0),
+    }
+    defaults.update(overrides)
+    return BacktestConfig(**defaults)
+
+
+async def _run(sim: BacktestSimulator, candles: list) -> None:
+    for candle in candles:
+        await sim.process_candle(candle)
+
+
+class TestNotionalSizing:
+    @pytest.mark.asyncio
+    async def test_notional_mode_sizes_qty_as_equity_fraction_over_entry(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # 10000 equity * 0.5 notional / 100 entry = 50 units
+        _install_engine(monkeypatch, [_long()])
+        sim = BacktestSimulator(
+            _trend_config(
+                sizing_mode="notional",
+                notional_pct=Decimal("0.5"),
+                max_position_notional_pct=Decimal(1),
+                max_symbol_exposure_pct=Decimal(1),
+            ),
+        )
+
+        await _run(sim, flat_candles(3))
+
+        assert sim.positions["BTCUSDT"].quantity == Decimal(50)
+
+    @pytest.mark.asyncio
+    async def test_notional_mode_is_clamped_by_configured_caps(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Full notional requested but the default 10% position cap re-binds:
+        # 10000 * 0.10 / 100 entry = 10 units
+        _install_engine(monkeypatch, [_long()])
+        sim = BacktestSimulator(
+            _trend_config(sizing_mode="notional", notional_pct=Decimal(1)),
+        )
+
+        await _run(sim, flat_candles(3))
+
+        assert sim.positions["BTCUSDT"].quantity == Decimal(10)
+
+
+class TestVolTargetSizing:
+    @pytest.mark.asyncio
+    async def test_vol_target_sizes_from_realized_vol(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # 40% target / 100% realized vol -> 0.4 weight -> 10000 * 0.4 / 100 = 40
+        _install_engine(monkeypatch, [_long()])
+        monkeypatch.setattr(
+            simulator_module,
+            "annualized_volatility",
+            lambda closes, bars_per_year: Decimal(1),
+        )
+        sim = BacktestSimulator(
+            _trend_config(
+                sizing_mode="vol_target",
+                vol_target_annual_pct=Decimal(40),
+                vol_lookback_bars=2,
+                max_position_notional_pct=Decimal(1),
+                max_symbol_exposure_pct=Decimal(1),
+            ),
+        )
+
+        await _run(sim, flat_candles(6))
+
+        assert sim.positions["BTCUSDT"].quantity == Decimal(40)
+
+    @pytest.mark.asyncio
+    async def test_vol_target_skips_entry_without_enough_history(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _install_engine(monkeypatch, [_long()])
+        sim = BacktestSimulator(
+            _trend_config(
+                sizing_mode="vol_target",
+                vol_target_annual_pct=Decimal(40),
+                vol_lookback_bars=5,
+                max_position_notional_pct=Decimal(1),
+                max_symbol_exposure_pct=Decimal(1),
+            ),
+        )
+
+        await _run(sim, flat_candles(3))
+
+        assert sim.positions == {}
+        assert sim.active_orders == []
+
+    @pytest.mark.asyncio
+    async def test_vol_target_skips_entry_on_zero_realized_vol(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Flat closes -> realized vol 0 -> weight undefined -> no entry, ever.
+        _install_engine(monkeypatch, [_long()])
+        sim = BacktestSimulator(
+            _trend_config(
+                sizing_mode="vol_target",
+                vol_target_annual_pct=Decimal(40),
+                vol_lookback_bars=3,
+                max_position_notional_pct=Decimal(1),
+                max_symbol_exposure_pct=Decimal(1),
+            ),
+        )
+
+        await _run(sim, flat_candles(10))
+
+        assert sim.positions == {}
+        assert sim.active_orders == []
+
+
+class TestSizingValidationAndDefaults:
+    @pytest.mark.asyncio
+    async def test_default_risk_mode_preserves_fixed_fractional_sizing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # 10000 * 0.005 risk / 2 stop distance = 25, clamped by the 10%
+        # notional cap to 10000 * 0.10 / 100 = 10 — the historical sizing.
+        _install_engine(monkeypatch, [_long()])
+        sim = BacktestSimulator(_trend_config())
+
+        await _run(sim, flat_candles(3))
+
+        assert sim.positions["BTCUSDT"].quantity == Decimal(10)
+
+    def test_non_risk_sizing_with_smc_retest_raises(self) -> None:
+        with pytest.raises(ValueError, match="sizing_mode"):
+            BacktestSimulator(BacktestConfig(sizing_mode="notional"))
+
+    def test_unknown_sizing_mode_raises(self) -> None:
+        with pytest.raises(ValueError, match="sizing_mode"):
+            BacktestSimulator(
+                BacktestConfig(signal_source="price_sma", sizing_mode="kelly"),
+            )
+
+    def test_vol_target_requires_positive_target(self) -> None:
+        with pytest.raises(ValueError, match="vol_target_annual_pct"):
+            BacktestSimulator(
+                BacktestConfig(
+                    signal_source="price_sma",
+                    sizing_mode="vol_target",
+                    vol_target_annual_pct=Decimal(0),
+                ),
+            )
+
+    @pytest.mark.parametrize("vol_lookback_bars", [1, 200])
+    def test_vol_target_rejects_lookback_outside_candle_buffer(
+        self,
+        vol_lookback_bars: int,
+    ) -> None:
+        # Outside [2, 199] the buffer can never supply lookback+1 closes and
+        # the arm would silently never trade — fail loudly at construction.
+        with pytest.raises(ValueError, match="vol_lookback_bars"):
+            BacktestSimulator(
+                BacktestConfig(
+                    signal_source="price_sma",
+                    sizing_mode="vol_target",
+                    vol_target_annual_pct=Decimal(40),
+                    vol_lookback_bars=vol_lookback_bars,
+                ),
+            )
+
+    def test_caps_flow_from_config_into_risk_parameters(self) -> None:
+        sim = BacktestSimulator(
+            BacktestConfig(
+                signal_source="price_sma",
+                max_position_notional_pct=Decimal(1),
+                max_symbol_exposure_pct=Decimal("0.8"),
+                max_total_exposure_leverage=Decimal(2),
+            ),
+        )
+
+        assert (
+            sim._risk.max_position_notional_pct,
+            sim._risk.max_symbol_exposure_pct,
+            sim._risk.max_total_exposure_leverage,
+        ) == (Decimal(1), Decimal("0.8"), Decimal(2))

--- a/app/engine/tests/unit/backtest/test_simulator_sizing_modes.py
+++ b/app/engine/tests/unit/backtest/test_simulator_sizing_modes.py
@@ -191,6 +191,18 @@ class TestSizingValidationAndDefaults:
                 BacktestConfig(signal_source="price_sma", sizing_mode="kelly"),
             )
 
+    def test_notional_requires_positive_notional_pct(self) -> None:
+        # Without this, notional_pct<=0 makes notional_quantity return None and
+        # the arm silently never trades instead of failing loudly.
+        with pytest.raises(ValueError, match="notional_pct"):
+            BacktestSimulator(
+                BacktestConfig(
+                    signal_source="price_sma",
+                    sizing_mode="notional",
+                    notional_pct=Decimal(0),
+                ),
+            )
+
     def test_vol_target_requires_positive_target(self) -> None:
         with pytest.raises(ValueError, match="vol_target_annual_pct"):
             BacktestSimulator(

--- a/app/engine/tests/unit/backtest/test_simulator_strategy_knobs.py
+++ b/app/engine/tests/unit/backtest/test_simulator_strategy_knobs.py
@@ -13,7 +13,9 @@ from app.engine.backtest.types import BacktestConfig, OrderType
 from .series import make_candle
 
 
-def _signal(timestamp: datetime, *, entry: str, stop: str, direction: str = "LONG") -> dict[str, Any]:
+def _signal(
+    timestamp: datetime, *, entry: str, stop: str, direction: str = "LONG"
+) -> dict[str, Any]:
     e = Decimal(entry)
     s = Decimal(stop)
     risk = abs(e - s)
@@ -35,7 +37,9 @@ def _signal(timestamp: datetime, *, entry: str, stop: str, direction: str = "LON
     }
 
 
-def _install_signal(monkeypatch: pytest.MonkeyPatch, sig: dict[str, Any], fire_at: datetime) -> None:
+def _install_signal(
+    monkeypatch: pytest.MonkeyPatch, sig: dict[str, Any], fire_at: datetime
+) -> None:
     async def fake_analyze(**kwargs: Any) -> dict[str, Any] | None:
         if kwargs["candles"][-1]["open_time"] == fire_at:
             return dict(sig)  # fresh copy; sim mutates stop_loss in place
@@ -61,7 +65,11 @@ class TestHtfTrendGate:
     async def test_downtrend_vetoes_long(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # Falling prices → slow EMA sits ABOVE the last close → long is counter-trend.
         candles = _ramp_candles(60, "130", "100")
-        _install_signal(monkeypatch, _signal(candles[-1].open_time, entry="100", stop="98"), candles[-1].open_time)
+        _install_signal(
+            monkeypatch,
+            _signal(candles[-1].open_time, entry="100", stop="98"),
+            candles[-1].open_time,
+        )
         sim = BacktestSimulator(BacktestConfig(htf_ema_period=10, warmup_bars=50))
 
         for c in candles:
@@ -74,7 +82,11 @@ class TestHtfTrendGate:
     async def test_uptrend_allows_long(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # Rising prices → slow EMA sits BELOW the last close → long is trend-aligned.
         candles = _ramp_candles(60, "70", "100")
-        _install_signal(monkeypatch, _signal(candles[-1].open_time, entry="100", stop="98"), candles[-1].open_time)
+        _install_signal(
+            monkeypatch,
+            _signal(candles[-1].open_time, entry="100", stop="98"),
+            candles[-1].open_time,
+        )
         sim = BacktestSimulator(BacktestConfig(htf_ema_period=10, warmup_bars=50))
 
         for c in candles:
@@ -84,9 +96,15 @@ class TestHtfTrendGate:
         assert len(market_orders) == 1, "a trend-aligned long must pass the HTF gate"
 
     @pytest.mark.asyncio
-    async def test_disabled_gate_allows_counter_trend(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_disabled_gate_allows_counter_trend(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         candles = _ramp_candles(60, "130", "100")
-        _install_signal(monkeypatch, _signal(candles[-1].open_time, entry="100", stop="98"), candles[-1].open_time)
+        _install_signal(
+            monkeypatch,
+            _signal(candles[-1].open_time, entry="100", stop="98"),
+            candles[-1].open_time,
+        )
         sim = BacktestSimulator(BacktestConfig(htf_ema_period=0, warmup_bars=50))  # gate off
 
         for c in candles:
@@ -95,10 +113,16 @@ class TestHtfTrendGate:
         assert len([o for o in sim.active_orders if o.type == OrderType.MARKET]) == 1
 
     @pytest.mark.asyncio
-    async def test_strict_dual_ema_allows_when_stacked(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_strict_dual_ema_allows_when_stacked(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         # Rising ramp → close > fast EMA > slow EMA → strict long allowed.
         candles = _ramp_candles(70, "70", "100")
-        _install_signal(monkeypatch, _signal(candles[-1].open_time, entry="100", stop="98"), candles[-1].open_time)
+        _install_signal(
+            monkeypatch,
+            _signal(candles[-1].open_time, entry="100", stop="98"),
+            candles[-1].open_time,
+        )
         sim = BacktestSimulator(BacktestConfig(htf_ema_period=50, htf_ema_fast=10, warmup_bars=50))
 
         for c in candles:
@@ -107,10 +131,16 @@ class TestHtfTrendGate:
         assert len([o for o in sim.active_orders if o.type == OrderType.MARKET]) == 1
 
     @pytest.mark.asyncio
-    async def test_strict_dual_ema_vetoes_when_not_stacked(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_strict_dual_ema_vetoes_when_not_stacked(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         # Falling ramp → close < fast < slow → strict long vetoed.
         candles = _ramp_candles(70, "130", "100")
-        _install_signal(monkeypatch, _signal(candles[-1].open_time, entry="100", stop="98"), candles[-1].open_time)
+        _install_signal(
+            monkeypatch,
+            _signal(candles[-1].open_time, entry="100", stop="98"),
+            candles[-1].open_time,
+        )
         sim = BacktestSimulator(BacktestConfig(htf_ema_period=50, htf_ema_fast=10, warmup_bars=50))
 
         for c in candles:
@@ -125,7 +155,11 @@ class TestMinStopFloor:
         # Entry 100, structure stop only 10bps away; floor at 100bps (1%) must widen it to 99.0.
         # Fire one bar before the end so the market entry fills and a position opens.
         candles = _ramp_candles(56, "97", "100")
-        _install_signal(monkeypatch, _signal(candles[-2].open_time, entry="100", stop="99.9"), candles[-2].open_time)
+        _install_signal(
+            monkeypatch,
+            _signal(candles[-2].open_time, entry="100", stop="99.9"),
+            candles[-2].open_time,
+        )
         sim = BacktestSimulator(BacktestConfig(min_stop_bps=Decimal(100), warmup_bars=50))
 
         for c in candles:
@@ -137,7 +171,11 @@ class TestMinStopFloor:
     async def test_wide_stop_is_untouched(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # Structure stop already 2% away; a 1% floor must not move it.
         candles = _ramp_candles(56, "97", "100")
-        _install_signal(monkeypatch, _signal(candles[-2].open_time, entry="100", stop="98"), candles[-2].open_time)
+        _install_signal(
+            monkeypatch,
+            _signal(candles[-2].open_time, entry="100", stop="98"),
+            candles[-2].open_time,
+        )
         sim = BacktestSimulator(BacktestConfig(min_stop_bps=Decimal(100), warmup_bars=50))
 
         for c in candles:
@@ -152,14 +190,25 @@ class TestMinStopFloor:
         # per dollar of fees — the whole point. Assert risked_amount rises.
         candles = _ramp_candles(56, "97", "100")
 
-        _install_signal(monkeypatch, _signal(candles[-2].open_time, entry="100", stop="99.9"), candles[-2].open_time)
+        _install_signal(
+            monkeypatch,
+            _signal(candles[-2].open_time, entry="100", stop="99.9"),
+            candles[-2].open_time,
+        )
         floored = BacktestSimulator(BacktestConfig(min_stop_bps=Decimal(100), warmup_bars=50))
         for c in candles:
             await floored.process_candle(c)
 
-        _install_signal(monkeypatch, _signal(candles[-2].open_time, entry="100", stop="99.9"), candles[-2].open_time)
+        _install_signal(
+            monkeypatch,
+            _signal(candles[-2].open_time, entry="100", stop="99.9"),
+            candles[-2].open_time,
+        )
         unfloored = BacktestSimulator(BacktestConfig(min_stop_bps=Decimal(0), warmup_bars=50))
         for c in candles:
             await unfloored.process_candle(c)
 
-        assert floored.positions["BTCUSDT"].risked_amount > unfloored.positions["BTCUSDT"].risked_amount
+        assert (
+            floored.positions["BTCUSDT"].risked_amount
+            > unfloored.positions["BTCUSDT"].risked_amount
+        )

--- a/app/engine/tests/unit/backtest/test_sizing_caps.py
+++ b/app/engine/tests/unit/backtest/test_sizing_caps.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from decimal import Decimal
 
-from app.engine.decision.sizing import RiskCappedSize, size_with_exposure_caps
+from app.engine.decision.sizing import (
+    RiskCappedSize,
+    cap_quantity_with_exposure_caps,
+    size_with_exposure_caps,
+)
 from app.engine.models import RiskParameters
 
 
@@ -90,4 +94,58 @@ class TestSizeWithExposureCaps:
         )
 
         assert sized is not None
+        assert (sized.quantity, sized.capped) == (Decimal(10), True)
+
+
+class TestCapQuantityWithExposureCaps:
+    def test_quantity_within_caps_passes_through(self) -> None:
+        sized = cap_quantity_with_exposure_caps(
+            quantity=Decimal(5),
+            equity=Decimal(10_000),
+            entry_price=Decimal(100),
+            risk=make_risk(),
+        )
+
+        assert sized == RiskCappedSize(
+            quantity=Decimal(5),
+            original_quantity=Decimal(5),
+        )
+        assert sized.capped is False
+
+    def test_position_notional_cap_clamps_quantity(self) -> None:
+        sized = cap_quantity_with_exposure_caps(
+            quantity=Decimal(200),
+            equity=Decimal(10_000),
+            entry_price=Decimal(100),
+            risk=make_risk(max_position_notional_pct=Decimal("0.10")),
+        )
+
+        assert (sized.quantity, sized.original_quantity, sized.capped) == (
+            Decimal(10),
+            Decimal(200),
+            True,
+        )
+
+    def test_symbol_headroom_clamps_quantity(self) -> None:
+        # 25% symbol cap on 10k equity = 2500 USD; 2000 held -> 500 headroom -> 5 units
+        sized = cap_quantity_with_exposure_caps(
+            quantity=Decimal(50),
+            equity=Decimal(10_000),
+            entry_price=Decimal(100),
+            risk=make_risk(max_symbol_exposure_pct=Decimal("0.25")),
+            existing_symbol_exposure_usd=Decimal(2000),
+        )
+
+        assert (sized.quantity, sized.capped) == (Decimal(5), True)
+
+    def test_total_leverage_headroom_clamps_quantity(self) -> None:
+        # 3x leverage on 10k equity = 30k USD; 29k held -> 1k headroom -> 10 units
+        sized = cap_quantity_with_exposure_caps(
+            quantity=Decimal(500),
+            equity=Decimal(10_000),
+            entry_price=Decimal(100),
+            risk=make_risk(max_total_exposure_leverage=Decimal(3)),
+            existing_total_exposure_usd=Decimal(29_000),
+        )
+
         assert (sized.quantity, sized.capped) == (Decimal(10), True)

--- a/app/engine/tests/unit/paper/test_bracket_scoped_close.py
+++ b/app/engine/tests/unit/paper/test_bracket_scoped_close.py
@@ -1,0 +1,307 @@
+"""
+Unit tests for zero-TP brackets and bracket-scoped position close.
+
+Phase 3a (trend paper): the trend co-primaries run with no take profit
+(exit on flip/stop), and two strategies can hold positions on the same
+symbol, so closing must be scoped to a single bracket and must cancel the
+bracket's resting stop before the close order (no double exit fill).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+from fastapi import HTTPException
+import pytest
+
+from app.engine.backtest.types import BacktestOrder, OrderSide, OrderStatus, OrderType
+from app.engine.models import Candle, TimeFrame
+from app.engine.paper.broker import (
+    ClientOrderIDs,
+    PaperBroker,
+    PaperPosition,
+    PlaceBracketRequest,
+)
+
+# Accessing broker internals is intentional in these unit tests.
+# ruff: noqa: SLF001
+
+SYMBOL = "BTCUSDT"
+ENTRY_PRICE = Decimal(50000)
+STOP_PRICE = Decimal(49500)
+QUANTITY = Decimal("0.01")
+
+
+@pytest.fixture
+def mock_pool() -> tuple[MagicMock, AsyncMock]:
+    pool = MagicMock()
+    conn = AsyncMock()
+    conn.transaction = MagicMock(return_value=AsyncMock())
+    pool.acquire.return_value.__aenter__.return_value = conn
+    pool.acquire.return_value.__aexit__.return_value = None
+    return pool, conn
+
+
+def _make_broker(pool: MagicMock) -> PaperBroker:
+    broker = PaperBroker(database_url="postgresql://test:test@localhost/test")
+    broker.db_pool = pool
+    return broker
+
+
+def _make_candle(*, open_price: Decimal, high: Decimal, low: Decimal) -> Candle:
+    now = datetime.now(UTC)
+    return Candle(
+        venue="spot",
+        symbol=SYMBOL,
+        timeframe=TimeFrame.D1,
+        open_time=now,
+        close_time=now,
+        open_price=open_price,
+        high_price=high,
+        low_price=low,
+        close_price=open_price,
+        volume=Decimal(100),
+        quote_volume=Decimal(0),
+        trades=1,
+        taker_buy_base_volume=Decimal(0),
+        taker_buy_quote_volume=Decimal(0),
+    )
+
+
+def _zero_tp_request(client_order_ids: ClientOrderIDs | None = None) -> PlaceBracketRequest:
+    return PlaceBracketRequest(
+        symbol=SYMBOL,
+        side="BUY",
+        quantity=QUANTITY,
+        take_profit_prices=[],
+        stop_loss_price=STOP_PRICE,
+        order_type="MARKET",
+        client_order_ids=client_order_ids,
+    )
+
+
+def _seed_long_bracket(
+    broker: PaperBroker,
+    bracket_id: UUID,
+    stop_client_order_id: str,
+) -> None:
+    """Seed a filled long position with its resting stop, as after entry fill."""
+    position = PaperPosition(SYMBOL)
+    position.net_quantity = QUANTITY
+    position.avg_entry_price = ENTRY_PRICE
+    broker.positions[(SYMBOL, bracket_id)] = position
+
+    stop_order = BacktestOrder(
+        symbol=SYMBOL,
+        side=OrderSide.SELL,
+        type=OrderType.STOP_MARKET,
+        quantity=QUANTITY,
+        stop_price=STOP_PRICE,
+        client_order_id=stop_client_order_id,
+        status=OrderStatus.NEW,
+        reduce_only=True,
+    )
+    broker.active_orders[stop_client_order_id] = stop_order
+    broker._order_bracket_ids[stop_client_order_id] = bracket_id
+
+
+@pytest.mark.asyncio
+async def test_zero_tp_bracket_creates_entry_and_stop_only(
+    mock_pool: tuple[MagicMock, AsyncMock],
+) -> None:
+    """Empty take_profit_prices places exactly two orders: entry + stop."""
+    pool, _conn = mock_pool
+    broker = _make_broker(pool)
+
+    response = await broker.place_bracket_order(_zero_tp_request())
+
+    entry = broker.active_orders[response.client_order_ids.main]
+    stop = broker.active_orders[response.client_order_ids.stop_loss]
+    assert (
+        response.client_order_ids.take_profits,
+        len(broker.active_orders),
+        (entry.type, entry.reduce_only),
+        (stop.type, stop.stop_price, stop.reduce_only),
+    ) == ([], 2, (OrderType.MARKET, False), (OrderType.STOP_MARKET, STOP_PRICE, True))
+
+
+@pytest.mark.asyncio
+async def test_zero_tp_bracket_honors_engine_supplied_ids(
+    mock_pool: tuple[MagicMock, AsyncMock],
+) -> None:
+    """Engine-supplied IDs with an empty take_profits list are accepted."""
+    pool, _conn = mock_pool
+    broker = _make_broker(pool)
+    supplied = ClientOrderIDs(main="trend-main-1", take_profits=[], stop_loss="trend-sl-1")
+
+    response = await broker.place_bracket_order(_zero_tp_request(supplied))
+
+    assert (response.client_order_ids, sorted(broker.active_orders)) == (
+        supplied,
+        ["trend-main-1", "trend-sl-1"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_bracket_with_multiple_tp_prices_rejected(
+    mock_pool: tuple[MagicMock, AsyncMock],
+) -> None:
+    """More than one TP is still rejected with HTTP 400."""
+    pool, _conn = mock_pool
+    broker = _make_broker(pool)
+    request = PlaceBracketRequest(
+        symbol=SYMBOL,
+        side="BUY",
+        quantity=QUANTITY,
+        take_profit_prices=[Decimal(51000), Decimal(52000)],
+        stop_loss_price=STOP_PRICE,
+        order_type="MARKET",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await broker.place_bracket_order(request)
+
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_close_position_closes_only_matching_bracket(
+    mock_pool: tuple[MagicMock, AsyncMock],
+) -> None:
+    """Two brackets on one symbol: closing one leaves the other's position and stop."""
+    pool, _conn = mock_pool
+    broker = _make_broker(pool)
+    bracket_a, bracket_b = uuid4(), uuid4()
+    _seed_long_bracket(broker, bracket_a, "sleeve-a-sl")
+    _seed_long_bracket(broker, bracket_b, "sleeve-b-sl")
+    candle = _make_candle(
+        open_price=Decimal(50200),
+        high=Decimal(50300),
+        low=Decimal(50100),
+    )
+    broker.latest_candles[SYMBOL] = candle
+    broker.current_prices[SYMBOL] = candle.close_price
+
+    result = await broker.close_position(SYMBOL, bracket_a, client_order_id="trend-close-a")
+
+    assert (
+        result["status"],
+        broker.positions[(SYMBOL, bracket_a)].net_quantity,
+        broker.positions[(SYMBOL, bracket_b)].net_quantity,
+        "sleeve-a-sl" in broker.active_orders,
+        "sleeve-b-sl" in broker.active_orders,
+    ) == ("success", Decimal(0), QUANTITY, False, True)
+
+
+@pytest.mark.asyncio
+async def test_close_position_cancels_resting_stop_before_close(
+    mock_pool: tuple[MagicMock, AsyncMock],
+) -> None:
+    """A candle that would trigger the stop must not double-exit the position."""
+    pool, _conn = mock_pool
+    broker = _make_broker(pool)
+    bracket_id = uuid4()
+    _seed_long_bracket(broker, bracket_id, "trend-sl-1")
+    candle = _make_candle(
+        open_price=Decimal(49400),
+        high=Decimal(49450),
+        low=Decimal(49000),
+    )
+    broker.latest_candles[SYMBOL] = candle
+    broker.current_prices[SYMBOL] = candle.close_price
+
+    result = await broker.close_position(SYMBOL, bracket_id, client_order_id="trend-close-1")
+
+    assert (
+        result["status"],
+        broker.positions[(SYMBOL, bracket_id)].net_quantity,
+        broker.active_orders,
+    ) == ("success", Decimal(0), {})
+
+
+@pytest.mark.asyncio
+async def test_close_position_without_position_cancels_resting_orders(
+    mock_pool: tuple[MagicMock, AsyncMock],
+) -> None:
+    """Flattening a bracket with no position cancels its resting orders in DB and memory."""
+    pool, conn = mock_pool
+    broker = _make_broker(pool)
+    bracket_id = uuid4()
+    entry_order = BacktestOrder(
+        symbol=SYMBOL,
+        side=OrderSide.BUY,
+        type=OrderType.LIMIT,
+        quantity=QUANTITY,
+        price=ENTRY_PRICE,
+        client_order_id="trend-main-1",
+        status=OrderStatus.NEW,
+        reduce_only=False,
+    )
+    broker.active_orders["trend-main-1"] = entry_order
+    broker._order_bracket_ids["trend-main-1"] = bracket_id
+    _seed_long_bracket(broker, bracket_id, "trend-sl-1")
+    broker.positions.pop((SYMBOL, bracket_id))
+
+    result = await broker.close_position(SYMBOL, bracket_id)
+
+    executed_sql = " ".join(call.args[0] for call in conn.execute.call_args_list)
+    assert (
+        result["status"],
+        broker.active_orders,
+        "UPDATE paper_orders" in executed_sql,
+    ) == ("success", {}, True)
+
+
+@pytest.mark.asyncio
+async def test_close_position_closes_short_position_with_buy_order(
+    mock_pool: tuple[MagicMock, AsyncMock],
+) -> None:
+    """A short bracket flattens to zero via a BUY market close."""
+    pool, _conn = mock_pool
+    broker = _make_broker(pool)
+    bracket_id = uuid4()
+    position = PaperPosition(SYMBOL)
+    position.net_quantity = -QUANTITY
+    position.avg_entry_price = ENTRY_PRICE
+    broker.positions[(SYMBOL, bracket_id)] = position
+    candle = _make_candle(
+        open_price=Decimal(50200),
+        high=Decimal(50300),
+        low=Decimal(50100),
+    )
+    broker.latest_candles[SYMBOL] = candle
+    broker.current_prices[SYMBOL] = candle.close_price
+
+    result = await broker.close_position(SYMBOL, bracket_id, client_order_id="trend-close-short")
+
+    assert (
+        result["status"],
+        result["closed"],
+        broker.positions[(SYMBOL, bracket_id)].net_quantity,
+    ) == ("success", "true", Decimal(0))
+
+
+@pytest.mark.asyncio
+async def test_close_position_duplicate_client_id_places_single_close(
+    mock_pool: tuple[MagicMock, AsyncMock],
+) -> None:
+    """Retrying a close with the same client_order_id does not duplicate the order."""
+    pool, _conn = mock_pool
+    broker = _make_broker(pool)
+    bracket_id = uuid4()
+    _seed_long_bracket(broker, bracket_id, "trend-sl-1")
+
+    first = await broker.close_position(SYMBOL, bracket_id, client_order_id="trend-close-1")
+    second = await broker.close_position(SYMBOL, bracket_id, client_order_id="trend-close-1")
+
+    close_orders = [
+        order for order in broker.active_orders.values() if order.client_order_id == "trend-close-1"
+    ]
+    assert (first["status"], second["status"], len(close_orders)) == (
+        "success",
+        "duplicate",
+        1,
+    )


### PR DESCRIPTION
## Summary

Phase 3a **PR1 of 4** (plan: `docs/plans/2026-07-10-phase-3a-trend-paper.md`, stacked on #209).

The daily trend co-primaries (tsmom-28d, price>SMA-65d) run long/cash with `trend_tp_r=0` — no take profit, exit on flip/stop — and two strategies hold positions on the **same symbol** in separate brackets. This PR extends the PaperBroker accordingly:

- `place_bracket_order` accepts an **empty `take_profit_prices`** list and places entry + STOP_MARKET stop only. Multiple TPs are still rejected (400). Single-TP behavior unchanged.
- New **bracket-scoped `close_position(symbol, bracket_id, client_order_id=None)`**: closes only the matching bracket's position and cancels the bracket's resting orders **before** placing the market close, so one candle cannot fill both the stop and the close (no double exit). `close_all_positions(symbol)` would flatten the sibling strategy's sleeve — this is the safe primitive for PR2's desired-state diff.
- Retrying a close with the same `client_order_id` is a no-op (`status: duplicate`) — restart idempotence.
- `/close_position` endpoint + `cancel_bracket_orders_sql` schema builder (parameterized).

## Tests (TDD)

New `app/engine/tests/unit/paper/test_bracket_scoped_close.py` (8 tests, written RED first):
zero-TP creates entry+stop only · engine-supplied IDs with empty TP list · multi-TP still rejected · close touches only the matching bracket · stop-triggering candle cannot double-exit · no-position close cancels resting orders (DB + memory) · SHORT closes via BUY · duplicate close client ID places a single order.

Gates: `ruff check` / `ruff format --check` / `mypy` clean on changed files; paper unit suite 105 passed × 3 consecutive runs.

## Notes

- Pre-existing (untouched by this PR): `close_all_positions` places market closes without cancelling resting stops first — same double-exit hazard this PR fixes for the bracket-scoped path. Candidate follow-up.
- Pre-existing repo gate failures unrelated to this diff: mypy errors in `adapters/redis/redis_adapter.py:717` and `monitoring/pipeline_health_service.py:170`; `ruff format` drift in 5 files; `test_redis_adapter_syntax.py` mypy-compliance test failing.
