### PR TITLE
fix(soak): stop UI health from aborting soak; add missing UI /api/health route

### DIFF
--- a/app/ui/next.config.js
+++ b/app/ui/next.config.js
@@ -11,6 +11,8 @@ const nextConfig = {
   },
   async rewrites() {
     const internalApiUrl = process.env.NEXT_INTERNAL_API_URL || 'http://bff:3001/api'
+    // Filesystem routes under src/app/api/ (e.g. /api/health) win over this
+    // afterFiles rewrite, so they are served by the UI itself, not the BFF.
     return [
       {
         source: '/api/:path*',

--- a/app/ui/src/app/api/health/route.spec.ts
+++ b/app/ui/src/app/api/health/route.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+
+import { GET } from './route'
+
+describe('GET /api/health', () => {
+  it('returns 200 with ok status and a parseable ISO timestamp', async () => {
+    const response = GET()
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body).toEqual({ status: 'ok', timestamp: expect.any(String) })
+    expect(new Date(body.timestamp).toISOString()).toBe(body.timestamp)
+  })
+})

--- a/app/ui/src/app/api/health/route.ts
+++ b/app/ui/src/app/api/health/route.ts
@@ -1,0 +1,5 @@
+export const dynamic = 'force-dynamic'
+
+export function GET(): Response {
+  return Response.json({ status: 'ok', timestamp: new Date().toISOString() })
+}

--- a/scripts/run_testnet_soak.py
+++ b/scripts/run_testnet_soak.py
@@ -278,6 +278,12 @@ def build_recommendations(results: list[CheckResult]) -> list[str]:
                 "Inspect stack logs and health endpoints before retrying; a service failed to become healthy."
             )
             handled = True
+        elif result.status == "warn" and result.name.startswith("health:"):
+            recommendations.append(
+                f"Investigate the unhealthy non-critical service ({result.name}); "
+                "the soak continued because it does not gate the trading pipeline."
+            )
+            handled = True
         elif result.status == "fail" and result.name == "log_assertions":
             recommendations.append(
                 "Review engine/router startup logs; required testnet execution markers were missing or error signatures were present."
@@ -294,7 +300,7 @@ def build_recommendations(results: list[CheckResult]) -> list[str]:
             )
             handled = True
 
-        if result.status == "fail" and not handled:
+        if result.status in ("fail", "warn") and not handled:
             recommendations.append(result.message)
 
     if not recommendations:
@@ -469,13 +475,16 @@ class TestnetSoakRunner:
 
     def _build_report_payload(self, *, report_type: str, run_state: str) -> dict[str, Any]:
         overall_pass = run_state == "completed" and all(
-            result.status == "pass" for result in self.results if result.status != "skip"
+            result.status == "pass"
+            for result in self.results
+            if result.status not in ("skip", "warn")
         )
         payload = {
             "started_at": self.started_at.isoformat(),
             "finished_at": datetime.now(UTC).isoformat(),
             "duration_seconds": self.args.duration_seconds,
             "overall_status": "pass" if overall_pass else "fail",
+            "warnings": sum(1 for result in self.results if result.status == "warn"),
             "report_type": report_type,
             "run_state": run_state,
             "termination_signal": self.termination_signal,
@@ -589,7 +598,9 @@ class TestnetSoakRunner:
         except http.client.HTTPException as exc:
             raise RuntimeError(str(exc)) from exc
 
-    def _wait_for_http(self, name: str, url: str, *, timeout_seconds: int = 120) -> None:
+    def _wait_for_http(
+        self, name: str, url: str, *, timeout_seconds: int = 120, critical: bool = True
+    ) -> None:
         deadline = time.monotonic() + timeout_seconds
         while time.monotonic() < deadline:
             try:
@@ -611,7 +622,7 @@ class TestnetSoakRunner:
         self._record(
             CheckResult(
                 name=f"health:{name}",
-                status="fail",
+                status="fail" if critical else "warn",
                 message=f"{name} did not become healthy within timeout",
                 details={"url": url, "timeout_seconds": timeout_seconds},
             )
@@ -791,8 +802,12 @@ class TestnetSoakRunner:
         return status == "pass"
 
     def check_stack_health(self) -> bool:
-        for name in ("engine", "router", "bff", "ui"):
+        for name in ("engine", "router", "bff"):
             self._wait_for_http(name, self.health_urls[name])
+        # The soak validates the engine→router trading pipeline; the UI is a
+        # bystander that monitor_window never probes, so an unhealthy UI is
+        # recorded as a warning instead of aborting a 7-day run.
+        self._wait_for_http("ui", self.health_urls["ui"], critical=False)
         # /readyz is 503 while the startup reconciler runs and flips to 200
         # once it completes, so a passing probe proves C6 reconciliation ran
         # to completion before the stack started taking work. Allow more time
@@ -800,8 +815,8 @@ class TestnetSoakRunner:
         # 2-minute timeout each before failing open (~6.5m worst case), and a
         # slow first sweep must not spuriously fail an otherwise healthy soak.
         self._wait_for_http("router_ready", self.health_urls["router_ready"], timeout_seconds=420)
-        return all(
-            result.status == "pass" for result in self.results if result.name.startswith("health:")
+        return not any(
+            result.status == "fail" for result in self.results if result.name.startswith("health:")
         )
 
     def assert_log_signatures(self) -> bool:

--- a/tests/test_run_testnet_soak.py
+++ b/tests/test_run_testnet_soak.py
@@ -9,6 +9,8 @@ import tempfile
 import types
 from urllib.error import URLError
 
+import pytest
+
 
 def _load_run_testnet_soak_module():
     script_path = Path(__file__).resolve().parents[1] / "scripts" / "run_testnet_soak.py"
@@ -352,6 +354,175 @@ def test_monitor_window_skips_periodic_order_smoke_before_interval(monkeypatch):
     runner.monitor_window()
 
     assert calls == []
+
+
+def _make_runner(module, monkeypatch, **overrides):
+    monkeypatch.setattr(
+        module.TestnetSoakRunner, "_resolve_compose_command", lambda self: ["docker-compose"]
+    )
+    defaults = {
+        "compose_file": "docker-compose.dev.yml",
+        "duration_seconds": 5,
+        "poll_interval_seconds": 1,
+        "output_dir": tempfile.mkdtemp(),
+        "skip_preflight_tests": True,
+        "enable_order_smoke": False,
+        "keep_running": True,
+        "heartbeat_interval_seconds": 60,
+    }
+    defaults.update(overrides)
+    return module.TestnetSoakRunner(argparse.Namespace(**defaults))
+
+
+def _fake_clock(module, monkeypatch):
+    state = {"now": 0.0}
+    monkeypatch.setattr(module.time, "monotonic", lambda: state["now"])
+    monkeypatch.setattr(
+        module.time, "sleep", lambda seconds: state.__setitem__("now", state["now"] + seconds)
+    )
+    return state
+
+
+@pytest.mark.parametrize(
+    ("critical", "expected_status"),
+    [(True, "fail"), (False, "warn")],
+)
+def test_wait_for_http_timeout_status_depends_on_criticality(
+    monkeypatch, critical, expected_status
+):
+    module = _load_run_testnet_soak_module()
+    runner = _make_runner(module, monkeypatch)
+    _fake_clock(module, monkeypatch)
+
+    def failing_request(*args, **kwargs):
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(runner, "_request_json", failing_request)
+
+    runner._wait_for_http(
+        "ui", "http://localhost:3000/api/health", timeout_seconds=4, critical=critical
+    )
+
+    result = runner.results[-1]
+    assert (result.name, result.status) == ("health:ui", expected_status)
+    assert "did not become healthy" in result.message
+
+
+def test_check_stack_health_passes_when_only_ui_unhealthy(monkeypatch):
+    module = _load_run_testnet_soak_module()
+    runner = _make_runner(module, monkeypatch)
+    _fake_clock(module, monkeypatch)
+
+    ui_url = runner.health_urls["ui"]
+
+    def fake_request_json(url, **kwargs):
+        if url == ui_url:
+            raise RuntimeError("connection refused")
+        return 200, "{}"
+
+    monkeypatch.setattr(runner, "_request_json", fake_request_json)
+
+    assert runner.check_stack_health() is True
+    statuses = {
+        result.name: result.status for result in runner.results if result.name.startswith("health:")
+    }
+    assert statuses == {
+        "health:engine": "pass",
+        "health:router": "pass",
+        "health:bff": "pass",
+        "health:ui": "warn",
+        "health:router_ready": "pass",
+    }
+
+
+def test_check_stack_health_fails_when_critical_service_unhealthy(monkeypatch):
+    module = _load_run_testnet_soak_module()
+    runner = _make_runner(module, monkeypatch)
+    _fake_clock(module, monkeypatch)
+
+    bff_url = runner.health_urls["bff"]
+
+    def fake_request_json(url, **kwargs):
+        if url == bff_url:
+            raise RuntimeError("connection refused")
+        return 200, "{}"
+
+    monkeypatch.setattr(runner, "_request_json", fake_request_json)
+
+    assert runner.check_stack_health() is False
+
+
+def test_report_overall_status_treats_warn_as_nonblocking(monkeypatch):
+    module = _load_run_testnet_soak_module()
+    runner = _make_runner(module, monkeypatch)
+
+    runner._record(
+        module.CheckResult(name="health:engine", status="pass", message="engine became healthy")
+    )
+    runner._record(
+        module.CheckResult(
+            name="health:ui", status="warn", message="ui did not become healthy within timeout"
+        )
+    )
+
+    payload = runner._build_report_payload(report_type="final", run_state="completed")
+
+    assert payload["overall_status"] == "pass"
+    assert payload["warnings"] == 1
+
+
+def test_report_overall_status_fails_when_any_fail_present(monkeypatch):
+    module = _load_run_testnet_soak_module()
+    runner = _make_runner(module, monkeypatch)
+
+    runner._record(
+        module.CheckResult(
+            name="health:engine",
+            status="fail",
+            message="engine did not become healthy within timeout",
+        )
+    )
+    runner._record(
+        module.CheckResult(
+            name="health:ui", status="warn", message="ui did not become healthy within timeout"
+        )
+    )
+
+    payload = runner._build_report_payload(report_type="final", run_state="completed")
+
+    assert payload["overall_status"] == "fail"
+
+
+def test_build_recommendations_falls_back_to_message_for_unhandled_warn():
+    module = _load_run_testnet_soak_module()
+
+    recommendations = module.build_recommendations(
+        [
+            module.CheckResult(
+                name="order_smoke_setup",
+                status="warn",
+                message="smoke configuration partially degraded",
+            )
+        ]
+    )
+
+    assert "smoke configuration partially degraded" in recommendations
+
+
+def test_build_recommendations_flags_noncritical_health_warn():
+    module = _load_run_testnet_soak_module()
+
+    recommendations = module.build_recommendations(
+        [
+            module.CheckResult(
+                name="health:ui",
+                status="warn",
+                message="ui did not become healthy within timeout",
+            )
+        ]
+    )
+
+    assert any("soak continued" in recommendation for recommendation in recommendations)
 
 
 def test_build_recommendations_mentions_periodic_smoke_failures():


### PR DESCRIPTION
## Why

The 7-day testnet soak (run `manual-20260710T060215Z`, Gap-1 sign-off blocker) died ~15 minutes in with `overall_status: fail` even though every pipeline check passed. Root cause is two defects:

1. **The UI has no `/api/health` route.** The soak launcher and `app/ui/Dockerfile:62` both probe `http://localhost:3000/api/health`, but no route handler exists — the `/api/:path*` rewrite proxied it toward the BFF, so the probe never measured UI health and never returned a usable 200 in the soak environment. `health:ui` was guaranteed to time out on every run.
2. **UI health was fatal to the soak.** `check_stack_health()` treated a `health:ui` timeout like an engine/router failure, silently skipping the entire monitor window and tearing the stack down — even though `monitor_window()` never probes the UI during the soak.

## What

- `scripts/run_testnet_soak.py`
  - `_wait_for_http()` gains `critical: bool = True`; a non-critical timeout records `warn` instead of `fail`
  - `check_stack_health()` probes `ui` with `critical=False`; engine/router/bff/router_ready remain fatal; gate is now "no health check failed"
  - `overall_status` ignores `warn` (like `skip`); report gains a top-level `warnings` count so a warn-carrying pass is visible at a glance
  - `build_recommendations()` surfaces health warns and falls back to the raw message for any unhandled warn
- `app/ui/src/app/api/health/route.ts` (new): self-health route handler (`force-dynamic`), which the filesystem router serves ahead of the BFF rewrite — this is the endpoint the Dockerfile healthcheck and the soak launcher were already probing
- `app/ui/next.config.js`: comment documenting that filesystem `/api/*` routes shadow the BFF rewrite

## Safety

A real engine/router/bff/router_ready failure aborts and fails the report exactly as before (guard test added: any `fail` ⇒ `overall_status: fail`). Only the UI is non-gating, matching what the soak actually monitors.

## Tests

- 8 new pytest cases in `tests/test_run_testnet_soak.py` (32 total, 3× green): warn-vs-fail timeout criticality, stack health passes on UI-only failure, fails on critical failure, warn non-blocking + counted, fail dominance, warn recommendations + fallback
- New colocated vitest spec for the route handler (3× green)
- `pnpm typecheck`, `pnpm lint`, `pnpm build` (route present in build manifest), `ruff check` + `ruff format` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
