### PR TITLE
feat(trend-live): isolated paper-engine launcher to run alongside the testnet soak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -542,3 +542,6 @@ artifacts/
 app/router/main
 app/router/server
 data/backtest/
+
+# trend-live paper isolated profile (secrets)
+.env.trend-paper

--- a/docker-compose.trend-paper.yml
+++ b/docker-compose.trend-paper.yml
@@ -1,0 +1,49 @@
+# Isolated dependencies for the trend-live paper engine (phase 3a).
+# Separate compose project + volumes: the testnet soak's `down -v` on the
+# dev stack can never destroy paper-trading state, and host ports avoid
+# everything the soak owns (5432/6379/8000/8001/3001/3000).
+# Usage: docker compose --env-file .env.trend-paper -f docker-compose.trend-paper.yml up -d
+name: trend-paper
+
+services:
+  trend-paper-db:
+    # Digest-pinned: a multi-week paper run must not change database version
+    # across container recreations.
+    image: timescale/timescaledb:latest-pg16@sha256:5e3b972218628b5c8a3721792adf3894c4aef67309a312f46c093b4791115fec
+    container_name: trend-paper-db
+    restart: unless-stopped
+    environment:
+      - POSTGRES_USER=${TREND_PAPER_DB_USER:-trading_user}
+      - POSTGRES_PASSWORD=${TREND_PAPER_DB_PASSWORD:?set TREND_PAPER_DB_PASSWORD in .env.trend-paper}
+      - POSTGRES_DB=${TREND_PAPER_DB_NAME:-trend_paper}
+    ports:
+      - "${TREND_PAPER_DB_PORT:-5433}:5432"
+    volumes:
+      - trend_paper_pg_data:/var/lib/postgresql/data
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -U ${TREND_PAPER_DB_USER:-trading_user} -d ${TREND_PAPER_DB_NAME:-trend_paper}",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  trend-paper-redis:
+    image: redis:7-alpine@sha256:ee64a64eaab618d88051c3ade8f6352d11531fcf79d9a4818b9b183d8c1d18ba
+    container_name: trend-paper-redis
+    restart: unless-stopped
+    ports:
+      - "${TREND_PAPER_REDIS_PORT:-6380}:6379"
+    volumes:
+      - trend_paper_redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  trend_paper_pg_data:
+  trend_paper_redis_data:

--- a/docs/trend-live-paper-runbook.md
+++ b/docs/trend-live-paper-runbook.md
@@ -45,6 +45,65 @@ TrendDailyCandlePoller started (symbols=BTCUSDT,ETHUSDT, interval=300s)
 Started trend_daily_poller
 ```
 
+## Running alongside the testnet soak (isolated stack)
+
+The `make db-up && make dev-engine` path above assumes it owns the shared
+`.env` and the default host ports. While the 7-day testnet soak runs, both
+belong to the soak (spot_testnet execution, router on 8001, Telegram, ports
+8000/8001/3001/5432/6379) — use the isolated profile instead; it shares
+nothing with the soak stack.
+
+1. Create `.env.trend-paper` at the repo root (gitignored — set a real
+   password in both places):
+
+    ```bash
+    TREND_LIVE_ENABLED=1
+    EXECUTION_MODE=disabled
+    ENABLE_PAPER_TRADING=true
+    BINANCE_DATA_SOURCE=mainnet
+    DATABASE_URL=postgresql://trading_user:CHANGE_ME@localhost:5433/trend_paper
+    REDIS_URL=redis://localhost:6380/0
+    # unroutable on purpose: the engine's /health and /metrics probe
+    # ROUTER_URL, whose default is the soak router on 8001
+    ROUTER_URL=http://127.0.0.1:9
+    TREND_PAPER_ENGINE_PORT=8016
+    TREND_PAPER_DB_USER=trading_user
+    TREND_PAPER_DB_PASSWORD=CHANGE_ME
+    TREND_PAPER_DB_NAME=trend_paper
+    TREND_PAPER_DB_PORT=5433
+    TREND_PAPER_REDIS_PORT=6380
+    ```
+
+2. Start the dedicated TimescaleDB (5433) + Redis (6380) — a separate compose
+   project whose volumes the soak's `docker-compose down -v` can never touch:
+
+    ```bash
+    docker compose --env-file .env.trend-paper -f docker-compose.trend-paper.yml up -d
+    ```
+
+3. Launch the engine detached (validates isolation, runs migrations against
+   5433, starts uvicorn on 127.0.0.1:8016 without --reload, logs + pid under
+   `artifacts/trend-paper/manual-<ts>/`):
+
+    ```bash
+    app/engine/.venv/bin/python scripts/launch_trend_live_paper.py
+    ```
+
+4. Verify: `curl -s http://127.0.0.1:8016/health/simple`, expect the startup
+   log lines from the Enable section in `engine.log`, and run the SQL below
+   against port 5433.
+
+The launcher fails closed on any soak collision: `EXECUTION_MODE` must be
+`disabled` (the paper engine can never reach the soak router),
+`ENABLE_PAPER_TRADING=true` keeps equity sampling in-DB (no router polling),
+`DATABASE_URL`/`REDIS_URL`/engine port must avoid every soak-owned port, and
+Telegram/BFF/router/Binance credentials are stripped from the inherited
+environment (no duplicate alerts, no keys the paper path doesn't need).
+
+To stop: `kill $(python3 -c "import json;print(json.load(open('artifacts/trend-paper/<run>/launcher.json'))['pid'])")`.
+Paper state persists in the `trend-paper` compose project's volumes across
+engine restarts; warmup + recovery make relaunches idempotent.
+
 ## Verify
 
 Daily bars close at 00:00 UTC; the poller picks the new bar up within one

--- a/scripts/launch_trend_live_paper.py
+++ b/scripts/launch_trend_live_paper.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Launch the trend-live paper engine isolated from the shared .env and the soak stack.
+
+The shared .env drives the testnet soak (spot_testnet execution, router,
+Telegram, host ports 8000/8001/3001/5432/6379). This launcher builds the
+engine environment exclusively from an isolated env file, refuses any
+configuration that could collide with the soak or reach live execution or
+alert channels, runs migrations against the dedicated database, and starts
+uvicorn detached (no --reload) so the paper run survives the terminal.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import UTC, datetime
+import json
+import os
+from pathlib import Path
+import socket
+import subprocess
+import sys
+import time
+from typing import Any
+import urllib.parse
+from urllib.request import urlopen
+
+# Never inherited from the parent shell: anything that could point the paper
+# engine at the soak stack, live execution, alert channels, or exchange keys.
+INHERITED_ENV_DENYLIST = (
+    "EXECUTION_MODE",
+    "I_UNDERSTAND_LIVE_TRADING",
+    "SIGNAL_EMITTER_SUBSCRIBER_ENABLED",
+    "DATABASE_URL",
+    "DB_HOST",
+    "DB_PORT",
+    "DB_NAME",
+    "DB_USER",
+    "DB_PASSWORD",
+    "REDIS_URL",
+    "REDIS_HOST",
+    "REDIS_PORT",
+    "REDIS_PASSWORD",
+    "ROUTER_URL",
+    "ROUTER_API_KEY",
+    "TELEGRAM_BOT_TOKEN",
+    "TELEGRAM_CHAT_ID",
+    "BFF_URL",
+    "INTERNAL_ALERTS_TOKEN",
+    "ENGINE_INTERNAL_API_TOKEN",
+    "BINANCE_API_KEY",
+    "BINANCE_API_SECRET",
+    "BINANCE_SECRET_KEY",
+    "BINANCE_SPOT_API_KEY",
+    "BINANCE_SPOT_SECRET_KEY",
+    "BINANCE_FUTURES_API_KEY",
+    "BINANCE_FUTURES_SECRET_KEY",
+)
+
+# Host ports owned by the soak dev-compose stack (plus homebrew PG on 5432).
+SOAK_RESERVED_PORTS = frozenset({3000, 3001, 5432, 6379, 8000, 8001, 8002})
+
+# Set in the env file only if you intend to break isolation on purpose.
+FORBIDDEN_ENV_KEYS = ("TELEGRAM_BOT_TOKEN", "BFF_URL", "ROUTER_API_KEY")
+
+# 8010 is squatted by an unrelated container on this host; 8016 is free.
+DEFAULT_ENGINE_PORT = 8016
+
+ENGINE_HEALTH_TIMEOUT_SECONDS = 90
+
+
+def parse_env_file(path: Path) -> dict[str, str]:
+    if not path.exists():
+        raise SystemExit(f"env file not found: {path} (copy the template from the runbook)")
+    values: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        if key.startswith("export "):
+            key = key.removeprefix("export ").strip()
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            value = value[1:-1]
+        values[key] = value
+    return values
+
+
+def build_engine_environment(
+    parent_env: dict[str, str], file_env: dict[str, str]
+) -> dict[str, str]:
+    env = {key: value for key, value in parent_env.items() if key not in INHERITED_ENV_DENYLIST}
+    env.update(file_env)
+    env["PYTHONUNBUFFERED"] = "1"
+    return env
+
+
+def _validate_url_port(
+    env: dict[str, str],
+    key: str,
+    *,
+    schemes: set[str],
+    failures: list[str],
+) -> None:
+    raw = env.get(key, "").strip()
+    if not raw:
+        failures.append(f"{key} must be set to the dedicated trend-paper instance")
+        return
+    parsed = urllib.parse.urlparse(raw)
+    if parsed.scheme not in schemes:
+        failures.append(f"{key} must use one of {sorted(schemes)}, got {parsed.scheme!r}")
+        return
+    try:
+        port = parsed.port
+    except ValueError:
+        failures.append(f"{key} has an invalid port")
+        return
+    # A missing port silently defaults to the soak's 5432/6379 at runtime.
+    if port is None:
+        failures.append(f"{key} must specify an explicit port")
+        return
+    if port in SOAK_RESERVED_PORTS:
+        failures.append(
+            f"{key} points at port {port}, which the soak stack owns — "
+            "use the dedicated trend-paper instance"
+        )
+
+
+def validate_trend_paper_environment(env: dict[str, str]) -> list[str]:
+    failures: list[str] = []
+
+    if env.get("TREND_LIVE_ENABLED", "").strip() != "1":
+        failures.append("TREND_LIVE_ENABLED must be 1 — this launcher exists to run trend paper")
+    if env.get("EXECUTION_MODE", "").strip().lower() != "disabled":
+        failures.append(
+            "EXECUTION_MODE must be disabled so the paper engine can never reach the soak router"
+        )
+    if env.get("ENABLE_PAPER_TRADING", "").strip().lower() not in {"1", "true", "yes", "on"}:
+        failures.append(
+            "ENABLE_PAPER_TRADING must be true so equity sampling stays in-DB (no router polling)"
+        )
+    if env.get("BINANCE_DATA_SOURCE", "").strip().lower() != "mainnet":
+        failures.append(
+            "BINANCE_DATA_SOURCE must be mainnet — OOS evidence must match the backtest data"
+        )
+
+    _validate_url_port(env, "DATABASE_URL", schemes={"postgresql", "postgres"}, failures=failures)
+    _validate_url_port(env, "REDIS_URL", schemes={"redis", "rediss"}, failures=failures)
+    # The engine builds a RouterHTTPClient unconditionally and its /health and
+    # /metrics endpoints probe it; ROUTER_URL defaults to the soak router on
+    # 8001, so it must be pinned to an unroutable address (e.g. 127.0.0.1:9).
+    _validate_url_port(env, "ROUTER_URL", schemes={"http", "https"}, failures=failures)
+
+    raw_port = env.get("TREND_PAPER_ENGINE_PORT", str(DEFAULT_ENGINE_PORT)).strip()
+    try:
+        port = int(raw_port)
+    except ValueError:
+        failures.append(f"TREND_PAPER_ENGINE_PORT must be an integer, got {raw_port!r}")
+    else:
+        if port in SOAK_RESERVED_PORTS:
+            failures.append(
+                f"TREND_PAPER_ENGINE_PORT {port} collides with a soak-owned port; pick another"
+            )
+
+    for key in FORBIDDEN_ENV_KEYS:
+        if env.get(key, "").strip():
+            failures.append(f"{key} must stay unset for the isolated paper engine")
+
+    return failures
+
+
+def resolve_project_python(project_root: Path) -> str:
+    project_python = project_root / "app" / "engine" / ".venv" / "bin" / "python"
+    return str(project_python) if project_python.exists() else sys.executable
+
+
+def build_engine_command(project_root: Path, *, port: int) -> list[str]:
+    return [
+        resolve_project_python(project_root),
+        "-m",
+        "uvicorn",
+        "app.engine.main:app",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+    ]
+
+
+def build_migrate_command(project_root: Path) -> list[str]:
+    return [resolve_project_python(project_root), "app/engine/scripts/migrate_db.py"]
+
+
+def wrap_with_caffeinate(command: list[str]) -> list[str]:
+    if sys.platform == "darwin":
+        return ["caffeinate", "-i", "--", *command]
+    return command
+
+
+def ensure_port_available(port: int) -> None:
+    # Probe the wildcard address too: docker-proxy squats bind 0.0.0.0 and a
+    # loopback-only bind would "succeed" while external traffic reaches the
+    # other process.
+    for host in ("0.0.0.0", "127.0.0.1"):
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+                probe.bind((host, port))
+        except OSError as exc:
+            raise SystemExit(
+                f"engine port {port} is already in use ({host}): {exc}; "
+                "set TREND_PAPER_ENGINE_PORT to a free port"
+            ) from exc
+
+
+def wait_for_engine_health(*, port: int, process: Any, timeout_seconds: int) -> None:
+    url = f"http://127.0.0.1:{port}/health/simple"
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        exit_code = process.poll()
+        if exit_code is not None:
+            raise SystemExit(f"engine exited during startup (code {exit_code}); see engine.log")
+        try:
+            with urlopen(url, timeout=5) as response:
+                if 200 <= response.status < 300:
+                    return
+        except OSError:
+            pass
+        time.sleep(1)
+
+    process.terminate()
+    raise SystemExit(
+        f"engine did not become healthy within {timeout_seconds}s; terminated — see engine.log"
+    )
+
+
+def build_run_directory(project_root: Path, output_dir: str | None) -> Path:
+    if output_dir:
+        path = Path(output_dir)
+        return path if path.is_absolute() else project_root / path
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    return project_root / "artifacts" / "trend-paper" / f"manual-{timestamp}"
+
+
+def launch_detached_engine(
+    args: argparse.Namespace, *, project_root: Path | None = None
+) -> dict[str, Any]:
+    root = project_root or Path(__file__).resolve().parents[1]
+    env_file = Path(args.env_file)
+    if not env_file.is_absolute():
+        env_file = root / env_file
+    file_env = parse_env_file(env_file)
+    env = build_engine_environment(dict(os.environ), file_env)
+
+    failures = validate_trend_paper_environment(env)
+    if failures:
+        raise SystemExit(
+            "Refusing to launch the trend paper engine:\n"
+            + "\n".join(f"  - {failure}" for failure in failures)
+        )
+
+    run_dir = build_run_directory(root, getattr(args, "output_dir", None))
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    if not args.skip_migrate:
+        migrate = subprocess.run(
+            build_migrate_command(root),
+            cwd=str(root),
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        (run_dir / "migrate.stdout.log").write_text(migrate.stdout, encoding="utf-8")
+        (run_dir / "migrate.stderr.log").write_text(migrate.stderr, encoding="utf-8")
+        if migrate.returncode != 0:
+            raise SystemExit(
+                f"Migrations failed (exit {migrate.returncode}); "
+                f"see {run_dir / 'migrate.stderr.log'}"
+            )
+
+    port = int(env.get("TREND_PAPER_ENGINE_PORT", str(DEFAULT_ENGINE_PORT)))
+    ensure_port_available(port)
+    command = wrap_with_caffeinate(build_engine_command(root, port=port))
+    engine_log = run_dir / "engine.log"
+    with engine_log.open("a", encoding="utf-8") as handle:
+        process = subprocess.Popen(
+            command,
+            cwd=str(root),
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=handle,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+
+    wait_for_engine_health(
+        port=port, process=process, timeout_seconds=ENGINE_HEALTH_TIMEOUT_SECONDS
+    )
+
+    metadata = {
+        "pid": process.pid,
+        "port": port,
+        "launched_at": datetime.now(UTC).isoformat(),
+        "run_dir": str(run_dir),
+        "engine_log": str(engine_log),
+        "env_file": str(env_file),
+        "command": command,
+    }
+    (run_dir / "launcher.json").write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+    return metadata
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Launch the trend-live paper engine as a detached background process."
+    )
+    parser.add_argument("--env-file", default=".env.trend-paper")
+    parser.add_argument("--output-dir")
+    parser.add_argument("--skip-migrate", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    metadata = launch_detached_engine(parse_args())
+    print(json.dumps(metadata, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_launch_trend_live_paper.py
+++ b/tests/test_launch_trend_live_paper.py
@@ -1,0 +1,366 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import tempfile
+
+import pytest
+
+
+def _load_launch_trend_live_paper_module():
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "launch_trend_live_paper.py"
+    spec = importlib.util.spec_from_file_location("launch_trend_live_paper", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _isolated_env() -> dict[str, str]:
+    return {
+        "TREND_LIVE_ENABLED": "1",
+        "EXECUTION_MODE": "disabled",
+        "ENABLE_PAPER_TRADING": "true",
+        "BINANCE_DATA_SOURCE": "mainnet",
+        "DATABASE_URL": "postgresql://trading_user:secret@localhost:5433/trend_paper",
+        "REDIS_URL": "redis://localhost:6380/0",
+        "ROUTER_URL": "http://127.0.0.1:9",
+        "TREND_PAPER_ENGINE_PORT": "8016",
+    }
+
+
+def test_parse_env_file_reads_pairs_and_skips_comments():
+    module = _load_launch_trend_live_paper_module()
+    env_file = Path(tempfile.mkdtemp()) / ".env.trend-paper"
+    env_file.write_text(
+        "# isolated paper engine\n"
+        "\n"
+        "TREND_LIVE_ENABLED=1\n"
+        "DATABASE_URL='postgresql://u:p@localhost:5433/trend_paper'\n"
+        'REDIS_URL="redis://localhost:6380/0"\n',
+        encoding="utf-8",
+    )
+
+    parsed = module.parse_env_file(env_file)
+
+    assert parsed == {
+        "TREND_LIVE_ENABLED": "1",
+        "DATABASE_URL": "postgresql://u:p@localhost:5433/trend_paper",
+        "REDIS_URL": "redis://localhost:6380/0",
+    }
+
+
+def test_parse_env_file_strips_export_prefix_and_rejects_missing_file():
+    module = _load_launch_trend_live_paper_module()
+    env_dir = Path(tempfile.mkdtemp())
+    env_file = env_dir / ".env.trend-paper"
+    env_file.write_text("export TREND_LIVE_ENABLED=1\n", encoding="utf-8")
+
+    assert module.parse_env_file(env_file) == {"TREND_LIVE_ENABLED": "1"}
+
+    with pytest.raises(SystemExit, match="env file"):
+        module.parse_env_file(env_dir / "does-not-exist")
+
+
+def test_build_engine_environment_strips_soak_coupled_vars_and_overlays_file():
+    module = _load_launch_trend_live_paper_module()
+
+    parent = {
+        "PATH": "/usr/bin",
+        "EXECUTION_MODE": "spot_testnet",
+        "DATABASE_URL": "postgresql://trading_user:pw@localhost:5432/trading_platform",
+        "REDIS_URL": "redis://localhost:6379/0",
+        "TELEGRAM_BOT_TOKEN": "tg-secret",
+        "TELEGRAM_CHAT_ID": "12345",
+        "ROUTER_URL": "http://localhost:8001",
+        "ROUTER_API_KEY": "router-secret",
+        "BFF_URL": "http://localhost:3001",
+        "INTERNAL_ALERTS_TOKEN": "alerts-secret",
+        "ENGINE_INTERNAL_API_TOKEN": "engine-secret",
+        "BINANCE_API_KEY": "binance-key",
+        "BINANCE_SPOT_API_KEY": "spot-key",
+        "I_UNDERSTAND_LIVE_TRADING": "1",
+        "SIGNAL_EMITTER_SUBSCRIBER_ENABLED": "1",
+    }
+    file_env = _isolated_env()
+
+    env = module.build_engine_environment(parent, file_env)
+
+    assert env["PATH"] == "/usr/bin"
+    assert env["PYTHONUNBUFFERED"] == "1"
+    assert env["EXECUTION_MODE"] == "disabled"
+    assert env["DATABASE_URL"] == "postgresql://trading_user:secret@localhost:5433/trend_paper"
+    assert env["REDIS_URL"] == "redis://localhost:6380/0"
+    # the parent's soak router URL must lose to the file's unroutable pin
+    assert env["ROUTER_URL"] == "http://127.0.0.1:9"
+    for leaked in (
+        "TELEGRAM_BOT_TOKEN",
+        "TELEGRAM_CHAT_ID",
+        "ROUTER_API_KEY",
+        "BFF_URL",
+        "INTERNAL_ALERTS_TOKEN",
+        "ENGINE_INTERNAL_API_TOKEN",
+        "BINANCE_API_KEY",
+        "BINANCE_SPOT_API_KEY",
+        "I_UNDERSTAND_LIVE_TRADING",
+        "SIGNAL_EMITTER_SUBSCRIBER_ENABLED",
+    ):
+        assert leaked not in env
+
+
+def test_validate_trend_paper_environment_accepts_isolated_profile():
+    module = _load_launch_trend_live_paper_module()
+
+    assert module.validate_trend_paper_environment(_isolated_env()) == []
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected_fragment"),
+    [
+        ({"TREND_LIVE_ENABLED": "0"}, "TREND_LIVE_ENABLED"),
+        ({"EXECUTION_MODE": "spot_testnet"}, "EXECUTION_MODE"),
+        ({"ENABLE_PAPER_TRADING": "false"}, "ENABLE_PAPER_TRADING"),
+        ({"BINANCE_DATA_SOURCE": "testnet"}, "BINANCE_DATA_SOURCE"),
+        (
+            {"DATABASE_URL": "postgresql://trading_user:pw@localhost:5432/trading_platform"},
+            "DATABASE_URL",
+        ),
+        ({"DATABASE_URL": "mysql://u:p@localhost:5433/trend_paper"}, "DATABASE_URL"),
+        # Portless URLs default to 5432/6379 at runtime — the soak DB and redis
+        ({"DATABASE_URL": "postgresql://u:p@localhost/trend_paper"}, "DATABASE_URL"),
+        ({"REDIS_URL": "redis://localhost/0"}, "REDIS_URL"),
+        ({"DATABASE_URL": "postgresql://u:p@localhost:banana/trend_paper"}, "DATABASE_URL"),
+        ({"REDIS_URL": "redis://localhost:6379/0"}, "REDIS_URL"),
+        ({"ROUTER_URL": ""}, "ROUTER_URL"),
+        ({"ROUTER_URL": "http://localhost:8001"}, "ROUTER_URL"),
+        ({"TREND_PAPER_ENGINE_PORT": "8000"}, "TREND_PAPER_ENGINE_PORT"),
+        ({"TREND_PAPER_ENGINE_PORT": "not-a-port"}, "TREND_PAPER_ENGINE_PORT"),
+        ({"TELEGRAM_BOT_TOKEN": "tg-secret"}, "TELEGRAM_BOT_TOKEN"),
+        ({"BFF_URL": "http://localhost:3001"}, "BFF_URL"),
+        ({"ROUTER_API_KEY": "router-secret"}, "ROUTER_API_KEY"),
+    ],
+)
+def test_validate_trend_paper_environment_rejects_soak_collisions(overrides, expected_fragment):
+    module = _load_launch_trend_live_paper_module()
+    env = _isolated_env()
+    env.update(overrides)
+
+    failures = module.validate_trend_paper_environment(env)
+
+    assert any(expected_fragment in failure for failure in failures)
+
+
+def test_build_engine_command_uses_project_python_without_reload():
+    module = _load_launch_trend_live_paper_module()
+    project_root = Path(tempfile.mkdtemp())
+    project_python = project_root / "app" / "engine" / ".venv" / "bin" / "python"
+    project_python.parent.mkdir(parents=True, exist_ok=True)
+    project_python.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+
+    command = module.build_engine_command(project_root, port=8010)
+
+    assert command == [
+        str(project_python),
+        "-m",
+        "uvicorn",
+        "app.engine.main:app",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "8010",
+    ]
+    assert "--reload" not in command
+
+
+def test_build_migrate_command_targets_engine_migration_script():
+    module = _load_launch_trend_live_paper_module()
+    project_root = Path(tempfile.mkdtemp())
+
+    command = module.build_migrate_command(project_root)
+
+    assert command == [sys.executable, "app/engine/scripts/migrate_db.py"]
+
+
+def test_wait_for_engine_health_returns_when_health_endpoint_answers(monkeypatch):
+    module = _load_launch_trend_live_paper_module()
+
+    class AliveProcess:
+        def poll(self):
+            return None
+
+        def terminate(self):
+            raise AssertionError("healthy engine must not be terminated")
+
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    urls: list[str] = []
+
+    def fake_urlopen(url, timeout=0):
+        urls.append(url)
+        return FakeResponse()
+
+    monkeypatch.setattr(module, "urlopen", fake_urlopen)
+    monkeypatch.setattr(module.time, "sleep", lambda seconds: None)
+
+    module.wait_for_engine_health(port=8016, process=AliveProcess(), timeout_seconds=5)
+
+    assert urls == ["http://127.0.0.1:8016/health/simple"]
+
+
+def test_wait_for_engine_health_fails_when_process_dies(monkeypatch):
+    module = _load_launch_trend_live_paper_module()
+
+    class DeadProcess:
+        def poll(self):
+            return 3
+
+        def terminate(self):
+            raise AssertionError("dead process needs no terminate")
+
+    with pytest.raises(SystemExit, match="exited"):
+        module.wait_for_engine_health(port=8016, process=DeadProcess(), timeout_seconds=5)
+
+
+def test_wait_for_engine_health_terminates_and_fails_on_timeout(monkeypatch):
+    module = _load_launch_trend_live_paper_module()
+
+    terminated: list[bool] = []
+
+    class HangingProcess:
+        def poll(self):
+            return None
+
+        def terminate(self):
+            terminated.append(True)
+
+    def fake_urlopen(url, timeout=0):
+        raise OSError("connection refused")
+
+    clock = {"now": 0.0}
+    monkeypatch.setattr(module, "urlopen", fake_urlopen)
+    monkeypatch.setattr(module.time, "monotonic", lambda: clock["now"])
+
+    def fake_sleep(seconds):
+        clock["now"] += seconds
+
+    monkeypatch.setattr(module.time, "sleep", fake_sleep)
+
+    with pytest.raises(SystemExit, match="did not become healthy"):
+        module.wait_for_engine_health(port=8016, process=HangingProcess(), timeout_seconds=5)
+
+    assert terminated == [True]
+
+
+def test_launch_detached_engine_migrates_then_starts_with_sanitized_env(monkeypatch):
+    module = _load_launch_trend_live_paper_module()
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    temp_root = Path(tempfile.mkdtemp())
+    env_file = temp_root / ".env.trend-paper"
+    env_file.write_text(
+        "\n".join(f"{key}={value}" for key, value in _isolated_env().items()),
+        encoding="utf-8",
+    )
+    run_dir = temp_root / "artifacts" / "trend-paper" / "manual-test"
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tg-secret")
+    monkeypatch.setenv("EXECUTION_MODE", "spot_testnet")
+
+    args = argparse.Namespace(
+        env_file=str(env_file),
+        output_dir=str(run_dir),
+        skip_migrate=False,
+    )
+
+    class FakeCompleted:
+        returncode = 0
+        stdout = "migrations ok"
+        stderr = ""
+
+    run_calls: list[dict[str, object]] = []
+
+    def fake_run(command, **kwargs):
+        run_calls.append({"command": command, **kwargs})
+        return FakeCompleted()
+
+    class FakeProcess:
+        pid = 54321
+
+    popen_calls: list[dict[str, object]] = []
+
+    def fake_popen(command, **kwargs):
+        popen_calls.append({"command": command, **kwargs})
+        return FakeProcess()
+
+    port_probes: list[int] = []
+    health_waits: list[tuple[int, object, int]] = []
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    monkeypatch.setattr(module.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(module, "ensure_port_available", lambda port: port_probes.append(port))
+    monkeypatch.setattr(
+        module,
+        "wait_for_engine_health",
+        lambda *, port, process, timeout_seconds: health_waits.append(
+            (port, process, timeout_seconds)
+        ),
+    )
+
+    metadata = module.launch_detached_engine(args, project_root=temp_root)
+
+    assert len(run_calls) == 1
+    assert run_calls[0]["command"][-1] == "app/engine/scripts/migrate_db.py"
+    assert run_calls[0]["env"]["DATABASE_URL"].endswith(":5433/trend_paper")
+
+    assert port_probes == [8016]
+    assert len(popen_calls) == 1
+    assert popen_calls[0]["command"][:3] == ["caffeinate", "-i", "--"]
+    assert popen_calls[0]["start_new_session"] is True
+    assert popen_calls[0]["cwd"] == str(temp_root)
+    engine_env = popen_calls[0]["env"]
+    assert engine_env["EXECUTION_MODE"] == "disabled"
+    assert "TELEGRAM_BOT_TOKEN" not in engine_env
+
+    assert len(health_waits) == 1
+    assert health_waits[0][0] == 8016
+
+    assert metadata["pid"] == 54321
+    assert metadata["port"] == 8016
+    launcher = json.loads((run_dir / "launcher.json").read_text(encoding="utf-8"))
+    assert launcher["pid"] == 54321
+    assert launcher["command"] == popen_calls[0]["command"]
+    assert (run_dir / "engine.log").exists()
+
+
+def test_launch_detached_engine_refuses_invalid_environment(monkeypatch):
+    module = _load_launch_trend_live_paper_module()
+
+    temp_root = Path(tempfile.mkdtemp())
+    env_file = temp_root / ".env.trend-paper"
+    bad_env = _isolated_env()
+    bad_env["EXECUTION_MODE"] = "spot_testnet"
+    env_file.write_text(
+        "\n".join(f"{key}={value}" for key, value in bad_env.items()),
+        encoding="utf-8",
+    )
+
+    args = argparse.Namespace(
+        env_file=str(env_file),
+        output_dir=str(temp_root / "run"),
+        skip_migrate=True,
+    )
+
+    with pytest.raises(SystemExit):
+        module.launch_detached_engine(args, project_root=temp_root)


### PR DESCRIPTION
## Why

Phase 3a is built but not running: `TREND_LIVE_ENABLED=1` is the entire payoff (out-of-sample paper evidence for tsmom28+sma65), and every day it stays off is OOS evidence not accruing. But the runbook's enable path (`make db-up && make dev-engine`) owns the shared `.env` and default host ports — both now belong to the 7-day testnet soak (run `manual-20260711T064627Z`), and the soak ends with `compose down -v`, which would destroy paper state living in that stack's volumes.

## What

**`scripts/launch_trend_live_paper.py`** — detached launcher with hard isolation:
- Engine env built exclusively from `.env.trend-paper` overlaid on a denylisted parent env: `EXECUTION_MODE`, `DATABASE_URL`, `REDIS_*`, `ROUTER_*`, `TELEGRAM_*`, `BFF_URL`, `INTERNAL_ALERTS_TOKEN`, `ENGINE_INTERNAL_API_TOKEN`, and all `BINANCE_*` keys never leak in (the paper path is keyless).
- Fail-closed validation: `EXECUTION_MODE=disabled` (no `RouterExecutionSubscriber`), `ENABLE_PAPER_TRADING=true` (in-DB equity sampling instead of `RouterEquitySamplerService` polling the soak router), `BINANCE_DATA_SOURCE=mainnet` (OOS evidence must match backtest data), and `DATABASE_URL`/`REDIS_URL`/`ROUTER_URL`/engine port must carry **explicit** ports off the soak-owned set {8000, 8001, 8002, 3000, 3001, 5432, 6379}. Portless URLs are rejected — they'd default to the soak's 5432/6379 at runtime.
- `ROUTER_URL` must be pinned (template uses unroutable `http://127.0.0.1:9`): the engine constructs `RouterHTTPClient` unconditionally and its `/health` + `/metrics` endpoints probe it, which would otherwise land paper-engine requests on the soak router.
- Bind-probes the engine port on both `0.0.0.0` and `127.0.0.1` (a docker-proxy squat passes a loopback-only probe), runs migrations against the dedicated DB, starts uvicorn detached (no `--reload`, caffeinate-wrapped), and only writes success metadata after `/health/simple` answers — engine death or hang during startup is reported, not silently declared launched.

**`docker-compose.trend-paper.yml`** — separate compose project (`name: trend-paper`): digest-pinned `timescale/timescaledb:latest-pg16` on 5433 + `redis:7-alpine` on 6380 with their own named volumes. The soak's `docker-compose down -v` on the dev stack cannot touch them.

**Runbook** — new "Running alongside the testnet soak" section with the `.env.trend-paper` template (a committed `.env.trend-paper.example` was blocked by the protect-files hook, so the template lives in the runbook; `.gitignore` gains `.env.trend-paper`).

## QCHECK

Adversarial fresh-context review (Codex MCP still down). Round 1: 0 CRITICAL, 2 HIGH — both confirmed empirically and fixed with regression tests: (1) portless `DATABASE_URL`/`REDIS_URL` bypassed the port validator via `urlparse().port is None` and defaulted to the soak's 5432/6379 at runtime; (2) the `ROUTER_URL` default meant `/health`//`/metrics` probes hit the soak router. Also fixed: default engine port 8010 was squatted by an unrelated container (now 8016 + bind probe), launcher declared success without liveness verification (now health-gated), invalid-port traceback, `export`-prefix / missing-env-file ergonomics, floating image tags (digest-pinned).

## Tests

24 launcher tests (65 total across the three root launcher/soak suites), 3× green; ruff check + format clean; `docker compose config` validates. Wiring: launcher is an operator entry point documented in the runbook (same model as `scripts/launch_testnet_soak.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
