### PR TITLE
fix(trend-live): set PYTHONPATH so the launcher's migrate step can import app.engine

### DIFF
--- a/scripts/launch_trend_live_paper.py
+++ b/scripts/launch_trend_live_paper.py
@@ -251,6 +251,10 @@ def launch_detached_engine(
         env_file = root / env_file
     file_env = parse_env_file(env_file)
     env = build_engine_environment(dict(os.environ), file_env)
+    # migrate_db.py imports app.engine.*; script-by-path execution does not
+    # put the repo root on sys.path.
+    inherited_pythonpath = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = f"{root}:{inherited_pythonpath}" if inherited_pythonpath else str(root)
 
     failures = validate_trend_paper_environment(env)
     if failures:

--- a/tests/test_launch_trend_live_paper.py
+++ b/tests/test_launch_trend_live_paper.py
@@ -323,6 +323,10 @@ def test_launch_detached_engine_migrates_then_starts_with_sanitized_env(monkeypa
     assert len(run_calls) == 1
     assert run_calls[0]["command"][-1] == "app/engine/scripts/migrate_db.py"
     assert run_calls[0]["env"]["DATABASE_URL"].endswith(":5433/trend_paper")
+    # migrate_db.py imports app.engine.*; running a script by path does not
+    # put the repo root on sys.path, so the launcher must set PYTHONPATH
+    assert run_calls[0]["env"]["PYTHONPATH"].split(":")[0] == str(temp_root)
+    assert popen_calls[0]["env"]["PYTHONPATH"].split(":")[0] == str(temp_root)
 
     assert port_probes == [8016]
     assert len(popen_calls) == 1


### PR DESCRIPTION
One-line fix found on first real launch of #215: `migrate_db.py` imports `app.engine.*`, but script-by-path execution does not put the repo root on `sys.path` — migrations died with ModuleNotFoundError before the engine started. The launcher now prepends the project root to PYTHONPATH for both the migrate subprocess and the engine (regression-tested; 28 launcher tests 3× green, ruff clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)