### PR TITLE
fix(bff): provision alert tables and contain event-listener rejections that killed the process

### DIFF
--- a/app/bff/src/alerts/alerts.gateway.spec.ts
+++ b/app/bff/src/alerts/alerts.gateway.spec.ts
@@ -297,6 +297,60 @@ describe('AlertsGateway', () => {
     });
   });
 
+  describe('alert persistence failures', () => {
+    // Regression: 2026-07-11 soak — first live decision event crashed the
+    // whole BFF process because the async listener's rejection (missing
+    // alerts table) was unhandled.
+    const flushMicrotasks = async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    };
+
+    beforeEach(() => {
+      gateway.afterInit(mockServer);
+      mockAlertsService.create.mockRejectedValue(new Error('relation "alerts" does not exist'));
+    });
+
+    it('contains a rejected decision-alert insert and logs it', async () => {
+      const errorSpy = jest.spyOn((gateway as any).logger, 'error').mockImplementation();
+      const decisionCallback = mockEventEmitter.on.mock.calls.find(
+        (call) => call[0] === CONTRACT_TOPICS.decisionV1,
+      )[1];
+
+      const result = decisionCallback({ symbol: 'ETHUSDT', action: 'open_short', confidence: 0.7 });
+      await flushMicrotasks();
+
+      expect(result).toBeUndefined();
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('decision alert'));
+    });
+
+    it('keeps the connection alive when the unread-count lookup fails', async () => {
+      const errorSpy = jest.spyOn((gateway as any).logger, 'error').mockImplementation();
+      mockAlertsService.getUnreadCount.mockRejectedValue(new Error('db down'));
+
+      await expect(gateway.handleConnection(mockClient)).resolves.toBeUndefined();
+
+      expect(mockClient.emit).toHaveBeenCalledWith('connected', {
+        message: 'Connected to alerts gateway',
+        unreadCount: 0,
+      });
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('unread count'));
+    });
+
+    it('contains a rejected order-alert insert and logs it', async () => {
+      const errorSpy = jest.spyOn((gateway as any).logger, 'error').mockImplementation();
+      const orderCallback = mockEventEmitter.on.mock.calls.find(
+        (call) => call[0] === CONTRACT_TOPICS.orderUpdateV1,
+      )[1];
+
+      const result = orderCallback({ orderId: 'o-1', symbol: 'ETHUSDT', status: 'FILLED' });
+      await flushMicrotasks();
+
+      expect(result).toBeUndefined();
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('order alert'));
+    });
+  });
+
   describe('handshake auth middleware', () => {
     it('registers a middleware that rejects token-less sockets with an error', async () => {
       gateway.afterInit(mockServer);

--- a/app/bff/src/alerts/alerts.gateway.ts
+++ b/app/bff/src/alerts/alerts.gateway.ts
@@ -54,13 +54,20 @@ export class AlertsGateway implements OnGatewayInit, OnGatewayConnection, OnGate
       this.server.to('alerts').emit('alert.updated', alert);
     });
 
-    // Subscribe to trading events to create alerts
-    this.eventEmitter.on(CONTRACT_TOPICS.decisionV1, async (decision: DecisionEvent) => {
-      await this.createDecisionAlert(decision);
+    // Subscribe to trading events to create alerts. Rejections must be
+    // contained here: an async listener's unhandled rejection kills the
+    // whole Node process (2026-07-11 soak: the first live decision event
+    // crashed the BFF when the alerts insert failed).
+    this.eventEmitter.on(CONTRACT_TOPICS.decisionV1, (decision: DecisionEvent) => {
+      void this.createDecisionAlert(decision).catch((error) => {
+        this.logger.error(`Failed to create decision alert: ${error}`);
+      });
     });
 
-    this.eventEmitter.on(CONTRACT_TOPICS.orderUpdateV1, async (orderUpdate: OrderUpdateEvent) => {
-      await this.createOrderAlert(orderUpdate);
+    this.eventEmitter.on(CONTRACT_TOPICS.orderUpdateV1, (orderUpdate: OrderUpdateEvent) => {
+      void this.createOrderAlert(orderUpdate).catch((error) => {
+        this.logger.error(`Failed to create order alert: ${error}`);
+      });
     });
   }
 
@@ -78,11 +85,17 @@ export class AlertsGateway implements OnGatewayInit, OnGatewayConnection, OnGate
     // Join user-specific room for targeted alerts
     client.join(`alerts:${user.sub}`);
 
-    // Send initial unread count
-    const unreadCount = await this.alertsService.getUnreadCount();
+    // Send initial unread count; a DB failure here must not reject out of
+    // handleConnection (Nest discards the promise — rejection kills the process)
+    let unreadCount = 0;
+    try {
+      unreadCount = (await this.alertsService.getUnreadCount()).count;
+    } catch (error) {
+      this.logger.error(`Failed to load unread count: ${error}`);
+    }
     client.emit('connected', {
       message: 'Connected to alerts gateway',
-      unreadCount: unreadCount.count,
+      unreadCount,
     });
   }
 

--- a/app/bff/src/engine-client/engine-client.service.spec.ts
+++ b/app/bff/src/engine-client/engine-client.service.spec.ts
@@ -235,4 +235,13 @@ describe('EngineClientService', () => {
       });
     });
   });
+
+  describe('error event safety', () => {
+    // Regression: 2026-07-11 soak — eventemitter2 throws on an unhandled
+    // 'error' emit, so a Redis blip inside the redis client's error callback
+    // became an uncaught exception that killed the BFF process.
+    it('does not throw when an error event is emitted with no listeners', () => {
+      expect(() => service.emit('error', new Error('redis connection lost'))).not.toThrow();
+    });
+  });
 });

--- a/app/bff/src/engine-client/engine-client.service.ts
+++ b/app/bff/src/engine-client/engine-client.service.ts
@@ -34,7 +34,9 @@ export class EngineClientService extends EventEmitter2 implements OnModuleInit, 
   private isConnected = false;
 
   constructor(private readonly configService: ConfigService) {
-    super();
+    // eventemitter2 throws on an unhandled 'error' emit; our redis/tcp error
+    // callbacks re-emit, so without this a transport blip kills the process.
+    super({ ignoreErrors: true });
     this.engineType = this.configService.get<'redis' | 'tcp'>('engine.type')!;
     this.host = this.configService.get<string>('engine.host')!;
     this.port = this.configService.get<number>('engine.port')!;

--- a/app/bff/src/trading/trading.service.spec.ts
+++ b/app/bff/src/trading/trading.service.spec.ts
@@ -420,7 +420,8 @@ describe('TradingService', () => {
 
       expect(subscribeCallback).toBeDefined();
 
-      await subscribeCallback(orderUpdate);
+      subscribeCallback(orderUpdate);
+      await new Promise(setImmediate);
 
       expect(mockOrderRepository.findByClientOrderId).toHaveBeenCalledWith('main-1', 'USD_M');
       expect(mockOrderRepository.update).toHaveBeenCalledWith(
@@ -594,6 +595,47 @@ describe('TradingService', () => {
           error: 'Network error',
         }),
       );
+    });
+  });
+
+  describe('engine event containment', () => {
+    // Regression: 2026-07-11 soak — async engine-event listeners with
+    // unhandled rejections kill the whole Node process.
+    const flushMicrotasks = async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    };
+
+    it('contains order-update handler failures instead of crashing', async () => {
+      const errorSpy = jest.spyOn((service as any).logger, 'error').mockImplementation();
+      jest.spyOn(service as any, 'handleOrderUpdate').mockRejectedValue(new Error('db down'));
+
+      const subscribeCallback = mockEngineClientService.subscribe.mock.calls.find(
+        (call) => call[0] === CONTRACT_TOPICS.orderUpdateV1,
+      )?.[1];
+      expect(subscribeCallback).toBeDefined();
+
+      const result = subscribeCallback({ client_order_id: 'x' });
+      await flushMicrotasks();
+
+      expect(result).toBeUndefined();
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('order update'));
+    });
+
+    it('contains decision handler failures instead of crashing', async () => {
+      const errorSpy = jest.spyOn((service as any).logger, 'error').mockImplementation();
+      jest.spyOn(service as any, 'handleDecisionEvent').mockRejectedValue(new Error('db down'));
+
+      const subscribeCallback = mockEngineClientService.subscribe.mock.calls.find(
+        (call) => call[0] === CONTRACT_TOPICS.decisionV1,
+      )?.[1];
+      expect(subscribeCallback).toBeDefined();
+
+      const result = subscribeCallback({ symbol: 'BTCUSDT' });
+      await flushMicrotasks();
+
+      expect(result).toBeUndefined();
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('decision'));
     });
   });
 });

--- a/app/bff/src/trading/trading.service.ts
+++ b/app/bff/src/trading/trading.service.ts
@@ -187,15 +187,19 @@ export class TradingService implements OnModuleInit {
   }
 
   private subscribeToEngineEvents() {
-    // Subscribe to decision events from engine
+    // Rejections must be contained: an engine-event listener's unhandled
+    // rejection kills the whole Node process (2026-07-11 soak incident).
     this.engineClient.subscribe(CONTRACT_TOPICS.decisionV1, (event: DecisionEvent) => {
       this.eventEmitter.emit(CONTRACT_TOPICS.decisionV1, event);
-      this.handleDecisionEvent(event);
+      void this.handleDecisionEvent(event).catch((error) => {
+        this.logger.error(`Failed to handle decision event: ${error}`);
+      });
     });
 
-    // Subscribe to order update events
-    this.engineClient.subscribe(CONTRACT_TOPICS.orderUpdateV1, async (event: OrderUpdateV1) => {
-      await this.handleOrderUpdate(event);
+    this.engineClient.subscribe(CONTRACT_TOPICS.orderUpdateV1, (event: OrderUpdateV1) => {
+      void this.handleOrderUpdate(event).catch((error) => {
+        this.logger.error(`Failed to handle order update: ${error}`);
+      });
     });
   }
 

--- a/db/migrations/033_bff_alert_tables.sql
+++ b/db/migrations/033_bff_alert_tables.sql
@@ -1,0 +1,43 @@
+-- BFF-owned TypeORM tables that no migration created (synchronize=false, so
+-- they only ever existed in dev DBs from an old schema-sync run). A fresh DB
+-- crashed the BFF on the first live decision event: INSERT INTO "alerts"
+-- failed with 42P01. Column names/quoting match the TypeORM entities exactly
+-- (app/bff/src/alerts/entities/alert.entity.ts,
+--  app/bff/src/database/entities/alert-snapshot.entity.ts).
+
+DO $$ BEGIN
+    CREATE TYPE alerts_type_enum AS ENUM ('order', 'position', 'decision', 'smc', 'error', 'info');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+    CREATE TYPE alerts_priority_enum AS ENUM ('low', 'medium', 'high', 'critical');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS alerts (
+    "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    "type" alerts_type_enum NOT NULL,
+    "priority" alerts_priority_enum NOT NULL,
+    "title" CHARACTER VARYING NOT NULL,
+    "message" TEXT NOT NULL,
+    "data" JSONB,
+    "read" BOOLEAN NOT NULL DEFAULT FALSE,
+    "createdAt" TIMESTAMP NOT NULL DEFAULT NOW(),
+    "updatedAt" TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_alerts_created_at ON alerts ("createdAt" DESC);
+CREATE INDEX IF NOT EXISTS idx_alerts_read ON alerts ("read") WHERE "read" = FALSE;
+
+CREATE TABLE IF NOT EXISTS alert_snapshots (
+    "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    "signal_id" CHARACTER VARYING NOT NULL UNIQUE,
+    "symbol" CHARACTER VARYING NOT NULL,
+    "timeframe" CHARACTER VARYING NOT NULL,
+    "image_path" CHARACTER VARYING NOT NULL,
+    "meta" JSONB NOT NULL DEFAULT '{}',
+    "created_at" TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_alert_snapshots_created_at ON alert_snapshots ("created_at" DESC);


### PR DESCRIPTION
## Why

The relaunched 7-day soak caught a real crash 1h in: the engine's first live decision event (`open_short ETHUSDT`) killed the entire BFF process. The container stayed 'Up' (dev watcher) while the app was dead, and the soak monitor silently accumulated failed BFF probes every 15s — dooming the run to `overall_status: fail`.

## Root causes and fixes

1. **Missing tables**: BFF TypeORM runs `synchronize: false` and no migration ever created `alerts`/`alert_snapshots` — they existed only in old dev DBs from an ancient schema-sync. A fresh DB (the soak wipes volumes) 42P01s on the first alert insert. **Migration 033** creates both tables matching the entities exactly — validated by replaying the exact production INSERT, idempotent re-apply, all inside a rolled-back transaction; DO-blocks survive the MigrationRunner's whole-file execution (it never splits SQL).

2. **Process-killing rejections at four sites** (QCHECK swept every listener in the BFF):
   - `alerts.gateway.ts`: the two async event listeners (the incident itself)
   - `trading.service.ts`: async order-update listener + floating decision-handler promise
   - `alerts.gateway.ts#handleConnection`: awaited unread-count — Nest discards the promise, so a DB error on client connect was another process-killer
   - `engine-client.service.ts`: `emit('error')` with zero listeners — eventemitter2 **throws** on that, inside redis/net error callbacks → any Redis blip killed the process. Now `super({ ignoreErrors: true })`.

Each fix has a regression test that crashes the old implementation (the RED runs literally killed the jest worker, reproducing production).

## Gates

Full BFF suite 353/353; targeted suites 3× green; tsc clean; eslint clean; migration verified against scratch DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)