### PR TITLE
fix(soak): run soak stack without file watchers (compose override, on by default)

### DIFF
--- a/docker-compose.soak.yml
+++ b/docker-compose.soak.yml
@@ -1,0 +1,32 @@
+# Soak override: pin monitor-critical services to non-watch commands.
+#
+# The dev stack runs file watchers (engine uvicorn --reload, bff nest
+# --watch, router air) over bind-mounted source. During a multi-day soak any
+# source edit restarts the service; the soak monitor records every missed
+# 15s probe and those failures surface only in the FINAL report, silently
+# dooming the run. The engine watcher also burns ~0.8 CPU core stat-polling
+# the macOS bind mount.
+#
+# Usage:
+#   scripts/launch_testnet_soak.py \
+#     --compose-file docker-compose.dev.yml --compose-file docker-compose.soak.yml ...
+services:
+  engine:
+    command:
+      - uvicorn
+      - app.engine.main:app
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8000"
+
+  router:
+    # Mirrors .air.toml's build step, then execs the binary so signals reach
+    # the router directly.
+    command:
+      - sh
+      - -c
+      - go build -o ./tmp/router ./cmd/router/main.go && exec ./tmp/router
+
+  bff:
+    command: pnpm run start

--- a/scripts/launch_testnet_soak.py
+++ b/scripts/launch_testnet_soak.py
@@ -10,6 +10,10 @@ import subprocess
 import sys
 from typing import Any
 
+# Kept in sync with run_testnet_soak.py: the soak override must be on by
+# default so a flag-less launch never boots the watcher stack.
+DEFAULT_COMPOSE_FILES = ("docker-compose.dev.yml", "docker-compose.soak.yml")
+
 
 def build_run_directory(project_root: Path, output_dir: str | None) -> Path:
     if output_dir:
@@ -36,11 +40,12 @@ def build_runner_command(
     *,
     project_root: Path,
 ) -> list[str]:
+    raw_compose = args.compose_file or list(DEFAULT_COMPOSE_FILES)
+    compose_files = [raw_compose] if isinstance(raw_compose, str) else list(raw_compose)
     command = [
         resolve_project_python(project_root),
         "scripts/run_testnet_soak.py",
-        "--compose-file",
-        args.compose_file,
+        *[arg for path in compose_files for arg in ("--compose-file", path)],
         "--duration-seconds",
         str(args.duration_seconds),
         "--poll-interval-seconds",
@@ -98,7 +103,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Launch the testnet soak runner as a detached background process."
     )
-    parser.add_argument("--compose-file", default="docker-compose.dev.yml")
+    parser.add_argument("--compose-file", action="append", default=None)
     parser.add_argument("--duration-seconds", type=int, default=86400)
     parser.add_argument("--poll-interval-seconds", type=int, default=15)
     parser.add_argument("--heartbeat-interval-seconds", type=int, default=60)

--- a/scripts/run_testnet_soak.py
+++ b/scripts/run_testnet_soak.py
@@ -31,6 +31,12 @@ except ImportError:  # pragma: no cover - optional dependency in tests
         return None
 
 
+# The soak override MUST be in the default set: without it the dev stack's
+# file watchers (uvicorn --reload / nest --watch / air) restart critical
+# services on any source edit, silently dooming a multi-day run.
+DEFAULT_COMPOSE_FILES = ("docker-compose.dev.yml", "docker-compose.soak.yml")
+
+
 @dataclass(slots=True)
 class CheckResult:
     name: str
@@ -447,7 +453,10 @@ class TestnetSoakRunner:
         raise RuntimeError("Neither docker-compose nor docker compose is available")
 
     def _compose(self, *args: str) -> list[str]:
-        return [*self.compose_cmd, "-f", self.args.compose_file, *args]
+        raw = self.args.compose_file or DEFAULT_COMPOSE_FILES
+        compose_files = [raw] if isinstance(raw, str) else list(raw)
+        file_args = [arg for path in compose_files for arg in ("-f", path)]
+        return [*self.compose_cmd, *file_args, *args]
 
     def _write_text(self, path: Path, content: str) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -1136,8 +1145,9 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run a bounded automated testnet soak.")
     parser.add_argument(
         "--compose-file",
-        default="docker-compose.dev.yml",
-        help="Docker Compose file to use",
+        action="append",
+        default=None,
+        help="Docker Compose file; repeat for override files (default: docker-compose.dev.yml)",
     )
     parser.add_argument(
         "--duration-seconds",
@@ -1181,6 +1191,8 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
+    if not args.compose_file:
+        args.compose_file = list(DEFAULT_COMPOSE_FILES)
     runner = TestnetSoakRunner(args)
     report = runner.run()
     print(json.dumps(report, indent=2))

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -1,6 +1,7 @@
-import yaml
-import pytest
 from pathlib import Path
+
+import pytest
+import yaml
 
 
 def test_timescaledb_configuration():
@@ -61,9 +62,7 @@ def test_services_use_timescaledb_connection():
                 break
 
         assert db_url is not None, f"{service_name} should have DATABASE_URL"
-        assert (
-            "postgres:5432" in db_url
-        ), f"{service_name} should connect to postgres service"
+        assert "postgres:5432" in db_url, f"{service_name} should connect to postgres service"
 
 
 def test_monitoring_services_configured():
@@ -101,3 +100,22 @@ def test_engine_and_router_auth_env_are_wired(compose_file: str):
     assert any("ENGINE_INTERNAL_API_TOKEN" in str(var) for var in engine_env)
     assert any("SECURITY_REQUIRED_API_KEY" in str(var) for var in router_env)
     assert any("ENGINE_INTERNAL_API_TOKEN" in str(var) for var in router_env)
+
+
+def test_soak_override_pins_critical_services_to_non_watch_commands():
+    """Watchers restart services on source edits, silently dooming a soak run."""
+    docker_compose_path = Path(__file__).parent.parent / "docker-compose.soak.yml"
+
+    with open(docker_compose_path, "r") as f:
+        config = yaml.safe_load(f)
+
+    services = config["services"]
+    engine_command = services["engine"]["command"]
+    assert "--reload" not in engine_command
+    assert engine_command[0] == "uvicorn"
+
+    router_command = " ".join(services["router"]["command"])
+    assert "air" not in router_command
+    assert "go build" in router_command
+
+    assert services["bff"]["command"] == "pnpm run start"

--- a/tests/test_launch_testnet_soak.py
+++ b/tests/test_launch_testnet_soak.py
@@ -62,6 +62,57 @@ def test_build_runner_command_enables_requested_flags():
     ]
 
 
+def test_build_runner_command_repeats_compose_file_for_each_entry():
+    module = _load_launch_testnet_soak_module()
+
+    args = argparse.Namespace(
+        compose_file=["docker-compose.dev.yml", "docker-compose.soak.yml"],
+        duration_seconds=86400,
+        poll_interval_seconds=15,
+        enable_order_smoke=False,
+        skip_preflight_tests=False,
+        keep_running=False,
+        heartbeat_interval_seconds=120,
+    )
+
+    command = module.build_runner_command(
+        args,
+        Path("/tmp/run-dir"),
+        project_root=Path("/repo-without-venv"),
+    )
+
+    dev_index = command.index("docker-compose.dev.yml")
+    assert command[dev_index - 1] == "--compose-file"
+    soak_index = command.index("docker-compose.soak.yml")
+    assert command[soak_index - 1] == "--compose-file"
+    # -f order determines override precedence: dev first, soak override second
+    assert dev_index < soak_index
+
+
+def test_build_runner_command_defaults_to_dev_plus_soak_override():
+    module = _load_launch_testnet_soak_module()
+
+    args = argparse.Namespace(
+        compose_file=None,
+        duration_seconds=86400,
+        poll_interval_seconds=15,
+        enable_order_smoke=False,
+        skip_preflight_tests=False,
+        keep_running=False,
+        heartbeat_interval_seconds=120,
+    )
+
+    command = module.build_runner_command(
+        args,
+        Path("/tmp/run-dir"),
+        project_root=Path("/repo-without-venv"),
+    )
+
+    dev_index = command.index("docker-compose.dev.yml")
+    soak_index = command.index("docker-compose.soak.yml")
+    assert dev_index < soak_index
+
+
 def test_launch_detached_soak_writes_launcher_metadata(monkeypatch):
     module = _load_launch_testnet_soak_module()
 

--- a/tests/test_run_testnet_soak.py
+++ b/tests/test_run_testnet_soak.py
@@ -452,6 +452,35 @@ def test_check_stack_health_fails_when_critical_service_unhealthy(monkeypatch):
     assert runner.check_stack_health() is False
 
 
+def test_compose_supports_multiple_files(monkeypatch):
+    module = _load_run_testnet_soak_module()
+    runner = _make_runner(
+        module, monkeypatch, compose_file=["docker-compose.dev.yml", "docker-compose.soak.yml"]
+    )
+
+    assert runner._compose("up", "-d") == [
+        "docker-compose",
+        "-f",
+        "docker-compose.dev.yml",
+        "-f",
+        "docker-compose.soak.yml",
+        "up",
+        "-d",
+    ]
+
+
+def test_compose_accepts_single_string_for_back_compat(monkeypatch):
+    module = _load_run_testnet_soak_module()
+    runner = _make_runner(module, monkeypatch, compose_file="docker-compose.dev.yml")
+
+    assert runner._compose("logs") == [
+        "docker-compose",
+        "-f",
+        "docker-compose.dev.yml",
+        "logs",
+    ]
+
+
 def test_report_overall_status_treats_warn_as_nonblocking(monkeypatch):
     module = _load_run_testnet_soak_module()
     runner = _make_runner(module, monkeypatch)


### PR DESCRIPTION
## Why

trading-engine-dev was burning 76–87% CPU: uvicorn's `--reload` watcher stat-polling the macOS bind mount (reload parent 2h+ CPU vs 26s for the app). Worse than the burn: engine/bff/router all run file watchers over bind-mounted source, so **any source edit during the 7-day soak restarts a monitor-critical service** — the monitor accumulates missed 15s probes that only surface in the final report, silently failing the run (the same mechanism that doomed run 2). Four PRs landed today alone; a watcher-armed soak cannot survive a week of development on this machine.

## What

- **docker-compose.soak.yml** — override pinning non-watch commands: engine uvicorn without `--reload`; router `go build && exec ./tmp/router` (byte-identical to .air.toml's build step, exec for direct signal delivery); bff `pnpm run start` (nest compile-once). UI keeps its dev watcher — it's non-critical (warn) by design.
- **run_testnet_soak.py / launch_testnet_soak.py** — `--compose-file` is now repeatable, and the **default is dev + soak override** (QCHECK MEDIUM: a flag-less muscle-memory launch must never boot the watcher stack).
- Drift test asserts the override's commands stay non-watch.

## QCHECK

Fresh-context adversarial review: 0 CRITICAL/HIGH. Fixed the MEDIUM (default set) and LOWs (None-tolerant back-compat, -f ordering assertion, drift test). Verified empirically: merged config has no watch flags; router dev image toolchain/workdir/tmp-dir compatible; bff `nest start` viable in the dev image (no prestart hooks, CLI present); healthcheck timing unchanged (air/nest already compiled at boot).

## Gates

75 tests across the four suites 3× green; ruff clean; merged compose config validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)