### PR TITLE
fix(soak): cancel every bracket leg in order smoke; detect entry fills

### DIFF
--- a/scripts/run_testnet_soak.py
+++ b/scripts/run_testnet_soak.py
@@ -668,7 +668,7 @@ class TestnetSoakRunner:
             raise RuntimeError("price lookup response missing price")
         return Decimal(str(price))
 
-    def _resolve_exchange_order_id(self, symbol: str, client_order_id: str) -> int:
+    def _fetch_order(self, symbol: str, client_order_id: str) -> dict[str, Any]:
         api_key = (os.getenv("BINANCE_API_KEY") or os.getenv("BINANCE_SPOT_API_KEY") or "").strip()
         api_secret = (
             os.getenv("BINANCE_SECRET_KEY")
@@ -698,9 +698,13 @@ class TestnetSoakRunner:
             allow_insecure_tls=True,
         )
         parsed = self._parse_json_body(raw_body)
-        if status >= 300:
+        if status >= 300 or not isinstance(parsed, dict):
             raise RuntimeError(f"order lookup failed with status {status}: {parsed}")
-        order_id = parsed.get("orderId") if isinstance(parsed, dict) else None
+        return parsed
+
+    def _resolve_exchange_order_id(self, symbol: str, client_order_id: str) -> int:
+        order = self._fetch_order(symbol, client_order_id)
+        order_id = order.get("orderId")
         if order_id is None:
             raise RuntimeError("order lookup response missing orderId")
         return int(order_id)
@@ -921,9 +925,8 @@ class TestnetSoakRunner:
             )
             return
 
-        client_order_id = (
-            parsed.get("client_order_ids", {}).get("main") if isinstance(parsed, dict) else None
-        )
+        leg_ids = parsed.get("client_order_ids", {}) if isinstance(parsed, dict) else {}
+        client_order_id = leg_ids.get("main")
         if not client_order_id:
             self._record(
                 CheckResult(
@@ -935,17 +938,72 @@ class TestnetSoakRunner:
             )
             return
 
+        # Every placed leg must be cancelled. Without client_order_ids in the
+        # request the router places exits synchronously, so cancelling only
+        # the entry leaks a resting TP + SL per cycle on the shared testnet
+        # account until the 5-per-symbol algo-order cap rejects every
+        # placement. Entry first to close the fill window.
+        # Falsy ids appear when the router reports partial_failure (a leg was
+        # not placed); skip them instead of feeding "" into the order lookup.
+        cancel_targets = [
+            client_order_id,
+            *[tp for tp in (leg_ids.get("take_profits") or []) if tp],
+            *([leg_ids["stop_loss"]] if leg_ids.get("stop_loss") else []),
+        ]
+
+        self._sleep_with_shutdown(config.cancel_after_seconds)
+        # Best effort across ALL legs: aborting on the first failure would
+        # leave the remaining legs resting — the exact leak being fixed.
+        cancel_failures: list[dict[str, Any]] = []
+        for leg_client_order_id in cancel_targets:
+            try:
+                exchange_order_id = self._resolve_exchange_order_id(symbol, leg_client_order_id)
+            except Exception as exc:
+                cancel_failures.append({"client_order_id": leg_client_order_id, "error": str(exc)})
+                continue
+
+            cancel_status, cancel_body = self._request_json(
+                f"{self.router_base_url}/cancel",
+                method="POST",
+                headers=headers,
+                body={
+                    "symbol": symbol,
+                    "order_id": exchange_order_id,
+                    "client_order_id": leg_client_order_id,
+                },
+                timeout=20,
+            )
+            if cancel_status >= 300:
+                cancel_failures.append(
+                    {
+                        "client_order_id": leg_client_order_id,
+                        "status": cancel_status,
+                        "body": self._parse_json_body(cancel_body),
+                    }
+                )
+
+        # Entry-fill race: if the entry (partially) filled during the window,
+        # the cancels above just removed its protective exits — surface the
+        # acquired base asset loudly instead of recording a silent pass.
         try:
-            exchange_order_id = self._resolve_exchange_order_id(symbol, client_order_id)
+            final_entry = self._fetch_order(symbol, client_order_id)
+            executed_qty = Decimal(str(final_entry.get("executedQty") or "0"))
         except Exception as exc:
+            cancel_failures.append(
+                {"client_order_id": client_order_id, "error": f"final fill check failed: {exc}"}
+            )
+            executed_qty = Decimal("0")
+
+        if executed_qty > 0:
             self._record(
                 CheckResult(
                     name=result_name,
                     status="fail",
-                    message="Order smoke could not resolve exchange order ID",
+                    message="Order smoke entry filled during the cancel window; "
+                    "acquired base asset left on the testnet account",
                     details={
-                        "error": str(exc),
                         "client_order_id": client_order_id,
+                        "executed_qty": str(executed_qty),
                         "symbol": symbol,
                         "trigger": trigger,
                     },
@@ -953,29 +1011,14 @@ class TestnetSoakRunner:
             )
             return
 
-        self._sleep_with_shutdown(config.cancel_after_seconds)
-        cancel_status, cancel_body = self._request_json(
-            f"{self.router_base_url}/cancel",
-            method="POST",
-            headers=headers,
-            body={
-                "symbol": symbol,
-                "order_id": exchange_order_id,
-                "client_order_id": client_order_id,
-            },
-            timeout=20,
-        )
-        parsed_cancel_body = self._parse_json_body(cancel_body)
-        if cancel_status >= 300:
+        if cancel_failures:
             self._record(
                 CheckResult(
                     name=result_name,
                     status="fail",
-                    message="Order smoke cancel failed",
+                    message=f"Order smoke cancel failed for {len(cancel_failures)} leg(s)",
                     details={
-                        "status": cancel_status,
-                        "body": parsed_cancel_body,
-                        "client_order_id": client_order_id,
+                        "failures": cancel_failures,
                         "symbol": symbol,
                         "trigger": trigger,
                     },
@@ -987,9 +1030,9 @@ class TestnetSoakRunner:
             CheckResult(
                 name=result_name,
                 status="pass",
-                message="Order smoke placement and cancel both succeeded",
+                message="Order smoke placement and cancel of all legs succeeded",
                 details={
-                    "client_order_id": client_order_id,
+                    "client_order_ids": cancel_targets,
                     "symbol": symbol,
                     "trigger": trigger,
                     "reference_price": _format_decimal(reference_price, places=2),

--- a/tests/test_run_testnet_soak.py
+++ b/tests/test_run_testnet_soak.py
@@ -719,21 +719,27 @@ def test_run_order_smoke_cycle_cancels_with_resolved_exchange_order_id(monkeypat
     calls: list[tuple[str, str, object | None]] = []
     state = {"now": 0.0}
 
+    exchange_ids = {"coid-123": 111, "coid-123-tp1": 222, "coid-123-sl": 333}
+
+    def fake_fetch_order(symbol, client_order_id):
+        return {"orderId": exchange_ids[client_order_id], "executedQty": "0"}
+
     def fake_request_json(
         url, *, method="GET", headers=None, body=None, timeout=5, allow_insecure_tls=False
     ):
         calls.append((url, method, body))
         if url.endswith("/place_bracket"):
-            return 200, '{"client_order_ids":{"main":"coid-123"}}'
+            return 200, (
+                '{"client_order_ids":{"main":"coid-123",'
+                '"take_profits":["coid-123-tp1"],"stop_loss":"coid-123-sl"}}'
+            )
         if url.endswith("/cancel"):
             return 200, '{"status":"success"}'
         raise AssertionError(url)
 
     monkeypatch.setattr(runner, "_fetch_reference_price", lambda symbol: Decimal("2000"))
     monkeypatch.setattr(runner, "_request_json", fake_request_json)
-    monkeypatch.setattr(
-        runner, "_resolve_exchange_order_id", lambda symbol, client_order_id: 987654321
-    )
+    monkeypatch.setattr(runner, "_fetch_order", fake_fetch_order)
     monkeypatch.setattr(module.time, "monotonic", lambda: state["now"])
     monkeypatch.setattr(
         module.time, "sleep", lambda seconds: state.__setitem__("now", state["now"] + seconds)
@@ -741,12 +747,109 @@ def test_run_order_smoke_cycle_cancels_with_resolved_exchange_order_id(monkeypat
 
     runner.run_order_smoke_cycle("startup")
 
-    cancel_call = next(call for call in calls if call[0].endswith("/cancel"))
-    assert cancel_call == (
-        "http://localhost:8001/cancel",
-        "POST",
-        {"symbol": "ETHUSDT", "order_id": 987654321, "client_order_id": "coid-123"},
+    # Every leg must be cancelled — synchronously-placed exits otherwise leak
+    # on the shared testnet account until the 5-per-symbol algo cap rejects
+    # all placements (run-4 failure). Entry first to close the fill window.
+    cancel_calls = [call for call in calls if call[0].endswith("/cancel")]
+    assert cancel_calls == [
+        (
+            "http://localhost:8001/cancel",
+            "POST",
+            {"symbol": "ETHUSDT", "order_id": 111, "client_order_id": "coid-123"},
+        ),
+        (
+            "http://localhost:8001/cancel",
+            "POST",
+            {"symbol": "ETHUSDT", "order_id": 222, "client_order_id": "coid-123-tp1"},
+        ),
+        (
+            "http://localhost:8001/cancel",
+            "POST",
+            {"symbol": "ETHUSDT", "order_id": 333, "client_order_id": "coid-123-sl"},
+        ),
+    ]
+    assert runner.results[-1].status == "pass"
+
+
+def test_run_order_smoke_cycle_fails_when_exit_leg_cancel_fails(monkeypatch):
+    module = _load_run_testnet_soak_module()
+    runner = _make_runner(module, monkeypatch, enable_order_smoke=True)
+    runner.periodic_order_smoke_config = module.build_periodic_order_smoke_config(
+        {"SOAK_SMOKE_SYMBOLS": "ETHUSDT", "SOAK_SMOKE_CANCEL_AFTER_SECONDS": "1"}
     )
+    _fake_clock(module, monkeypatch)
+
+    cancelled: list[str] = []
+
+    def fake_request_json(
+        url, *, method="GET", headers=None, body=None, timeout=5, allow_insecure_tls=False
+    ):
+        if url.endswith("/place_bracket"):
+            return 200, (
+                '{"client_order_ids":{"main":"coid-1",'
+                '"take_profits":["coid-1-tp1"],"stop_loss":"coid-1-sl"}}'
+            )
+        if url.endswith("/cancel"):
+            client_order_id = (body or {}).get("client_order_id")
+            cancelled.append(client_order_id)
+            # The FIRST leg fails: best-effort must still cancel the rest,
+            # otherwise the exits keep leaking (the bug being fixed).
+            if client_order_id == "coid-1":
+                return 400, '{"error":"boom"}'
+            return 200, '{"status":"success"}'
+        raise AssertionError(url)
+
+    monkeypatch.setattr(runner, "_fetch_reference_price", lambda symbol: Decimal("2000"))
+    monkeypatch.setattr(runner, "_request_json", fake_request_json)
+    monkeypatch.setattr(
+        runner, "_fetch_order", lambda symbol, client_order_id: {"orderId": 42, "executedQty": "0"}
+    )
+
+    runner.run_order_smoke_cycle("startup")
+
+    assert cancelled == ["coid-1", "coid-1-tp1", "coid-1-sl"]
+    result = runner.results[-1]
+    assert result.status == "fail"
+    assert result.details["failures"] == [
+        {"client_order_id": "coid-1", "status": 400, "body": {"error": "boom"}}
+    ]
+
+
+def test_run_order_smoke_cycle_fails_when_entry_filled_during_window(monkeypatch):
+    module = _load_run_testnet_soak_module()
+    runner = _make_runner(module, monkeypatch, enable_order_smoke=True)
+    runner.periodic_order_smoke_config = module.build_periodic_order_smoke_config(
+        {"SOAK_SMOKE_SYMBOLS": "ETHUSDT", "SOAK_SMOKE_CANCEL_AFTER_SECONDS": "1"}
+    )
+    _fake_clock(module, monkeypatch)
+
+    def fake_request_json(
+        url, *, method="GET", headers=None, body=None, timeout=5, allow_insecure_tls=False
+    ):
+        if url.endswith("/place_bracket"):
+            return 200, (
+                '{"client_order_ids":{"main":"coid-9",'
+                '"take_profits":["coid-9-tp1"],"stop_loss":"coid-9-sl"}}'
+            )
+        if url.endswith("/cancel"):
+            return 200, '{"status":"success"}'
+        raise AssertionError(url)
+
+    def fake_fetch_order(symbol, client_order_id):
+        # Final fill check sees a partial fill on the entry
+        executed = "0.00500000" if client_order_id == "coid-9" else "0"
+        return {"orderId": 7, "executedQty": executed}
+
+    monkeypatch.setattr(runner, "_fetch_reference_price", lambda symbol: Decimal("2000"))
+    monkeypatch.setattr(runner, "_request_json", fake_request_json)
+    monkeypatch.setattr(runner, "_fetch_order", fake_fetch_order)
+
+    runner.run_order_smoke_cycle("startup")
+
+    result = runner.results[-1]
+    assert result.status == "fail"
+    assert "filled during the cancel window" in result.message
+    assert result.details["executed_qty"] == "0.00500000"
 
 
 def test_record_writes_partial_report_and_heartbeat(monkeypatch):


### PR DESCRIPTION
## Why

Run 4 died at smoke #5: `400 too many open algo orders for ETHUSDT: 5/5`. Every smoke cycle leaked a resting TP + STOP_LOSS_LIMIT on the shared testnet account — the smoke posts brackets without `client_order_ids`, so the router places exits synchronously, but the cycle only ever cancelled the entry. Five ETHUSDT cycles across today's runs filled Binance's 5-per-symbol algo cap; BTCUSDT was two cycles behind, after which every smoke fails for the rest of the week.

## What

- Cancel **all** legs from the placement response's `client_order_ids` {main, take_profits[], stop_loss}, entry first (closes the fill window), best-effort across legs (aborting on the first failure would re-leak the remainder).
- Entry-fill race (QCHECK MEDIUM): after the cancels, a final order lookup checks `executedQty` — a (partial) fill during the 75s window now fails the cycle with the acquired quantity, instead of silently stranding base asset whose protective exits were just cancelled.
- Falsy leg ids from `partial_failure` placements are skipped instead of being fed into the order lookup.

## QCHECK

0 CRITICAL/HIGH. Verified by the reviewer: router `/cancel` semantics work identically for exit legs; the router returns its generated leg ids in the response; smoke brackets (no client ids) never touch the bracket store, so cancelling legs cannot trip the C4–C6 forbidden log markers. Fixed both MEDIUMs (fill race; test let abort-on-first-failure pass — now the main leg fails and the test asserts the exits are still cancelled) and the falsy-id LOW.

## Gates

43 tests across both soak suites, 3× green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)