### PR TITLE
fix(soak): retry signed order lookups on -1021 with fresh timestamp and wider recvWindow

### DIFF
--- a/scripts/run_testnet_soak.py
+++ b/scripts/run_testnet_soak.py
@@ -36,6 +36,10 @@ except ImportError:  # pragma: no cover - optional dependency in tests
 # services on any source edit, silently dooming a multi-day run.
 DEFAULT_COMPOSE_FILES = ("docker-compose.dev.yml", "docker-compose.soak.yml")
 
+FETCH_ORDER_ATTEMPTS = 3
+FETCH_ORDER_RETRY_DELAY_SECONDS = 0.5
+SIGNED_RECV_WINDOW_MS = 10000
+
 
 @dataclass(slots=True)
 class CheckResult:
@@ -681,26 +685,44 @@ class TestnetSoakRunner:
                 "Binance spot API credentials are required to resolve exchange order IDs"
             )
 
-        params = {
-            "symbol": symbol,
-            "origClientOrderId": client_order_id,
-            "timestamp": str(int(time.time() * 1000)),
-        }
-        query = urlencode(params)
-        signature = hmac.new(
-            api_secret.encode("utf-8"), query.encode("utf-8"), hashlib.sha256
-        ).hexdigest()
         base_url = os.getenv("BINANCE_SPOT_BASE_URL", "https://testnet.binance.vision").rstrip("/")
-        status, raw_body = self._request_json(
-            f"{base_url}/api/v3/order?{query}&signature={signature}",
-            headers={"X-MBX-APIKEY": api_key},
-            timeout=20,
-            allow_insecure_tls=True,
-        )
-        parsed = self._parse_json_body(raw_body)
-        if status >= 300 or not isinstance(parsed, dict):
-            raise RuntimeError(f"order lookup failed with status {status}: {parsed}")
-        return parsed
+        # A latency spike can push the signed timestamp outside Binance's
+        # recvWindow (-1021) even with a synced clock (run-5 smoke #18 failed
+        # on exactly one such lookup). Widen the window and retry with a
+        # FRESH timestamp; other API errors fail fast.
+        last_error = "order lookup failed"
+        for attempt in range(FETCH_ORDER_ATTEMPTS):
+            if attempt:
+                time.sleep(FETCH_ORDER_RETRY_DELAY_SECONDS)
+            params = {
+                "symbol": symbol,
+                "origClientOrderId": client_order_id,
+                "recvWindow": str(SIGNED_RECV_WINDOW_MS),
+                "timestamp": str(int(time.time() * 1000)),
+            }
+            query = urlencode(params)
+            signature = hmac.new(
+                api_secret.encode("utf-8"), query.encode("utf-8"), hashlib.sha256
+            ).hexdigest()
+            try:
+                status, raw_body = self._request_json(
+                    f"{base_url}/api/v3/order?{query}&signature={signature}",
+                    headers={"X-MBX-APIKEY": api_key},
+                    timeout=20,
+                    allow_insecure_tls=True,
+                )
+            except Exception as exc:
+                last_error = f"order lookup request failed: {exc}"
+                continue
+            parsed = self._parse_json_body(raw_body)
+            if status < 300 and isinstance(parsed, dict):
+                return parsed
+            last_error = f"order lookup failed with status {status}: {parsed}"
+            code = parsed.get("code") if isinstance(parsed, dict) else None
+            # Never retry while rate-limited/IP-banned (418/429).
+            if status in (418, 429) or code != -1021:
+                break
+        raise RuntimeError(last_error)
 
     def _resolve_exchange_order_id(self, symbol: str, client_order_id: str) -> int:
         order = self._fetch_order(symbol, client_order_id)

--- a/tests/test_run_testnet_soak.py
+++ b/tests/test_run_testnet_soak.py
@@ -994,3 +994,119 @@ def test_build_recommendations_preserves_distinct_entries():
     recommendations = module.build_recommendations(results)
 
     assert len(recommendations) == 2
+
+
+def _fetch_order_runner(module, monkeypatch):
+    runner = _make_runner(module, monkeypatch)
+    monkeypatch.setenv("BINANCE_API_KEY", "test-key")
+    monkeypatch.setenv("BINANCE_SECRET_KEY", "test-secret")
+    monkeypatch.setattr(module.time, "sleep", lambda seconds: None)
+    counter = {"now": 1_700_000_000.0}
+
+    def fake_time():
+        counter["now"] += 1.0
+        return counter["now"]
+
+    monkeypatch.setattr(module.time, "time", fake_time)
+    return runner
+
+
+def test_fetch_order_retries_recv_window_error_with_fresh_timestamp(monkeypatch):
+    module = _load_run_testnet_soak_module()
+    runner = _fetch_order_runner(module, monkeypatch)
+
+    urls: list[str] = []
+
+    def fake_request_json(url, **kwargs):
+        urls.append(url)
+        if len(urls) == 1:
+            return (
+                400,
+                '{"code":-1021,"msg":"Timestamp for this request is outside of the recvWindow."}',
+            )
+        return 200, '{"orderId":77,"executedQty":"0"}'
+
+    monkeypatch.setattr(runner, "_request_json", fake_request_json)
+
+    order = runner._fetch_order("ETHUSDT", "coid-1")
+
+    assert order["orderId"] == 77
+    assert len(urls) == 2
+    assert all("recvWindow=10000" in url for url in urls)
+    timestamps = [url.split("timestamp=")[1].split("&")[0] for url in urls]
+    assert timestamps[0] != timestamps[1]
+
+
+def test_fetch_order_retries_transient_network_errors(monkeypatch):
+    module = _load_run_testnet_soak_module()
+    runner = _fetch_order_runner(module, monkeypatch)
+
+    calls = {"n": 0}
+
+    def fake_request_json(url, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("timed out")
+        return 200, '{"orderId":88,"executedQty":"0"}'
+
+    monkeypatch.setattr(runner, "_request_json", fake_request_json)
+
+    assert runner._fetch_order("ETHUSDT", "coid-1")["orderId"] == 88
+    assert calls["n"] == 2
+
+
+def test_fetch_order_fails_fast_on_non_retryable_api_error(monkeypatch):
+    module = _load_run_testnet_soak_module()
+    runner = _fetch_order_runner(module, monkeypatch)
+
+    calls = {"n": 0}
+
+    def fake_request_json(url, **kwargs):
+        calls["n"] += 1
+        return 400, '{"code":-2013,"msg":"Order does not exist."}'
+
+    monkeypatch.setattr(runner, "_request_json", fake_request_json)
+
+    with pytest.raises(RuntimeError, match="-2013"):
+        runner._fetch_order("ETHUSDT", "coid-1")
+    assert calls["n"] == 1
+
+
+def test_fetch_order_fails_fast_when_rate_limited(monkeypatch):
+    module = _load_run_testnet_soak_module()
+    runner = _fetch_order_runner(module, monkeypatch)
+
+    calls = {"n": 0}
+
+    def fake_request_json(url, **kwargs):
+        calls["n"] += 1
+        return (
+            429,
+            '{"code":-1021,"msg":"Timestamp for this request is outside of the recvWindow."}',
+        )
+
+    monkeypatch.setattr(runner, "_request_json", fake_request_json)
+
+    with pytest.raises(RuntimeError, match="429"):
+        runner._fetch_order("ETHUSDT", "coid-1")
+    assert calls["n"] == 1
+
+
+def test_fetch_order_raises_after_exhausting_retries(monkeypatch):
+    module = _load_run_testnet_soak_module()
+    runner = _fetch_order_runner(module, monkeypatch)
+
+    calls = {"n": 0}
+
+    def fake_request_json(url, **kwargs):
+        calls["n"] += 1
+        return (
+            400,
+            '{"code":-1021,"msg":"Timestamp for this request is outside of the recvWindow."}',
+        )
+
+    monkeypatch.setattr(runner, "_request_json", fake_request_json)
+
+    with pytest.raises(RuntimeError, match="-1021"):
+        runner._fetch_order("ETHUSDT", "coid-1")
+    assert calls["n"] == 3


### PR DESCRIPTION
## Why

Run 5 died at smoke #18 on a single `-1021: Timestamp outside recvWindow` during the post-cancel fill-check lookup. All three legs had cancelled cleanly and host clock drift measured −447ms — a latency spike (the host network has been flapping) delayed the signed request past Binance's default 5s window. One flaky *verification* lookup must not doom a 7-day run.

## What

`_fetch_order` now sends `recvWindow=10000` (inside the signed payload) and retries up to 3× with a **fresh timestamp** on `-1021` and transient network errors (0.5s backoff). Other API errors fail fast, and 418/429 never retry (no hammering while rate-limited). This hardens both the cancel-loop id resolution and the fill check.

## QCHECK (per updated protocol, tier 1 scoped to this diff)

Adversarial empirical verification incl. 6 implementation mutations against the tests: 0 CRITICAL/HIGH/MEDIUM. Verified: JSON int code matching, last-attempt error freshness, non-dict-body fail-fast, ≤1s added latency is harmless to smoke timing, signature covers recvWindow. Took the rate-limit fail-fast LOW (+test); remaining LOWs are optional test-robustness adds, documented here: exception-exhaustion message assert, backoff-delay assert, signature-presence assert.

## Gates

48 tests across both soak suites 3× green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)